### PR TITLE
Upgrade inventory: bought items sort newest + no page scroll

### DIFF
--- a/backend/__tests__/integration/api.test.js
+++ b/backend/__tests__/integration/api.test.js
@@ -99,7 +99,10 @@ describe("marketplace buy", () => {
     expect((await User.findById(buyer._id)).walletBalance).toBe(400);
     expect((await User.findById(seller._id)).walletBalance).toBe(100);
     const buyerInv = (await User.findById(buyer._id)).inventory;
-    expect(buyerInv.some((i) => i.uniqueId === listing.uniqueId)).toBe(true);
+    const bought = buyerInv.find((i) => i.uniqueId === listing.uniqueId);
+    expect(bought).toBeDefined();
+    // acquired now, so it sorts as newest (not the listing's createdAt)
+    expect(Date.now() - new Date(bought.createdAt).getTime()).toBeLessThan(60000);
 
     const again = await request(app).post(`/marketplace/buy/${listing._id}`).set(...auth(buyer));
     expect(again.status).toBe(404);

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -178,7 +178,7 @@ module.exports = (io) => {
               image: item.itemImage,
               rarity: item.rarity,
               case: item.case,
-              createdAt: item.createdAt,
+              createdAt: new Date(), // acquired now, so it sorts as newest
               uniqueId: item.uniqueId,
             },
           },
@@ -222,7 +222,7 @@ module.exports = (io) => {
         image: claimed.itemImage,
         rarity: claimed.rarity,
         case: claimed.case,
-        createdAt: claimed.createdAt,
+        createdAt: new Date(), // acquired now, so it sorts as newest
         uniqueId: claimed.uniqueId,
       };
 

--- a/src/pages/Upgrade/UserItems.tsx
+++ b/src/pages/Upgrade/UserItems.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { MdOutlineNavigateBefore, MdOutlineNavigateNext } from "react-icons/md";
 import { AiOutlineClose, AiOutlineSearch } from "react-icons/ai";
 import Skeleton from "react-loading-skeleton";
@@ -36,7 +36,6 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
         order: "asc",
         caseId: "",
     });
-    const inventoryRef = useRef<HTMLDivElement | null>(null);
     const { userData } = useContext(UserContext);
 
     // any filter/sort change goes back to the first page
@@ -158,7 +157,6 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                             return (
                                 <div
                                     key={index}
-                                    ref={index === 0 ? inventoryRef : null}
                                     onClick={() => handleItemClick(item)}
                                     className={`cursor-pointer border-2 h-min ${selectedItems.some((selectedItem: { identifier: string }) => selectedItem.identifier === item.uniqueId) ? " border-[#606bc7]" : "border-transparent"}`}
                                 >
@@ -180,8 +178,7 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                         color: currentPage === 1 ? "gray" : "white",
                     }}
                     onClick={() => {
-                        currentPage !== 1 && setCurrentPage((prev) => prev - 1);
-                        currentPage !== 1 && inventoryRef.current?.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
+                        if (currentPage !== 1) setCurrentPage((prev) => prev - 1);
                     }}
                 />
                 <span>Page: {currentPage}{pageLimit > 0 ? ` / ${pageLimit}` : ""}</span>
@@ -191,8 +188,7 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                         color: currentPage === pageLimit ? "gray" : "white",
                     }}
                     onClick={() => {
-                        currentPage !== pageLimit && setCurrentPage((prev) => prev + 1);
-                        currentPage !== pageLimit && inventoryRef.current?.scrollIntoView({ behavior: "smooth" });
+                        if (currentPage !== pageLimit) setCurrentPage((prev) => prev + 1);
                     }}
                 />
             </div>


### PR DESCRIPTION
- bought/delisted items now get createdAt = acquisition time, so a freshly bought item shows as newest in the upgrade inventory (was inheriting the listing's createdAt)\n- remove the scrollIntoView on page change in the upgrade inventory