### PR TITLE
Add semantic color tokens for the dark casino theme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,37 @@ module.exports = {
         'secondary': '#4f46e5',
         'secondary-light': '#606bc7',
         'unique': '#FFCC00',
+
+        // semantic palette. the raw [#hex] classes already in the codebase
+        // still work; prefer these names in new code.
+        surface: {
+          page: '#141225',      // page / section background
+          deep: '#151225',      // deepest surface
+          nav: '#19172D',       // navbar, inputs, modal body
+          DEFAULT: '#212031',   // cards, panels, list rows
+          raised: '#281D3F',    // secondary buttons, chips
+          hover: '#3A2C5C',     // raised hover
+        },
+        line: {
+          DEFAULT: '#2A2840',   // hairline borders and dividers
+          strong: '#3A365A',
+        },
+        ink: {
+          DEFAULT: '#FFFFFF',   // primary text
+          soft: '#C9C6DE',      // secondary text
+          muted: '#84819A',     // muted labels, timestamps
+          faint: '#625F7E',     // muted icons
+        },
+        accent: {
+          DEFAULT: '#4F46E5',   // indigo, primary action
+          light: '#606BC7',
+          gold: '#FFCC00',      // winnings, rare highlights
+          amber: '#ECA823',
+        },
+        skeleton: {
+          base: '#1C1A31',      // react-loading-skeleton baseColor
+          highlight: '#161427', // react-loading-skeleton highlightColor
+        },
       },
     },
 


### PR DESCRIPTION
Adds an additive semantic color palette to the Tailwind theme (surface / line / ink / accent / skeleton) so new UI can use named tokens instead of raw hex arbitrary values.

Purely additive: the existing `primary` / `secondary` / `unique` tokens and every raw `bg-[#hex]` class in the app are untouched, so the app builds and renders identically. New code (starting with the upcoming collections page) will use the named tokens.