### PR TITLE
Collections: render items as trading cards with descriptions

### DIFF
--- a/backend/__tests__/integration/collections.read.test.js
+++ b/backend/__tests__/integration/collections.read.test.js
@@ -169,6 +169,40 @@ describe("GET /collections/:caseId", () => {
     expect(res.body.extras[0]._id).toBe(removed._id.toString());
     expect(res.body.extras[0].inCase).toBe(false);
     expect(res.body.extras[0].owned).toBe(3);
+    expect(res.body.extras[0].slotNumber).toBe(0); // extras sit outside the numbering
+  });
+
+  test("card numbers follow the canonical order and survive sort and filter", async () => {
+    const u = await makeUser();
+    const { c, items } = await makeCase([
+      { rarity: 1, baseValue: 100 },
+      { rarity: 3, baseValue: 300 },
+      { rarity: 5, baseValue: 1000 },
+    ]);
+    await Item.updateOne({ _id: items[0]._id }, { description: "a very common thing" });
+    await give(u, items[0], 2, c._id);
+
+    const res = await request(app).get(`/collections/${c._id}`).query({ userId: u._id.toString() });
+    const byId = new Map(res.body.items.map((i) => [i._id, i]));
+    // canonical order is rarest first: rarity 5 is card 1, rarity 1 is card 3
+    expect(byId.get(items[2]._id.toString()).slotNumber).toBe(1);
+    expect(byId.get(items[1]._id.toString()).slotNumber).toBe(2);
+    expect(byId.get(items[0]._id.toString()).slotNumber).toBe(3);
+    expect(byId.get(items[0]._id.toString()).description).toBe("a very common thing");
+    expect(byId.get(items[1]._id.toString()).description).toBe("");
+
+    // reversing the sort must not renumber the cards
+    const rev = await request(app)
+      .get(`/collections/${c._id}`)
+      .query({ userId: u._id.toString(), sortBy: "mostCommon" });
+    expect(rev.body.items[0]._id).toBe(items[0]._id.toString());
+    expect(rev.body.items[0].slotNumber).toBe(3);
+
+    // a filtered view keeps the numbers of the full album
+    const dups = await request(app)
+      .get(`/collections/${c._id}`)
+      .query({ userId: u._id.toString(), filter: "duplicates" });
+    expect(dups.body.items[0].slotNumber).toBe(3);
   });
 
   test("bad case id -> 404, invalid user -> 400", async () => {
@@ -176,6 +210,21 @@ describe("GET /collections/:caseId", () => {
     const { c } = await makeCase([{ rarity: 1, baseValue: 100 }]);
     expect((await request(app).get(`/collections/notanid`).query({ userId: u._id.toString() })).status).toBe(404);
     expect((await request(app).get(`/collections/${c._id}`).query({ userId: "nope" })).status).toBe(400);
+  });
+
+  test("a duplicated item id in Case.items counts as a single slot", async () => {
+    const u = await makeUser();
+    const { c, items } = await makeCase([
+      { rarity: 5, baseValue: 1000 },
+      { rarity: 1, baseValue: 100 },
+    ]);
+    // raw admin input can push the same id twice
+    await Case.updateOne({ _id: c._id }, { $push: { items: items[0]._id } });
+
+    const res = await request(app).get(`/collections/${c._id}`).query({ userId: u._id.toString() });
+    expect(res.body.slotsTotal).toBe(2);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.items.map((i) => i.slotNumber).sort()).toEqual([1, 2]);
   });
 
   test("second page respects the 18-per-page size", async () => {

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -5,6 +5,7 @@ const ItemSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  description: String,
   image: String,
   rarity: {
     type: String,

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -5,7 +5,10 @@ const ItemSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  description: String,
+  description: {
+    type: String,
+    maxlength: 200,
+  },
   image: String,
   rarity: {
     type: String,

--- a/backend/routes/collectionsRoutes.js
+++ b/backend/routes/collectionsRoutes.js
@@ -18,6 +18,17 @@ const pctOf = (owned, total) => (total ? Math.floor((1000 * owned) / total) / 10
 // Case.items (the authoritative slot set). completion, duplicate value and the
 // quicksell scope all use this one rule, so they can never disagree.
 
+// Case.items is raw admin input and can hold the same id twice; every consumer
+// works on the unique slot set so stats, numbering and quicksell agree
+function uniqueItems(caseDoc) {
+  const seen = new Set();
+  return (caseDoc.items || []).filter((it) => {
+    if (!it || seen.has(String(it._id))) return false;
+    seen.add(String(it._id));
+    return true;
+  });
+}
+
 // count owned copies and gather the uniqueIds per catalog item _id
 function indexInventory(inventory) {
   const countById = new Map();
@@ -39,7 +50,7 @@ function indexInventory(inventory) {
 // case) are never swept. returns { lines, plan, totalItems, totalValue }, where plan
 // is the sorted, flat list of uniqueIds to sell.
 function computeQuicksellPlan(inventory, caseDoc) {
-  const items = (caseDoc.items || []).filter(Boolean);
+  const items = uniqueItems(caseDoc);
   const metaById = new Map(
     items.map((it) => [
       String(it._id),
@@ -97,7 +108,7 @@ function computeQuicksellPlan(inventory, caseDoc) {
 }
 
 function caseStats(caseDoc, countById) {
-  const items = (caseDoc.items || []).filter(Boolean);
+  const items = uniqueItems(caseDoc);
   const slotsTotal = items.length;
   let slotsOwned = 0;
   let duplicatesValue = 0;
@@ -281,7 +292,7 @@ router.get("/:caseId", async (req, res) => {
     }
 
     const caseDoc = await Case.findById(caseId)
-      .populate("items", "name image rarity baseValue");
+      .populate("items", "name image rarity baseValue description");
     if (!caseDoc) {
       return res.status(404).json({ message: "Collection not found" });
     }
@@ -291,7 +302,7 @@ router.get("/:caseId", async (req, res) => {
     }
 
     const { countById, uniqueIdsById } = indexInventory(user.inventory);
-    const items = (caseDoc.items || []).filter(Boolean);
+    const items = uniqueItems(caseDoc);
     const caseItemIds = new Set(items.map((it) => String(it._id)));
     const stats = caseStats(caseDoc, countById);
 
@@ -303,6 +314,7 @@ router.get("/:caseId", async (req, res) => {
       return {
         _id: id,
         name: it.name,
+        description: it.description || "",
         image: it.image,
         rarity: it.rarity,
         baseValue: it.baseValue || 0,
@@ -315,6 +327,16 @@ router.get("/:caseId", async (req, res) => {
         uniqueIds: uniqueIdsById.get(id) || [],
       };
     });
+
+    // card numbers follow the album's canonical order (rarest first, name as
+    // tiebreak) and stick to the item, whatever filter or sort is applied
+    const numbered = [...rows].sort(
+      (a, b) =>
+        Number(b.rarity) - Number(a.rarity) ||
+        (a.name < b.name ? -1 : a.name > b.name ? 1 : 0)
+    );
+    const numberById = new Map(numbered.map((r, i) => [r._id, i + 1]));
+    for (const r of rows) r.slotNumber = numberById.get(r._id);
 
     const { filter, sortBy } = req.query;
     if (filter === "owned") rows = rows.filter((r) => r.owned > 0);
@@ -357,9 +379,10 @@ router.get("/:caseId", async (req, res) => {
     if (extraCounts.size) {
       const exDocs = await Item.find(
         { _id: { $in: [...extraCounts.keys()] } },
-        { baseValue: 1 }
+        { baseValue: 1, description: 1 }
       );
       const baseById = new Map(exDocs.map((i) => [String(i._id), i.baseValue || 0]));
+      const descById = new Map(exDocs.map((i) => [String(i._id), i.description || ""]));
       extras = [...extraCounts.entries()].map(([id, owned]) => {
         const snap = extraSnap.get(id) || {};
         const base = baseById.get(id) || 0; // deleted source -> 0, not sellable
@@ -368,8 +391,10 @@ router.get("/:caseId", async (req, res) => {
         return {
           _id: id,
           name: snap.name || "Unknown item",
+          description: descById.get(id) || "",
           image: snap.image || "",
           rarity: snap.rarity || "1",
+          slotNumber: 0,
           baseValue: base,
           sellValue: sv,
           owned,

--- a/src/pages/Collections/components/AlbumSlot.tsx
+++ b/src/pages/Collections/components/AlbumSlot.tsx
@@ -1,5 +1,5 @@
 import { BsLockFill } from "react-icons/bs";
-import { rarityColor } from "../../../utils/rarity";
+import { rarityColor, rarityAbbr } from "../../../utils/rarity";
 import { AlbumItem } from "../../../services/collections/CollectionService";
 
 interface Props {
@@ -7,52 +7,87 @@ interface Props {
   onClick: () => void;
 }
 
-// one album slot: a full-color card for an owned item (with a count badge for
-// duplicates), or a greyed, locked placeholder that still shows the item name.
+// one album slot, styled as a miniature of the full collection card: numbered
+// plate, framed art and a name plate over the rarity-textured band. missing
+// items render as a greyed, locked placeholder that still shows the name.
 const AlbumSlot: React.FC<Props> = ({ item, onClick }) => {
-  const color = rarityColor(item.rarity);
   const locked = item.owned === 0;
+  const color = locked ? "#3A365A" : rarityColor(item.rarity);
+  const plateBg = locked ? "bg-[#8f8a7c]" : "bg-[#EDE4CC]";
+  const cardNo = item.slotNumber ? String(item.slotNumber).padStart(2, "0") : "EX";
+
+  const artBackground = locked
+    ? "linear-gradient(160deg, #262338, #15131f)"
+    : `radial-gradient(120% 90% at 30% 25%, ${color}50, transparent 60%), linear-gradient(160deg, #223357, #101a33 55%, #1b2545)`;
+
+  const bandTexture = [
+    "radial-gradient(rgba(255,255,255,0.18) 1px, transparent 1.3px)",
+    "linear-gradient(rgba(10,6,20,0.35), rgba(10,6,20,0.5))",
+  ].join(", ");
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className="relative group w-28 md:w-40 flex flex-col items-center rounded-lg bg-surface border-b-4 pt-2 transition-all hover:-translate-y-1"
-      style={{ borderColor: locked ? "#2A2840" : color }}
+      className="relative group w-32 md:w-44 flex flex-col gap-1 rounded-xl bg-[#0E0C1B] p-1.5 transition-all hover:-translate-y-1"
+      style={{ boxShadow: `0 4px 14px rgba(0,0,0,0.4), 0 0 0 1px ${locked ? "#2A2840" : `${color}55`}` }}
     >
-      {item.owned > 1 && (
+      <div className="flex items-center justify-between gap-1">
         <span
-          className="absolute top-1 right-1 z-10 min-w-[22px] h-[22px] px-1 flex items-center justify-center rounded-full text-xs font-bold bg-surface-raised text-ink"
-          style={{ boxShadow: `0 0 0 1px ${color}` }}
+          className={`${plateBg} rounded px-1.5 py-0.5 font-serif font-bold text-[10px] leading-none text-[#241F35] border border-black/40`}
         >
-          ×{item.owned}
+          {cardNo}
         </span>
-      )}
-
-      <div className="relative w-full h-24 md:h-32 flex items-center justify-center overflow-hidden">
-        <img
-          src={item.image}
-          alt={item.name}
-          className={`max-h-full max-w-full object-contain transition-all ${
-            locked ? "grayscale opacity-20" : "group-hover:scale-105"
-          }`}
-          style={locked ? undefined : { filter: `drop-shadow(0 0 12px ${color}66)` }}
-        />
-        {locked && (
-          <span className="absolute inset-0 flex items-center justify-center text-ink-faint">
-            <BsLockFill className="text-xl md:text-2xl" />
-          </span>
-        )}
+        <span
+          className={`${plateBg} rounded px-1.5 py-0.5 font-serif font-bold text-[10px] leading-none text-[#241F35] border border-black/40`}
+          style={locked ? undefined : { backgroundImage: `linear-gradient(${color}59, ${color}59)` }}
+        >
+          {rarityAbbr(item.rarity)}
+        </span>
       </div>
 
-      <div className="flex items-center gap-1.5 px-2 pb-2 w-full">
-        <span
-          className="w-1.5 h-1.5 rounded-full shrink-0"
-          style={{ backgroundColor: locked ? "#3A365A" : color }}
-        />
-        <span className={`text-xs truncate ${locked ? "text-ink-faint" : "text-ink-soft"}`}>
-          {item.name}
-        </span>
+      <div className={`rounded-md p-[2px] ${plateBg}`}>
+        <div
+          className="relative h-20 md:h-28 rounded-[3px] border border-black/40 flex items-center justify-center overflow-hidden"
+          style={{ background: artBackground }}
+        >
+          {item.owned > 1 && (
+            <span
+              className="absolute top-1 right-1 z-10 min-w-[22px] h-[22px] px-1 flex items-center justify-center rounded-full text-xs font-bold bg-surface-raised text-ink"
+              style={{ boxShadow: `0 0 0 1px ${color}` }}
+            >
+              ×{item.owned}
+            </span>
+          )}
+          <img
+            src={item.image}
+            alt={item.name}
+            className={`max-h-[85%] max-w-[80%] object-contain transition-all ${
+              locked ? "grayscale opacity-25" : "group-hover:scale-105"
+            }`}
+            style={locked ? undefined : { filter: `drop-shadow(0 0 10px ${color}66)` }}
+          />
+          {locked && (
+            <span className="absolute inset-0 flex items-center justify-center text-[#8f8a7c]">
+              <BsLockFill className="text-xl md:text-2xl" />
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div
+        className="rounded-md border border-black/40 p-1"
+        style={{
+          backgroundColor: color,
+          backgroundImage: bandTexture,
+          backgroundSize: "8px 12px, auto",
+        }}
+      >
+        <div className={`${plateBg} rounded-[3px] px-1.5 py-0.5 border border-black/25`}>
+          <span className="block text-[11px] font-semibold truncate text-[#241F35]">
+            {item.name}
+          </span>
+        </div>
       </div>
     </button>
   );

--- a/src/pages/Collections/components/ItemCard.tsx
+++ b/src/pages/Collections/components/ItemCard.tsx
@@ -1,0 +1,140 @@
+import { BsLockFill } from "react-icons/bs";
+import { rarityColor, rarityName, rarityAbbr } from "../../../utils/rarity";
+import { AlbumItem } from "../../../services/collections/CollectionService";
+
+interface Props {
+  item: AlbumItem;
+}
+
+// double-lined parchment plate, the frame element every label on the card sits
+// in; tint washes the inner face with a translucent color
+const Plate: React.FC<{
+  dim?: boolean;
+  grow?: boolean;
+  tint?: string;
+  children: React.ReactNode;
+}> = ({ dim, grow, tint, children }) => (
+  <div
+    className={`rounded-md border border-black/50 p-[3px] ${grow ? "flex-1 min-w-0" : "shrink-0"} ${
+      dim ? "bg-[#8f8a7c]" : "bg-[#EDE4CC]"
+    }`}
+  >
+    <div
+      className="h-full rounded-[4px] border border-black/25 px-2 py-0.5 flex items-center justify-center min-w-0"
+      style={tint ? { backgroundImage: `linear-gradient(${tint}, ${tint})` } : undefined}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+// light bands keep dark ink, dark bands flip to light, so the footer stays
+// readable on every rarity color
+const isLightHex = (hex: string): boolean => {
+  const n = parseInt(hex.slice(1), 16);
+  return (((n >> 16) & 255) * 299 + ((n >> 8) & 255) * 587 + (n & 255) * 114) / 1000 > 150;
+};
+
+// a full collection card: numbered plates, framed art and a description panel
+// textured in the item's rarity color
+const ItemCard: React.FC<Props> = ({ item }) => {
+  const locked = item.owned === 0;
+  const color = locked ? "#3A365A" : rarityColor(item.rarity);
+  const cardNo = item.slotNumber ? String(item.slotNumber).padStart(2, "0") : "EX";
+
+  const artBackground = locked
+    ? "linear-gradient(160deg, #262338, #15131f)"
+    : [
+        "repeating-linear-gradient(105deg, rgba(255,255,255,0.04) 0 2px, transparent 2px 7px)",
+        `radial-gradient(120% 90% at 30% 25%, ${color}55, transparent 60%)`,
+        "linear-gradient(160deg, #223357, #101a33 55%, #1b2545)",
+      ].join(", ");
+
+  const panelTexture = [
+    "linear-gradient(115deg, rgba(255,255,255,0.10), rgba(255,255,255,0) 35%)",
+    "radial-gradient(rgba(255,255,255,0.20) 1px, transparent 1.4px)",
+    "radial-gradient(rgba(0,0,0,0.30) 1px, transparent 1.4px)",
+    "linear-gradient(rgba(10,6,20,0.35), rgba(10,6,20,0.5))",
+  ].join(", ");
+
+  return (
+    <div className="w-full rounded-2xl bg-[#0E0C1B] p-2 shadow-[0_10px_30px_rgba(0,0,0,0.45)]">
+      <div className="relative rounded-xl border border-[#57506E]/60 p-2 flex flex-col gap-2">
+        <span className="absolute top-1 left-1 w-2.5 h-2.5 border-t border-l border-[#CDC3A5]/70 rounded-tl" />
+        <span className="absolute top-1 right-1 w-2.5 h-2.5 border-t border-r border-[#CDC3A5]/70 rounded-tr" />
+        <span className="absolute bottom-1 left-1 w-2.5 h-2.5 border-b border-l border-[#CDC3A5]/70 rounded-bl" />
+        <span className="absolute bottom-1 right-1 w-2.5 h-2.5 border-b border-r border-[#CDC3A5]/70 rounded-br" />
+
+        <div className="flex items-stretch gap-1.5">
+          <Plate dim={locked}>
+            <span className="font-serif font-bold text-base leading-none text-[#241F35]">
+              {cardNo}
+            </span>
+          </Plate>
+          <Plate dim={locked} grow>
+            <span className="font-semibold text-sm text-[#241F35] truncate">{item.name}</span>
+          </Plate>
+          <Plate dim={locked} tint={locked ? undefined : `${color}59`}>
+            <span className="font-serif font-bold text-base leading-none text-[#241F35]">
+              {rarityAbbr(item.rarity)}
+            </span>
+          </Plate>
+        </div>
+
+        <div className={`rounded-md p-1 ${locked ? "bg-[#8f8a7c]" : "bg-[#EDE4CC]"}`}>
+          <div
+            className="relative h-44 rounded-[4px] border border-black/40 flex items-center justify-center overflow-hidden"
+            style={{ background: artBackground }}
+          >
+            <img
+              src={item.image}
+              alt={item.name}
+              className={`max-h-36 max-w-[75%] object-contain ${
+                locked ? "grayscale opacity-25" : ""
+              }`}
+              style={locked ? undefined : { filter: `drop-shadow(0 0 16px ${color}77)` }}
+            />
+            {locked && (
+              <span className="absolute inset-0 flex items-center justify-center text-[#8f8a7c]">
+                <BsLockFill className="text-3xl" />
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div
+          className="rounded-md border border-black/40 p-2.5 flex flex-col gap-1.5"
+          style={{
+            backgroundColor: color,
+            backgroundImage: panelTexture,
+            backgroundSize: "auto, 9px 13px, 13px 17px, auto",
+          }}
+        >
+          <div
+            className={`rounded-[4px] px-3 py-2.5 min-h-[84px] shadow-[inset_0_1px_3px_rgba(0,0,0,0.25)] ${
+              locked ? "bg-[#d6d2c4]" : "bg-[#F5EEDA]"
+            }`}
+          >
+            {item.description ? (
+              <p className="text-sm leading-relaxed text-[#2A2440] break-words">
+                {item.description}
+              </p>
+            ) : (
+              <p className="text-sm italic text-[#8A8064]">No description yet.</p>
+            )}
+          </div>
+          <div
+            className={`flex items-center justify-between px-0.5 text-[9px] font-medium uppercase tracking-widest ${
+              isLightHex(color) ? "text-black/60" : "text-white/70"
+            }`}
+          >
+            <span>©Kani Collection</span>
+            <span>{locked ? "Undiscovered" : rarityName(item.rarity)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ItemCard;

--- a/src/pages/Collections/components/ItemDetailModal.tsx
+++ b/src/pages/Collections/components/ItemDetailModal.tsx
@@ -4,8 +4,7 @@ import { MdOutlineSell, MdStorefront } from "react-icons/md";
 import Modal from "../../../components/Modal";
 import MainButton from "../../../components/MainButton";
 import Monetary from "../../../components/Monetary";
-import Rarities from "../../../components/Rarities";
-import { rarityColor } from "../../../utils/rarity";
+import ItemCard from "./ItemCard";
 import { AlbumItem } from "../../../services/collections/CollectionService";
 
 interface Props {
@@ -31,40 +30,24 @@ const ItemDetailModal: React.FC<Props> = ({
 
   if (!item) return null;
 
-  const color = rarityColor(item.rarity);
   const locked = item.owned === 0;
-  const rarityName = Rarities.find((r) => r.id.toString() === item.rarity)?.name || "";
   const canSell = isOwner && item.owned > 0 && item.sellValue > 0 && item.uniqueIds.length > 0;
 
   return (
     <Modal open={open} setOpen={setOpen} width="420px">
       <div className="flex flex-col items-center gap-4">
-        <div
-          className="w-full h-40 flex items-center justify-center rounded-lg bg-surface border-b-4"
-          style={{ borderColor: locked ? "#2A2840" : color }}
-        >
-          <img
-            src={item.image}
-            alt={item.name}
-            className={`max-h-32 max-w-[80%] object-contain ${locked ? "grayscale opacity-25" : ""}`}
-            style={locked ? undefined : { filter: `drop-shadow(0 0 14px ${color}66)` }}
-          />
-        </div>
+        <ItemCard item={item} />
 
-        <div className="flex flex-col items-center gap-1 text-center">
-          <h3 className="text-lg font-semibold text-ink">{item.name}</h3>
-          <span className="text-xs font-medium" style={{ color }}>
-            {rarityName}
-          </span>
-          <span className="text-sm text-ink-muted">
-            Sell value <Monetary value={item.sellValue} /> each
-          </span>
-          <span className={`mt-1 text-sm ${locked ? "text-ink-faint" : "text-ink-soft"}`}>
+        <div className="w-full flex items-center justify-between px-1 text-sm">
+          <span className={locked ? "text-ink-faint" : "text-ink-soft"}>
             {locked ? "Not yet collected" : `You own ×${item.owned}`}
           </span>
+          <span className="text-ink-muted">
+            Sell value <Monetary value={item.sellValue} /> each
+          </span>
         </div>
 
-        <div className="flex flex-col gap-2 w-full mt-2">
+        <div className="flex flex-col gap-2 w-full">
           <MainButton
             text="Go to case"
             onClick={() => navigate(`/case/${caseId}`)}

--- a/src/services/collections/CollectionService.ts
+++ b/src/services/collections/CollectionService.ts
@@ -30,8 +30,10 @@ export interface CollectionsSummary {
 export interface AlbumItem {
   _id: string;
   name: string;
+  description: string;
   image: string;
   rarity: string;
+  slotNumber: number;
   baseValue: number;
   sellValue: number;
   owned: number;

--- a/src/utils/rarity.ts
+++ b/src/utils/rarity.ts
@@ -2,3 +2,17 @@ import Rarities from "../components/Rarities";
 
 export const rarityColor = (rarity: string | number): string =>
   Rarities.find((r) => r.id.toString() === String(rarity))?.color || "#ffffff";
+
+export const rarityName = (rarity: string | number): string =>
+  Rarities.find((r) => r.id.toString() === String(rarity))?.name || "";
+
+const RARITY_ABBR: Record<string, string> = {
+  "1": "C",
+  "2": "R",
+  "3": "E",
+  "4": "UR",
+  "5": "UN",
+};
+
+export const rarityAbbr = (rarity: string | number): string =>
+  RARITY_ABBR[String(rarity)] || "?";


### PR DESCRIPTION
Collection album items now render as trading cards: a numbered, rarity-framed card in the detail modal (art window plus a description panel) and matching mini-cards in the album grid.

**Backend**
- `Item.description` (optional string, capped at 200 chars).
- `GET /collections/:caseId` returns each item's `description` and a stable `slotNumber` (card number follows the album's canonical rarest-first order, independent of the active filter/sort). Duplicate item ids in a case now count as a single slot.

**Frontend**
- New `ItemCard` component (full card) used by the item detail modal; `AlbumSlot` restyled as a mini-card.
- `rarityName`/`rarityAbbr` helpers; the rarity seal and footer stay legible on every rarity color and in the locked state.
