### PR TITLE
GitHub deploy webhook (push-to-deploy)

### DIFF
--- a/backend/__tests__/unit/deployWebhook.test.js
+++ b/backend/__tests__/unit/deployWebhook.test.js
@@ -1,0 +1,62 @@
+jest.mock("child_process", () => ({ exec: jest.fn() }));
+
+const crypto = require("crypto");
+const { exec } = require("child_process");
+
+const SECRET = "test-deploy-secret";
+process.env.DEPLOY_WEBHOOK_SECRET = SECRET;
+const { githubDeployHandler } = require("../../deployWebhook");
+
+const sign = (body) => "sha256=" + crypto.createHmac("sha256", SECRET).update(body).digest("hex");
+
+const mockRes = () => ({
+  statusCode: 0,
+  body: undefined,
+  status(c) { this.statusCode = c; return this; },
+  send(b) { this.body = b; return this; },
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("github deploy webhook", () => {
+  test("rejects a missing signature", () => {
+    const body = Buffer.from(JSON.stringify({ ref: "refs/heads/main" }));
+    const res = mockRes();
+    githubDeployHandler({ headers: { "x-github-event": "push" }, body }, res);
+    expect(res.statusCode).toBe(401);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  test("rejects a wrong signature", () => {
+    const body = Buffer.from(JSON.stringify({ ref: "refs/heads/main" }));
+    const res = mockRes();
+    githubDeployHandler({ headers: { "x-hub-signature-256": "sha256=deadbeef", "x-github-event": "push" }, body }, res);
+    expect(res.statusCode).toBe(401);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  test("answers a ping", () => {
+    const body = Buffer.from(JSON.stringify({ zen: "hello" }));
+    const res = mockRes();
+    githubDeployHandler({ headers: { "x-hub-signature-256": sign(body), "x-github-event": "ping" }, body }, res);
+    expect(res.statusCode).toBe(200);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  test("ignores pushes to other branches", () => {
+    const body = Buffer.from(JSON.stringify({ ref: "refs/heads/dev" }));
+    const res = mockRes();
+    githubDeployHandler({ headers: { "x-hub-signature-256": sign(body), "x-github-event": "push" }, body }, res);
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toBe("ignored");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  test("deploys on a valid push to main", () => {
+    const body = Buffer.from(JSON.stringify({ ref: "refs/heads/main" }));
+    const res = mockRes();
+    githubDeployHandler({ headers: { "x-hub-signature-256": sign(body), "x-github-event": "push" }, body }, res);
+    expect(res.statusCode).toBe(202);
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/deployWebhook.js
+++ b/backend/deployWebhook.js
@@ -1,0 +1,52 @@
+const crypto = require("crypto");
+const os = require("os");
+const { exec } = require("child_process");
+
+// receives GitHub push webhooks and triggers the deploy script. mounted before
+// the CORS / api-key gates (GitHub sends neither), so its own HMAC check is the
+// only thing that authorizes it. it never runs anything but the fixed deploy
+// script, so the worst a forged request could do is trigger a redeploy of main.
+const githubDeployHandler = (req, res) => {
+  const secret = process.env.DEPLOY_WEBHOOK_SECRET;
+  if (!secret) {
+    return res.status(503).send("deploy webhook not configured");
+  }
+
+  const signature = req.headers["x-hub-signature-256"];
+  // req.body is a Buffer here (mounted with express.raw)
+  const expected =
+    "sha256=" + crypto.createHmac("sha256", secret).update(req.body).digest("hex");
+
+  const sigBuf = Buffer.from(signature || "", "utf8");
+  const expBuf = Buffer.from(expected, "utf8");
+  if (sigBuf.length !== expBuf.length || !crypto.timingSafeEqual(sigBuf, expBuf)) {
+    return res.status(401).send("bad signature");
+  }
+
+  const event = req.headers["x-github-event"];
+  if (event === "ping") {
+    return res.status(200).send("pong");
+  }
+
+  let payload = {};
+  try {
+    payload = JSON.parse(req.body.toString("utf8"));
+  } catch (err) {
+    return res.status(400).send("bad payload");
+  }
+
+  if (event !== "push" || payload.ref !== "refs/heads/main") {
+    return res.status(202).send("ignored");
+  }
+
+  res.status(202).send("deploying");
+
+  // run fully detached (new session) so the backend restart inside the deploy
+  // script can't kill the deploy mid-flight
+  const script = `${os.homedir()}/deploy-kani.sh`;
+  exec(`setsid bash ${script} >> ${os.homedir()}/deploy-kani.log 2>&1 &`, {
+    detached: true,
+  });
+};
+
+module.exports = { githubDeployHandler };

--- a/backend/index.js
+++ b/backend/index.js
@@ -13,6 +13,11 @@ require("dotenv").config();
 const app = express();
 const server = http.createServer(app);
 
+// deploy webhook is mounted first, with a raw body parser, so it bypasses the
+// CORS + api-key gates below (GitHub sends neither) and can verify its own HMAC
+const { githubDeployHandler } = require("./deployWebhook");
+app.post("/deploy/github", express.raw({ type: "*/*" }), githubDeployHandler);
+
 const isDevelopment = process.env.NODE_ENV === "development";
 
 // allowed origins are configurable via ALLOWED_ORIGINS (comma-separated); falls


### PR DESCRIPTION
Adds an HMAC-verified POST /deploy/github endpoint so a GitHub push webhook can trigger an instant deploy (replacing the 2-min cron poll). Mounted before the CORS/api-key middleware with a raw-body parser; runs the existing deploy script detached. Unit-tested.