### PR TITLE
Upgrade inventory UX + input-guard bug fixes

### DIFF
--- a/backend/__tests__/integration/api.test.js
+++ b/backend/__tests__/integration/api.test.js
@@ -187,3 +187,27 @@ describe("openCase", () => {
     expect((await User.findById(u._id)).walletBalance).toBe(100);
   });
 });
+
+describe("input guards", () => {
+  test("GET /users/:id with a non-ObjectId returns 404, not a 500", async () => {
+    const res = await request(app).get("/users/undefined");
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /users/inventory/:userId with a bad id returns 404, not a 500", async () => {
+    const res = await request(app).get("/users/inventory/undefined");
+    expect(res.status).toBe(404);
+  });
+
+  test("inventory search with regex-special characters doesn't error", async () => {
+    const u = await makeUser();
+    const res = await request(app).get(`/users/inventory/${u._id}?name=${encodeURIComponent("((")}`);
+    expect(res.status).toBe(200);
+  });
+
+  test("login against a passwordless (Google) account returns 400, not a 500", async () => {
+    const u = await makeUser({ password: undefined });
+    const res = await request(app).post("/users/login").send({ email: u.email, password: "whatever" });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -106,6 +106,11 @@ router.post(
         return res.status(400).json({ message: "Email not found" });
       }
 
+      // accounts created via Google sign-in have no password set
+      if (!user.password) {
+        return res.status(400).json({ message: "Invalid credentials" });
+      }
+
       // Compare passwords (plain text, decrypting legacy AES-wrapped values)
       const originalPassword = resolvePassword(password);
 
@@ -469,6 +474,9 @@ router.put('/profilePicture', authMiddleware.isAuthenticated, async (req, res) =
 // Get user by id (public profile: only non-sensitive fields)
 router.get("/:id", async (req, res) => {
   try {
+    if (!ObjectId.isValid(req.params.id)) {
+      return res.status(404).json({ message: "User not found" });
+    }
     res.json(
       await User.findById(req.params.id)
         .select("username profilePicture xp level fixedItem nextBonus weeklyWinnings")
@@ -492,12 +500,22 @@ router.get("/inventory/:userId", async (req, res) => {
     const { name, rarity, sortBy, order, caseId } = req.query;
     const page = parseInt(req.query.page) || 1;
 
+    if (!ObjectId.isValid(userId)) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
     const user = await User.findById(userId);
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
 
     let query = { _id: user._id };  // Default to filtering by user ID
+
+    // guard optional filters so malformed input can't throw
+    const caseFilter = caseId && ObjectId.isValid(caseId) ? new ObjectId(caseId) : null;
+    const nameRegex = name
+      ? new RegExp(String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i")
+      : null;
 
     // Count Pipeline
     let countPipeline = [
@@ -506,12 +524,12 @@ router.get("/inventory/:userId", async (req, res) => {
       { $unwind: "$inventory" }
     ];
 
-    if (caseId) {
-      countPipeline.push({ $match: { "inventory.case": new ObjectId(caseId) } });
+    if (caseFilter) {
+      countPipeline.push({ $match: { "inventory.case": caseFilter } });
     }
 
-    if (name) {
-      countPipeline.push({ $match: { "inventory.name": new RegExp(name, "i") } });
+    if (nameRegex) {
+      countPipeline.push({ $match: { "inventory.name": nameRegex } });
     }
     if (rarity) {
       countPipeline.push({ $match: { "inventory.rarity": rarity } });
@@ -530,12 +548,12 @@ router.get("/inventory/:userId", async (req, res) => {
       { $unwind: "$inventory" }
     ];
 
-    if (caseId) {
-      pipeline.push({ $match: { "inventory.case": new ObjectId(caseId) } });
+    if (caseFilter) {
+      pipeline.push({ $match: { "inventory.case": caseFilter } });
     }
 
-    if (name) {
-      pipeline.push({ $match: { "inventory.name": new RegExp(name, "i") } });
+    if (nameRegex) {
+      pipeline.push({ $match: { "inventory.name": nameRegex } });
     }
     if (rarity) {
       pipeline.push({ $match: { "inventory.rarity": rarity } });

--- a/src/pages/Upgrade/UserItems.tsx
+++ b/src/pages/Upgrade/UserItems.tsx
@@ -1,12 +1,11 @@
 import { useContext, useEffect, useRef, useState } from "react";
-import { AiOutlineArrowDown } from "react-icons/ai";
 import { MdOutlineNavigateBefore, MdOutlineNavigateNext } from "react-icons/md";
+import { AiOutlineClose, AiOutlineSearch } from "react-icons/ai";
 import Skeleton from "react-loading-skeleton";
 import Item from "../../components/Item";
 import UserContext from "../../UserContext";
 import { getInventory } from "../../services/users/UserServices";
-import { AiOutlineClose } from "react-icons/ai";
-
+import Rarities from "../../components/Rarities";
 
 interface Inventory {
     selectedItems: any;
@@ -17,20 +16,43 @@ interface Inventory {
     setSelectedTarget: React.Dispatch<React.SetStateAction<any>>;
 }
 
+const sortOptions = [
+    { value: "newer", label: "Newest" },
+    { value: "older", label: "Oldest" },
+    { value: "mostRare", label: "Rarity: high to low" },
+    { value: "mostCommon", label: "Rarity: low to high" },
+];
+
 const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedCase, setSelectedCase, toggleReload, setSelectedTarget }) => {
     const [inventory, setInventory] = useState<any>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [pageLimit, setPageLimit] = useState<number>(0);
     const [currentPage, setCurrentPage] = useState<number>(1);
+    const [search, setSearch] = useState<string>("");
     const [inventoryFilters, setInventoryFilters] = useState({
-        name: '',
-        rarity: '',
-        sortBy: '',
-        order: 'asc',
-        caseId: ''
+        name: "",
+        rarity: "",
+        sortBy: "newer", // default: newest items first
+        order: "asc",
+        caseId: "",
     });
     const inventoryRef = useRef<HTMLDivElement | null>(null);
     const { userData } = useContext(UserContext);
+
+    // any filter/sort change goes back to the first page
+    const updateFilters = (patch: Partial<typeof inventoryFilters>) => {
+        setInventoryFilters((prev) => ({ ...prev, ...patch }));
+        setCurrentPage(1);
+    };
+
+    // debounce the search box into the name filter
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            setInventoryFilters((prev) => (prev.name === search ? prev : { ...prev, name: search }));
+            setCurrentPage(1);
+        }, 400);
+        return () => clearTimeout(timeout);
+    }, [search]);
 
     const getInventoryInfo = async () => {
         setLoading(true);
@@ -43,139 +65,139 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                 const inventory = await getInventory(userData.id, currentPage, newFilters);
                 setInventory(inventory.items);
                 setPageLimit(inventory.totalPages);
-            }
-            catch (error) {
+            } catch (error) {
                 console.log(error);
             }
         }
         setLoading(false);
-    }
+    };
 
     const handleItemClick = (item: any) => {
         const itemIdentifier = item.uniqueId;
-        const itemExists = selectedItems.some((selectedItem: { identifier: string; }) => selectedItem.identifier === itemIdentifier);
+        const itemExists = selectedItems.some((selectedItem: { identifier: string }) => selectedItem.identifier === itemIdentifier);
 
         setSelectedItems(
-            itemExists ?
-                selectedItems.filter((selectedItem: { identifier: string; }) => selectedItem.identifier !== itemIdentifier)
-                :
-                [...selectedItems, { item: item, identifier: itemIdentifier }]
-        )
+            itemExists
+                ? selectedItems.filter((selectedItem: { identifier: string }) => selectedItem.identifier !== itemIdentifier)
+                : [...selectedItems, { item: item, identifier: itemIdentifier }]
+        );
         setSelectedCase(item.case);
-    }
+    };
+
+    const clearCase = () => {
+        setSelectedCase(null);
+        setSelectedItems([]);
+        setSelectedTarget(null);
+        updateFilters({ caseId: "" });
+    };
 
     useEffect(() => {
         getInventoryInfo();
     }, [currentPage, inventoryFilters, userData, selectedCase, toggleReload]);
 
+    const selectClass = "bg-[#19172D] border border-gray-700 rounded px-2 py-1 text-sm focus:outline-none focus:border-[#606bc7]";
 
     return (
-        <div className="flex flex-col md:w-1/2  gap-2">
-            <div className="flex w-full items-center justify-between bg-[#1C1A33] rounded px-6 h-24">
-                <span>Inventory</span>
-                <div className="flex gap-4 ">
-                    {
-                        selectedCase !== null && (
-                            <div className="flex items-center gap-1 cursor-pointer border-b border-gray-500 text-gray-500" onClick={
-                                () => {
-                                    setSelectedCase(null);
-                                    setSelectedItems([]);
-                                    setSelectedTarget(null);
-                                    setInventoryFilters(prev => {
-                                        return {
-                                            ...prev,
-                                            caseId: ''
-                                        }
-                                    })
-                                }
-                            }>
-                                <AiOutlineClose />
-                                <span>Clear</span>
-
-                            </div>
-                        )
-                    }
-                    <div className="flex items-center justify-between cursor-pointer" onClick={() => {
-                        setInventoryFilters(prev => {
-                            return {
-                                ...prev,
-                                sortBy: prev.sortBy === '' ? 'mostRare' : ''
-                            }
-                        })
-                    }
-                    }>
-                        <span>Rarity</span>
-                        <AiOutlineArrowDown style={{
-                            transform: inventoryFilters.sortBy === 'mostRare' ? 'rotate(180deg)' : '',
-                            transition: 'transform 0.2s ease-in-out'
-
-                        }} />
-                    </div>
+        <div className="flex flex-col md:w-1/2 gap-2">
+            <div className="flex flex-col gap-3 bg-[#1C1A33] rounded px-6 py-4">
+                <div className="flex items-center justify-between">
+                    <span className="font-semibold">Inventory</span>
+                    {selectedCase && (
+                        <div
+                            className="flex items-center gap-1 cursor-pointer border-b border-gray-500 text-gray-400 hover:text-white"
+                            onClick={clearCase}
+                        >
+                            <AiOutlineClose />
+                            <span>Clear case</span>
+                        </div>
+                    )}
                 </div>
-
+                <div className="flex flex-wrap items-center gap-3">
+                    <div className="flex items-center gap-2 bg-[#19172D] border border-gray-700 rounded px-2 flex-1 min-w-[160px]">
+                        <AiOutlineSearch className="text-gray-400" />
+                        <input
+                            type="text"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            placeholder="Search items..."
+                            className="bg-transparent py-1 w-full text-sm focus:outline-none"
+                        />
+                        {search && (
+                            <AiOutlineClose className="text-gray-400 cursor-pointer" onClick={() => setSearch("")} />
+                        )}
+                    </div>
+                    <select
+                        value={inventoryFilters.sortBy}
+                        onChange={(e) => updateFilters({ sortBy: e.target.value })}
+                        className={selectClass}
+                    >
+                        {sortOptions.map((o) => (
+                            <option key={o.value} value={o.value}>{o.label}</option>
+                        ))}
+                    </select>
+                    <select
+                        value={inventoryFilters.rarity}
+                        onChange={(e) => updateFilters({ rarity: e.target.value })}
+                        className={selectClass}
+                    >
+                        <option value="">All rarities</option>
+                        {Rarities.map((r) => (
+                            <option key={r.id} value={String(r.id)}>{r.name}</option>
+                        ))}
+                    </select>
+                </div>
             </div>
-            <div className="flex h-[500px] border-2 border-[#1C1A33] flex-wrap gap-2 p-4 overflow-y-auto justify-around" >
-                {
-                    loading ? (
-                        { array: Array(12).fill(0) }.array.map((_, i) => (
-                            <Skeleton
-                                width={176}
-                                height={216}
-                                highlightColor="#161427"
-                                baseColor="#1c1a31"
-                                key={i}
-                            />
-                        ))
-                    ) : (
-                        inventory.length > 0 ? (
-                            inventory.map((item: any, index: number) => {
-                                if (item.case) {
-                                    return (
-                                        <div key={index} ref={
-                                            index === 0 ? inventoryRef : null
-                                        }
-                                            onClick={() => handleItemClick(item)}
-                                            className={`cursor-pointer border-2 h-min ${selectedItems.some((selectedItem: { identifier: string; }) => selectedItem.identifier === item.uniqueId) ? ' border-[#606bc7]' : 'border-transparent'}`}>
-                                            <Item item={item} />
-                                        </div>
-                                    )
-                                }
-                            })
-                        ) : (
-                            <div className="flex flex-col items-center justify-center gap-4">
-                                <span className="font-semibold">No items found</span>
-                            </div>
-                        )
-                    )
-                }
-
+            <div className="flex h-[500px] border-2 border-[#1C1A33] flex-wrap gap-2 p-4 overflow-y-auto justify-around">
+                {loading ? (
+                    { array: Array(12).fill(0) }.array.map((_, i) => (
+                        <Skeleton width={176} height={216} highlightColor="#161427" baseColor="#1c1a31" key={i} />
+                    ))
+                ) : inventory.length > 0 ? (
+                    inventory.map((item: any, index: number) => {
+                        if (item.case) {
+                            return (
+                                <div
+                                    key={index}
+                                    ref={index === 0 ? inventoryRef : null}
+                                    onClick={() => handleItemClick(item)}
+                                    className={`cursor-pointer border-2 h-min ${selectedItems.some((selectedItem: { identifier: string }) => selectedItem.identifier === item.uniqueId) ? " border-[#606bc7]" : "border-transparent"}`}
+                                >
+                                    <Item item={item} />
+                                </div>
+                            );
+                        }
+                    })
+                ) : (
+                    <div className="flex flex-col items-center justify-center gap-4">
+                        <span className="font-semibold">No items found</span>
+                    </div>
+                )}
             </div>
             <div className="flex items-center gap-4 text-white">
                 <MdOutlineNavigateBefore
                     style={{
                         cursor: currentPage === 1 ? "not-allowed" : "pointer",
-                        color: currentPage === 1 ? "gray" : "white"
+                        color: currentPage === 1 ? "gray" : "white",
                     }}
                     onClick={() => {
-                        currentPage !== 1 && setCurrentPage(prev => prev - 1);
-                        currentPage !== 1 && inventoryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' });
+                        currentPage !== 1 && setCurrentPage((prev) => prev - 1);
+                        currentPage !== 1 && inventoryRef.current?.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
                     }}
                 />
-                <span>Page: {currentPage}</span>
+                <span>Page: {currentPage}{pageLimit > 0 ? ` / ${pageLimit}` : ""}</span>
                 <MdOutlineNavigateNext
                     style={{
                         cursor: currentPage === pageLimit ? "not-allowed" : "pointer",
-                        color: currentPage === pageLimit ? "gray" : "white"
+                        color: currentPage === pageLimit ? "gray" : "white",
                     }}
                     onClick={() => {
-                        currentPage !== pageLimit && setCurrentPage(prev => prev + 1);
-                        currentPage !== pageLimit && inventoryRef.current?.scrollIntoView({ behavior: 'smooth' });
+                        currentPage !== pageLimit && setCurrentPage((prev) => prev + 1);
+                        currentPage !== pageLimit && inventoryRef.current?.scrollIntoView({ behavior: "smooth" });
                     }}
                 />
             </div>
         </div>
-    )
-
-}
+    );
+};
 
 export default UserItems;


### PR DESCRIPTION
**Fixes** (the two prod error-log lines):
- guard non-ObjectId ids on /users/:id and /users/inventory/:userId (no more Cast 500s)
- validate caseId, escape the inventory name search
- reject password login for passwordless (Google) accounts instead of a bcrypt 500

**Upgrade inventory UX:**
- default sort newest-first, add debounced search + rarity filter
- reset pagination on filter change, show total pages

Integration tests added for the guards.