### PR TITLE
Missions: profile missions tab with claimable KP rewards

### DIFF
--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -7,6 +7,7 @@ const friendsRoutes = require("../../routes/friendsRoutes");
 const gamesRoutes = require("../../routes/gamesRoutes");
 const fairRoutes = require("../../routes/fairRoutes");
 const collectionsRoutes = require("../../routes/collectionsRoutes");
+const missionsRoutes = require("../../routes/missionsRoutes");
 
 // no-op socket.io stand-in
 const io = { emit: () => {}, to: () => ({ emit: () => {} }) };
@@ -20,6 +21,7 @@ function makeApp() {
   app.use("/games", gamesRoutes(io));
   app.use("/fair", fairRoutes);
   app.use("/collections", collectionsRoutes);
+  app.use("/missions", missionsRoutes(io));
   return app;
 }
 

--- a/backend/__tests__/integration/missions.test.js
+++ b/backend/__tests__/integration/missions.test.js
@@ -59,7 +59,7 @@ describe("GET /missions", () => {
     const u = await makeUser();
     const res = await getMissions(u);
     expect(res.status).toBe(200);
-    expect(res.body.missions.length).toBeGreaterThanOrEqual(16);
+    expect(res.body.missions.length).toBeGreaterThanOrEqual(15);
     expect(res.body.missions.every((m) => m.current === 0)).toBe(true);
     expect(res.body.totals.claimable).toBe(0);
     expect(find(res.body, "first-case").complete).toBe(false);
@@ -134,8 +134,15 @@ describe("GET /missions", () => {
     const friend = await makeUser();
     const u = await makeUser({ profilePicture: "http://img/x.png", friends: [friend._id] });
     const res = await getMissions(u);
-    expect(find(res.body, "set-avatar").complete).toBe(true);
     expect(find(res.body, "add-friend").complete).toBe(true);
+  });
+
+  test("a disabled mission is never shown or claimable", async () => {
+    const u = await makeUser({ profilePicture: "http://img/x.png" });
+    const res = await getMissions(u);
+    expect(find(res.body, "set-avatar")).toBeUndefined(); // filtered out of the catalog
+    // and it cannot be claimed even though the user has a profile picture
+    expect((await auth(request(app).post("/missions/set-avatar/claim"), u)).status).toBe(404);
   });
 
   test("only activity at/after the launch timestamp counts", async () => {

--- a/backend/__tests__/integration/missions.test.js
+++ b/backend/__tests__/integration/missions.test.js
@@ -1,0 +1,213 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+// count all seeded activity regardless of wall clock
+process.env.MISSIONS_LAUNCH_AT = "2000-01-01T00:00:00.000Z";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Case = require("../../models/Case");
+const Battle = require("../../models/Battle");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 1000,
+    ...overrides,
+  });
+}
+
+function auth(req, user) {
+  return req.set("Authorization", `Bearer ${tokenFor(user)}`);
+}
+
+async function tx(userId, type, { amount = 1, meta = {}, direction = "debit", createdAt } = {}) {
+  const doc = { userId, type, direction, amount, meta };
+  if (createdAt) doc.createdAt = createdAt;
+  return Transaction.create(doc);
+}
+
+function getMissions(user) {
+  return auth(request(app).get("/missions"), user);
+}
+function find(body, key) {
+  return body.missions.find((m) => m.key === key);
+}
+
+describe("GET /missions", () => {
+  test("requires auth", async () => {
+    expect((await request(app).get("/missions")).status).toBe(401);
+  });
+
+  test("a fresh user has the full catalog with zero progress and nothing claimable", async () => {
+    const u = await makeUser();
+    const res = await getMissions(u);
+    expect(res.status).toBe(200);
+    expect(res.body.missions.length).toBeGreaterThanOrEqual(16);
+    expect(res.body.missions.every((m) => m.current === 0)).toBe(true);
+    expect(res.body.totals.claimable).toBe(0);
+    expect(find(res.body, "first-case").complete).toBe(false);
+  });
+
+  test("casesOpened sums meta.quantity across case_open rows", async () => {
+    const u = await makeUser();
+    await tx(u._id, TX.CASE_OPEN, { amount: 300, meta: { quantity: 3 } });
+    await tx(u._id, TX.CASE_OPEN, { amount: 200, meta: { quantity: 2 } });
+    const res = await getMissions(u);
+    expect(find(res.body, "first-case").current).toBe(1); // clamped to target
+    expect(find(res.body, "first-case").complete).toBe(true);
+    expect(find(res.body, "cases-10").current).toBe(5); // 3 + 2, not yet 10
+    expect(find(res.body, "cases-10").complete).toBe(false);
+  });
+
+  test("a big single payout completes big-win", async () => {
+    const u = await makeUser();
+    await tx(u._id, TX.SLOT_WIN, { amount: 12000, direction: "credit" });
+    const res = await getMissions(u);
+    expect(find(res.body, "big-win").complete).toBe(true);
+  });
+
+  test("a small win does not complete big-win", async () => {
+    const u = await makeUser();
+    await tx(u._id, TX.COINFLIP_WIN, { amount: 500, direction: "credit" });
+    const res = await getMissions(u);
+    expect(find(res.body, "big-win").complete).toBe(false);
+    expect(find(res.body, "coinflip-win").complete).toBe(true);
+  });
+
+  test("a finished battle win completes battle-win", async () => {
+    const u = await makeUser();
+    await Battle.create({
+      mode: "1v1",
+      entryCost: 100,
+      createdBy: u._id,
+      status: "finished",
+      finishedAt: new Date(),
+      winnerUserIds: [u._id],
+    });
+    const res = await getMissions(u);
+    expect(find(res.body, "battle-win").complete).toBe(true);
+  });
+
+  test("state-based missions read live user fields", async () => {
+    const friend = await makeUser();
+    const u = await makeUser({ profilePicture: "http://img/x.png", friends: [friend._id] });
+    const res = await getMissions(u);
+    expect(find(res.body, "set-avatar").complete).toBe(true);
+    expect(find(res.body, "add-friend").complete).toBe(true);
+  });
+
+  test("only activity at/after the launch timestamp counts", async () => {
+    process.env.MISSIONS_LAUNCH_AT = "2026-07-15T00:00:00.000Z";
+    const u = await makeUser();
+    await tx(u._id, TX.CASE_OPEN, { meta: { quantity: 1 }, createdAt: new Date("2026-07-14T00:00:00Z") });
+    let res = await getMissions(u);
+    expect(find(res.body, "first-case").complete).toBe(false); // before launch, ignored
+    await tx(u._id, TX.CASE_OPEN, { meta: { quantity: 1 }, createdAt: new Date("2026-07-16T00:00:00Z") });
+    res = await getMissions(u);
+    expect(find(res.body, "first-case").complete).toBe(true);
+    process.env.MISSIONS_LAUNCH_AT = "2000-01-01T00:00:00.000Z";
+  });
+});
+
+describe("POST /missions/:key/claim", () => {
+  test("claiming a completed mission credits the reward once and writes a ledger row", async () => {
+    const u = await makeUser({ walletBalance: 1000 });
+    await tx(u._id, TX.BONUS, { amount: 1000, direction: "credit" });
+
+    const res = await auth(request(app).post("/missions/first-bonus/claim"), u);
+    expect(res.status).toBe(200);
+    expect(res.body.claimed).toBe(true);
+    expect(res.body.reward).toBe(250);
+    expect(res.body.walletBalance).toBe(1250);
+
+    const fresh = await User.findById(u._id);
+    expect(fresh.walletBalance).toBe(1250);
+    const rows = await Transaction.find({ userId: u._id, type: TX.MISSION_REWARD });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amount).toBe(250);
+    expect(rows[0].meta.missionKey).toBe("first-bonus");
+  });
+
+  test("re-claiming does not double credit", async () => {
+    const u = await makeUser({ walletBalance: 1000 });
+    await tx(u._id, TX.BONUS, { amount: 1000, direction: "credit" });
+
+    const first = await auth(request(app).post("/missions/first-bonus/claim"), u);
+    expect(first.body.claimed).toBe(true);
+    const second = await auth(request(app).post("/missions/first-bonus/claim"), u);
+    expect(second.body.claimed).toBe(false);
+    expect(second.body.alreadyClaimed).toBe(true);
+
+    const fresh = await User.findById(u._id);
+    expect(fresh.walletBalance).toBe(1250); // only one reward
+    expect(await Transaction.countDocuments({ userId: u._id, type: TX.MISSION_REWARD })).toBe(1);
+  });
+
+  test("concurrent claims credit exactly once", async () => {
+    const u = await makeUser({ walletBalance: 1000 });
+    await tx(u._id, TX.BONUS, { amount: 1000, direction: "credit" });
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => auth(request(app).post("/missions/first-bonus/claim"), u))
+    );
+    const credited = results.filter((r) => r.body.claimed === true);
+    expect(credited).toHaveLength(1);
+
+    const fresh = await User.findById(u._id);
+    expect(fresh.walletBalance).toBe(1250);
+    expect(await Transaction.countDocuments({ userId: u._id, type: TX.MISSION_REWARD })).toBe(1);
+  });
+
+  test("claiming an incomplete mission is rejected", async () => {
+    const u = await makeUser();
+    const res = await auth(request(app).post("/missions/cases-100/claim"), u);
+    expect(res.status).toBe(400);
+    expect(await Transaction.countDocuments({ userId: u._id, type: TX.MISSION_REWARD })).toBe(0);
+  });
+
+  test("unknown mission key -> 404", async () => {
+    const u = await makeUser();
+    expect((await auth(request(app).post("/missions/not-a-mission/claim"), u)).status).toBe(404);
+  });
+});
+
+describe("POST /missions/:key/visit (social, honor-system)", () => {
+  test("visiting a social link completes it, then it can be claimed", async () => {
+    const u = await makeUser({ walletBalance: 500 });
+    let res = await getMissions(u);
+    expect(find(res.body, "join-discord").complete).toBe(false);
+
+    const visit = await auth(request(app).post("/missions/join-discord/visit"), u);
+    expect(visit.status).toBe(200);
+
+    res = await getMissions(u);
+    expect(find(res.body, "join-discord").complete).toBe(true);
+
+    const claim = await auth(request(app).post("/missions/join-discord/claim"), u);
+    expect(claim.body.claimed).toBe(true);
+    expect(claim.body.reward).toBe(150);
+    expect((await User.findById(u._id)).walletBalance).toBe(650);
+  });
+
+  test("visiting a non-social mission is rejected", async () => {
+    const u = await makeUser();
+    expect((await auth(request(app).post("/missions/first-case/visit"), u)).status).toBe(400);
+  });
+});

--- a/backend/__tests__/integration/missions.test.js
+++ b/backend/__tests__/integration/missions.test.js
@@ -105,6 +105,31 @@ describe("GET /missions", () => {
     expect(find(res.body, "battle-win").complete).toBe(true);
   });
 
+  test("complete-collection matches the album: a dangling item ref is not a required slot", async () => {
+    const u = await makeUser();
+    const s = uniqueSuffix();
+    const x = await Item.create({ name: `x-${s}`, image: "i", rarity: "1", baseValue: 100 });
+    const y = await Item.create({ name: `y-${s}`, image: "i", rarity: "2", baseValue: 200 });
+    const ghost = "651111111111111111111111"; // a deleted item still referenced by the case
+    const c = await Case.create({ title: `c-${s}`, image: "c", price: 100, items: [x._id, y._id, ghost] });
+    // own the two surviving items only
+    await User.updateOne(
+      { _id: u._id },
+      {
+        $push: {
+          inventory: {
+            $each: [
+              { _id: x._id, name: x.name, image: x.image, rarity: x.rarity, case: c._id, uniqueId: `u1-${s}` },
+              { _id: y._id, name: y.name, image: y.image, rarity: y.rarity, case: c._id, uniqueId: `u2-${s}` },
+            ],
+          },
+        },
+      }
+    );
+    const res = await getMissions(u);
+    expect(find(res.body, "complete-collection").complete).toBe(true);
+  });
+
   test("state-based missions read live user fields", async () => {
     const friend = await makeUser();
     const u = await makeUser({ profilePicture: "http://img/x.png", friends: [friend._id] });

--- a/backend/__tests__/integration/missions.test.js
+++ b/backend/__tests__/integration/missions.test.js
@@ -56,10 +56,10 @@ describe("GET /missions", () => {
   });
 
   test("a fresh user has the full catalog with zero progress and nothing claimable", async () => {
-    const u = await makeUser();
+    const u = await makeUser({ walletBalance: 0 });
     const res = await getMissions(u);
     expect(res.status).toBe(200);
-    expect(res.body.missions.length).toBeGreaterThanOrEqual(15);
+    expect(res.body.missions.length).toBeGreaterThanOrEqual(20);
     expect(res.body.missions.every((m) => m.current === 0)).toBe(true);
     expect(res.body.totals.claimable).toBe(0);
     expect(find(res.body, "first-case").complete).toBe(false);
@@ -143,6 +143,42 @@ describe("GET /missions", () => {
     expect(find(res.body, "set-avatar")).toBeUndefined(); // filtered out of the catalog
     // and it cannot be claimed even though the user has a profile picture
     expect((await auth(request(app).post("/missions/set-avatar/claim"), u)).status).toBe(404);
+  });
+
+  test("endgame metrics: total wagered, crash cashouts, level and balance", async () => {
+    const u = await makeUser({ level: 30, walletBalance: 1000000 });
+    await tx(u._id, TX.CRASH_BET, { amount: 400000 });
+    await tx(u._id, TX.SLOT_BET, { amount: 400000 });
+    await tx(u._id, TX.CASE_OPEN, { amount: 300000, meta: { quantity: 1 } });
+    await tx(u._id, TX.CRASH_CASHOUT, { amount: 50, direction: "credit" });
+    const res = await getMissions(u);
+    expect(find(res.body, "wager-million").complete).toBe(true); // 1.1M staked
+    expect(find(res.body, "crash-50").current).toBe(1);
+    expect(find(res.body, "level-30").complete).toBe(true);
+    expect(find(res.body, "millionaire").complete).toBe(true);
+  });
+
+  test("master collector needs every case complete, not just one", async () => {
+    const u = await makeUser();
+    const mk = async (rarities) => {
+      const items = [];
+      for (const r of rarities) items.push(await Item.create({ name: `i-${uniqueSuffix()}`, image: "i", rarity: String(r), baseValue: 100 }));
+      const c = await Case.create({ title: `c-${uniqueSuffix()}`, image: "c", price: 100, items: items.map((i) => i._id) });
+      return { c, items };
+    };
+    const a = await mk([1, 2]);
+    const b = await mk([1]);
+    const give = async (item, caseId) =>
+      User.updateOne({ _id: u._id }, { $push: { inventory: { _id: item._id, name: item.name, image: item.image, rarity: item.rarity, case: caseId, uniqueId: `u-${uniqueSuffix()}` } } });
+    // complete only case A
+    await give(a.items[0], a.c._id);
+    await give(a.items[1], a.c._id);
+    let res = await getMissions(u);
+    expect(find(res.body, "collections-all").complete).toBe(false); // case B still missing
+    // complete case B too
+    await give(b.items[0], b.c._id);
+    res = await getMissions(u);
+    expect(find(res.body, "collections-all").complete).toBe(true);
   });
 
   test("only activity at/after the launch timestamp counts", async () => {

--- a/backend/__tests__/integration/missions.test.js
+++ b/backend/__tests__/integration/missions.test.js
@@ -213,6 +213,48 @@ describe("POST /missions/:key/claim", () => {
   });
 });
 
+describe("GET /missions/pending (real-time announcements)", () => {
+  function getPending(user, light) {
+    return auth(request(app).get(`/missions/pending${light ? "?light=1" : ""}`), user);
+  }
+
+  test("the first call seeds silently, then only new completions are announced once", async () => {
+    const u = await makeUser();
+    // fresh user, nothing complete: first call seeds and returns nothing
+    let res = await getPending(u);
+    expect(res.status).toBe(200);
+    expect(res.body.pending).toEqual([]);
+
+    // complete a mission after the seed
+    await tx(u._id, TX.BONUS, { amount: 1000, direction: "credit" });
+    res = await getPending(u);
+    expect(res.body.pending.map((p) => p.key)).toEqual(["first-bonus"]);
+    expect(res.body.pending[0].reward).toBe(250);
+
+    // announced once: a second call does not re-announce it
+    res = await getPending(u);
+    expect(res.body.pending).toEqual([]);
+  });
+
+  test("completions that predate the first check are seeded silently (never toast)", async () => {
+    const u = await makeUser();
+    await tx(u._id, TX.BONUS, { amount: 1000, direction: "credit" }); // already complete before any check
+    let res = await getPending(u);
+    expect(res.body.pending).toEqual([]); // seeded, not announced
+    res = await getPending(u);
+    expect(res.body.pending).toEqual([]); // and still nothing
+  });
+
+  test("concurrent pending checks announce a mission exactly once", async () => {
+    const u = await makeUser();
+    await getPending(u); // seed
+    await tx(u._id, TX.COINFLIP_WIN, { amount: 500, direction: "credit" });
+    const results = await Promise.all(Array.from({ length: 5 }, () => getPending(u)));
+    const announced = results.flatMap((r) => r.body.pending.map((p) => p.key)).filter((k) => k === "coinflip-win");
+    expect(announced).toHaveLength(1);
+  });
+});
+
 describe("POST /missions/:key/visit (social, honor-system)", () => {
   test("visiting a social link completes it, then it can be claimed", async () => {
     const u = await makeUser({ walletBalance: 500 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -79,6 +79,7 @@ const gamesRoutes = require("./routes/gamesRoutes")(io);
 const friendsRoutes = require("./routes/friendsRoutes")(io);
 const fairRoutes = require("./routes/fairRoutes");
 const collectionsRoutes = require("./routes/collectionsRoutes");
+const missionsRoutes = require("./routes/missionsRoutes")(io);
 
 // Connect to MongoDB
 mongoose
@@ -108,6 +109,7 @@ app.use("/games", gamesRoutes);
 app.use("/friends", friendsRoutes);
 app.use("/fair", fairRoutes);
 app.use("/collections", collectionsRoutes);
+app.use("/missions", missionsRoutes);
 
 // Start the games
 coinFlip(io);

--- a/backend/models/MissionState.js
+++ b/backend/models/MissionState.js
@@ -1,0 +1,21 @@
+const mongoose = require("mongoose");
+
+// per-user mission bookkeeping. progress itself is derived on read from the
+// ledger / battles / inventory; only two things must be persisted: which mission
+// rewards have been claimed (the one-time-credit guard) and which social links
+// the user has clicked (client-reported completion that is not otherwise derivable).
+const MissionStateSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+    },
+    claimed: { type: [String], default: [] },
+    visited: { type: [String], default: [] },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("MissionState", MissionStateSchema);

--- a/backend/models/MissionState.js
+++ b/backend/models/MissionState.js
@@ -14,6 +14,11 @@ const MissionStateSchema = new mongoose.Schema(
     },
     claimed: { type: [String], default: [] },
     visited: { type: [String], default: [] },
+    // missions already announced via the real-time "mission complete" toast, so it
+    // fires exactly once. `seeded` marks the one-time catch-up that records existing
+    // completions silently (no toast for things finished before real-time tracking).
+    announced: { type: [String], default: [] },
+    seeded: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/backend/routes/missionsRoutes.js
+++ b/backend/routes/missionsRoutes.js
@@ -18,6 +18,20 @@ module.exports = (io) => {
     }
   });
 
+  // GET /missions/pending : missions newly complete since the last check, for the
+  // real-time toast (server-guarded so each fires once). ?light=1 skips the heavy
+  // collection scan for the frequent hot-path (balance-change) calls.
+  router.get("/pending", isAuthenticated, async (req, res) => {
+    try {
+      const light = req.query.light === "1" || req.query.light === "true";
+      const pending = await missions.getPendingAnnouncements(req.user._id, { light });
+      res.json({ pending });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
   // POST /missions/:key/visit : mark a social mission's link clicked (honor-system)
   router.post("/:key/visit", isAuthenticated, async (req, res) => {
     try {

--- a/backend/routes/missionsRoutes.js
+++ b/backend/routes/missionsRoutes.js
@@ -1,0 +1,45 @@
+const express = require("express");
+const { isAuthenticated } = require("../middleware/authMiddleware");
+const missions = require("../utils/missions");
+
+// missions are always the authenticated user's own progress; there is no userId
+// param (a user cannot view someone else's mission state).
+module.exports = (io) => {
+  const router = express.Router();
+
+  // GET /missions : the catalog with this user's progress + claim state
+  router.get("/", isAuthenticated, async (req, res) => {
+    try {
+      const data = await missions.getMissionsView(req.user._id);
+      res.json(data);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  // POST /missions/:key/visit : mark a social mission's link clicked (honor-system)
+  router.post("/:key/visit", isAuthenticated, async (req, res) => {
+    try {
+      const r = await missions.markVisited(req.user._id, req.params.key);
+      if (!r.ok) return res.status(400).json({ message: "Not a social mission" });
+      res.json({ ok: true });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  // POST /missions/:key/claim : credit the reward once (atomic)
+  router.post("/:key/claim", isAuthenticated, async (req, res) => {
+    try {
+      const r = await missions.claimMission(req.user._id, req.params.key, io);
+      res.status(r.code).json(r.body);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  return router;
+};

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -21,6 +21,7 @@ const TX = {
   MARKET_SALE: "market_sale",
   ITEM_SELL: "item_sell",
   ADMIN_ADJUST: "admin_adjust",
+  MISSION_REWARD: "mission_reward",
 };
 
 function calculateXPForLevel(level) {

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -1,0 +1,187 @@
+const mongoose = require("mongoose");
+const Transaction = require("../models/Transaction");
+const Battle = require("../models/Battle");
+const User = require("../models/User");
+const Case = require("../models/Case");
+const MissionState = require("../models/MissionState");
+const { creditUser, TX } = require("./economy");
+const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
+
+// a "big win" is any single game payout (slots / crash cashout / coin flip win)
+const WIN_TYPES = [TX.SLOT_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+
+// how many case collections the user has fully completed (every catalog item owned)
+async function countCompletedCollections(userId) {
+  const user = await User.findById(userId, { inventory: 1 });
+  if (!user) return 0;
+  const owned = new Set((user.inventory || []).map((e) => String(e._id)));
+  const cases = await Case.find({}, { items: 1 });
+  let done = 0;
+  for (const c of cases) {
+    const items = [...new Set((c.items || []).map(String))];
+    if (items.length && items.every((id) => owned.has(id))) done += 1;
+  }
+  return done;
+}
+
+// ensure the per-user state doc exists, then return it
+async function getState(userId) {
+  await MissionState.updateOne({ userId }, { $setOnInsert: { userId } }, { upsert: true });
+  return MissionState.findOne({ userId });
+}
+
+// gather every signal the catalog needs in one pass. progress is derived, never
+// stored, and only activity at/after the launch timestamp counts.
+async function buildContext(userId) {
+  const launch = missionsLaunchAt();
+  const [txAgg, battlesWon, collectionsCompleted, user, state] = await Promise.all([
+    Transaction.aggregate([
+      { $match: { userId: new mongoose.Types.ObjectId(String(userId)), createdAt: { $gte: launch } } },
+      {
+        $group: {
+          _id: "$type",
+          count: { $sum: 1 },
+          qty: { $sum: { $ifNull: ["$meta.quantity", 0] } },
+          maxAmount: { $max: "$amount" },
+        },
+      },
+    ]),
+    Battle.countDocuments({ winnerUserIds: userId, status: "finished", finishedAt: { $gte: launch } }),
+    countCompletedCollections(userId),
+    User.findById(userId, { profilePicture: 1, friends: 1 }),
+    getState(userId),
+  ]);
+
+  const byType = {};
+  for (const r of txAgg) byType[r._id] = r;
+  const count = (t) => (byType[t] ? byType[t].count : 0);
+  const openRow = byType[TX.CASE_OPEN];
+  const casesOpened = openRow ? openRow.qty || openRow.count : 0; // sum of quantities, count as fallback
+  const bigWin = WIN_TYPES.reduce((m, t) => Math.max(m, byType[t] ? byType[t].maxAmount || 0 : 0), 0);
+
+  return {
+    casesOpened,
+    games: { crash: count(TX.CRASH_BET), coinflip: count(TX.COINFLIP_BET), slots: count(TX.SLOT_BET) },
+    coinflipWins: count(TX.COINFLIP_WIN),
+    bonusesClaimed: count(TX.BONUS),
+    marketSales: count(TX.MARKET_SALE),
+    bigWin,
+    battlesWon,
+    collectionsCompleted,
+    hasProfilePicture: !!(user && user.profilePicture && String(user.profilePicture).trim() !== ""),
+    friendsCount: user && user.friends ? user.friends.length : 0,
+    claimed: new Set((state && state.claimed) || []),
+    visited: new Set((state && state.visited) || []),
+  };
+}
+
+function currentFor(mission, ctx) {
+  switch (mission.metric) {
+    case "casesOpened": return ctx.casesOpened;
+    case "gamesPlayed:crash": return ctx.games.crash;
+    case "gamesPlayed:coinflip": return ctx.games.coinflip;
+    case "gamesPlayed:slots": return ctx.games.slots;
+    case "coinflipWins": return ctx.coinflipWins;
+    case "bonusesClaimed": return ctx.bonusesClaimed;
+    case "marketSales": return ctx.marketSales;
+    case "bigWin": return ctx.bigWin;
+    case "battlesWon": return ctx.battlesWon;
+    case "collectionsCompleted": return ctx.collectionsCompleted;
+    case "profilePictureSet": return ctx.hasProfilePicture ? 1 : 0;
+    case "friendsAdded": return ctx.friendsCount;
+    case "social": return ctx.visited.has(mission.key) ? 1 : 0;
+    default: return 0;
+  }
+}
+
+function view(mission, ctx) {
+  const raw = currentFor(mission, ctx);
+  const complete = raw >= mission.target;
+  const claimed = ctx.claimed.has(mission.key);
+  return {
+    key: mission.key,
+    title: mission.title,
+    description: mission.description,
+    category: mission.category,
+    reward: mission.reward,
+    social: mission.social || null,
+    target: mission.target,
+    current: Math.min(raw, mission.target),
+    complete,
+    claimed,
+    claimable: complete && !claimed,
+  };
+}
+
+async function getMissionsView(userId) {
+  const ctx = await buildContext(userId);
+  const missions = CATALOG.map((m) => view(m, ctx));
+  const totals = {
+    total: missions.length,
+    completed: missions.filter((m) => m.complete).length,
+    claimable: missions.filter((m) => m.claimable).length,
+    claimed: missions.filter((m) => m.claimed).length,
+  };
+  return { missions, totals };
+}
+
+// mark a social mission's link as clicked. honor-system: the server cannot verify
+// the join/follow, which is why these rewards are tiny.
+async function markVisited(userId, key) {
+  const mission = byKey(key);
+  if (!mission || mission.metric !== "social") return { ok: false };
+  await MissionState.updateOne(
+    { userId },
+    { $setOnInsert: { userId }, $addToSet: { visited: key } },
+    { upsert: true }
+  );
+  return { ok: true };
+}
+
+// claim a completed mission's reward exactly once. the one-time guard lives in the
+// update FILTER (claimed !contains key), so two concurrent claims can never both
+// credit: the second finds the key already present and modifies nothing. the wallet
+// is credited only after the claim is marked, so a failure never double-pays.
+async function claimMission(userId, key, io) {
+  const mission = byKey(key);
+  if (!mission) return { code: 404, body: { message: "Mission not found" } };
+
+  const ctx = await buildContext(userId);
+  const v = view(mission, ctx);
+  if (!v.complete) return { code: 400, body: { message: "Mission not complete" } };
+  if (v.claimed) return { code: 200, body: { claimed: false, alreadyClaimed: true } };
+
+  await MissionState.updateOne({ userId }, { $setOnInsert: { userId } }, { upsert: true });
+  const res = await MissionState.updateOne(
+    { userId, claimed: { $ne: key } },
+    { $addToSet: { claimed: key } }
+  );
+  if (res.modifiedCount !== 1) {
+    return { code: 200, body: { claimed: false, alreadyClaimed: true } };
+  }
+
+  const updated = await creditUser(userId, mission.reward, 0, {
+    type: TX.MISSION_REWARD,
+    meta: { missionKey: key, missionTitle: mission.title },
+  });
+
+  if (io && updated) {
+    io.to(userId.toString()).emit("userDataUpdated", {
+      walletBalance: updated.walletBalance,
+      xp: updated.xp,
+      level: updated.level,
+    });
+  }
+
+  return {
+    code: 200,
+    body: {
+      claimed: true,
+      reward: mission.reward,
+      walletBalance: updated ? updated.walletBalance : undefined,
+      missionKey: key,
+    },
+  };
+}
+
+module.exports = { getMissionsView, markVisited, claimMission, buildContext, countCompletedCollections };

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -34,9 +34,9 @@ async function getState(userId) {
 
 // gather every signal the catalog needs in one pass. progress is derived, never
 // stored, and only activity at/after the launch timestamp counts.
-async function buildContext(userId, { includeCollections = true } = {}) {
+async function buildContext(userId, { includeCollections = true, state = null } = {}) {
   const launch = missionsLaunchAt();
-  const [txAgg, battlesWon, collectionsCompleted, user, state] = await Promise.all([
+  const [txAgg, battlesWon, collectionsCompleted, user, st] = await Promise.all([
     Transaction.aggregate([
       { $match: { userId: new mongoose.Types.ObjectId(String(userId)), createdAt: { $gte: launch } } },
       {
@@ -52,7 +52,8 @@ async function buildContext(userId, { includeCollections = true } = {}) {
     // the collections scan is the one heavy read; skip it on frequent hot-path calls
     includeCollections ? countCompletedCollections(userId) : Promise.resolve(0),
     User.findById(userId, { profilePicture: 1, friends: 1 }),
-    getState(userId),
+    // reuse an already-loaded state doc when the caller has one, to avoid re-reading it
+    state || getState(userId),
   ]);
 
   const byType = {};
@@ -73,9 +74,9 @@ async function buildContext(userId, { includeCollections = true } = {}) {
     collectionsCompleted,
     hasProfilePicture: !!(user && user.profilePicture && String(user.profilePicture).trim() !== ""),
     friendsCount: user && user.friends ? user.friends.length : 0,
-    claimed: new Set((state && state.claimed) || []),
-    visited: new Set((state && state.visited) || []),
-    announced: new Set((state && state.announced) || []),
+    claimed: new Set((st && st.claimed) || []),
+    visited: new Set((st && st.visited) || []),
+    announced: new Set((st && st.announced) || []),
   };
 }
 
@@ -137,7 +138,8 @@ async function getMissionsView(userId) {
 async function getPendingAnnouncements(userId, { light = false } = {}) {
   const state = await getState(userId);
   if (!state.seeded) {
-    const fullCtx = await buildContext(userId, { includeCollections: true });
+    // seed is always full so nothing pre-existing (incl. collections) ever toasts
+    const fullCtx = await buildContext(userId, { includeCollections: true, state });
     const keys = CATALOG.filter((m) => {
       const v = view(m, fullCtx);
       return v.complete && !v.claimed;
@@ -148,7 +150,7 @@ async function getPendingAnnouncements(userId, { light = false } = {}) {
     return [];
   }
 
-  const ctx = await buildContext(userId, { includeCollections: !light });
+  const ctx = await buildContext(userId, { includeCollections: !light, state });
   const pending = [];
   for (const m of CATALOG) {
     const v = view(m, ctx);

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -14,21 +14,31 @@ const WIN_TYPES = [TX.SLOT_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 // never shown, announced, or claimable
 const ACTIVE = CATALOG.filter((m) => m.active !== false);
 
-// how many case collections the user has fully completed (every catalog item owned).
+// case collections the user has fully completed vs how many cases have items.
 // populate + drop null (deleted) refs so "complete" matches exactly what the
 // collections tab shows: a dangling item id is not a slot the album counts either.
-async function countCompletedCollections(userId) {
+async function collectionsProgress(userId) {
   const user = await User.findById(userId, { inventory: 1 });
-  if (!user) return 0;
+  if (!user) return { done: 0, total: 0 };
   const owned = new Set((user.inventory || []).map((e) => String(e._id)));
   const cases = await Case.find({}, { items: 1 }).populate("items", "_id");
   let done = 0;
+  let total = 0;
   for (const c of cases) {
     const items = [...new Set((c.items || []).filter(Boolean).map((it) => String(it._id)))];
-    if (items.length && items.every((id) => owned.has(id))) done += 1;
+    if (!items.length) continue;
+    total += 1;
+    if (items.every((id) => owned.has(id))) done += 1;
   }
-  return done;
+  return { done, total };
 }
+
+async function countCompletedCollections(userId) {
+  return (await collectionsProgress(userId)).done;
+}
+
+// the stakes the "total wagered" mission counts: every KP put at risk on a game
+const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 // ensure the per-user state doc exists, then return it
 async function getState(userId) {
@@ -49,13 +59,14 @@ async function buildContext(userId, { includeCollections = true, state = null } 
           count: { $sum: 1 },
           qty: { $sum: { $ifNull: ["$meta.quantity", 0] } },
           maxAmount: { $max: "$amount" },
+          sumAmount: { $sum: "$amount" },
         },
       },
     ]),
     Battle.countDocuments({ winnerUserIds: userId, status: "finished", finishedAt: { $gte: launch } }),
     // the collections scan is the one heavy read; skip it on frequent hot-path calls
-    includeCollections ? countCompletedCollections(userId) : Promise.resolve(0),
-    User.findById(userId, { profilePicture: 1, friends: 1 }),
+    includeCollections ? collectionsProgress(userId) : Promise.resolve({ done: 0, total: 0 }),
+    User.findById(userId, { profilePicture: 1, friends: 1, level: 1, walletBalance: 1 }),
     // reuse an already-loaded state doc when the caller has one, to avoid re-reading it
     state || getState(userId),
   ]);
@@ -63,19 +74,26 @@ async function buildContext(userId, { includeCollections = true, state = null } 
   const byType = {};
   for (const r of txAgg) byType[r._id] = r;
   const count = (t) => (byType[t] ? byType[t].count : 0);
+  const sum = (t) => (byType[t] ? byType[t].sumAmount || 0 : 0);
   const openRow = byType[TX.CASE_OPEN];
   const casesOpened = openRow ? openRow.qty || openRow.count : 0; // sum of quantities, count as fallback
   const bigWin = WIN_TYPES.reduce((m, t) => Math.max(m, byType[t] ? byType[t].maxAmount || 0 : 0), 0);
+  const totalWagered = STAKE_TYPES.reduce((s, t) => s + sum(t), 0);
 
   return {
     casesOpened,
     games: { crash: count(TX.CRASH_BET), coinflip: count(TX.COINFLIP_BET), slots: count(TX.SLOT_BET) },
     coinflipWins: count(TX.COINFLIP_WIN),
+    crashCashouts: count(TX.CRASH_CASHOUT),
     bonusesClaimed: count(TX.BONUS),
     marketSales: count(TX.MARKET_SALE),
     bigWin,
+    totalWagered,
     battlesWon,
-    collectionsCompleted,
+    collectionsCompleted: collectionsCompleted.done,
+    collectionsTotal: collectionsCompleted.total,
+    level: user ? user.level || 0 : 0,
+    walletBalance: user ? user.walletBalance || 0 : 0,
     hasProfilePicture: !!(user && user.profilePicture && String(user.profilePicture).trim() !== ""),
     friendsCount: user && user.friends ? user.friends.length : 0,
     claimed: new Set((st && st.claimed) || []),
@@ -96,6 +114,12 @@ function currentFor(mission, ctx) {
     case "bigWin": return ctx.bigWin;
     case "battlesWon": return ctx.battlesWon;
     case "collectionsCompleted": return ctx.collectionsCompleted;
+    case "allCollectionsComplete":
+      return ctx.collectionsTotal > 0 && ctx.collectionsCompleted >= ctx.collectionsTotal ? 1 : 0;
+    case "crashCashouts": return ctx.crashCashouts;
+    case "totalWagered": return ctx.totalWagered;
+    case "level": return ctx.level;
+    case "walletBalance": return ctx.walletBalance;
     case "profilePictureSet": return ctx.hasProfilePicture ? 1 : 0;
     case "friendsAdded": return ctx.friendsCount;
     case "social": return ctx.visited.has(mission.key) ? 1 : 0;

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -10,15 +10,17 @@ const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 // a "big win" is any single game payout (slots / crash cashout / coin flip win)
 const WIN_TYPES = [TX.SLOT_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 
-// how many case collections the user has fully completed (every catalog item owned)
+// how many case collections the user has fully completed (every catalog item owned).
+// populate + drop null (deleted) refs so "complete" matches exactly what the
+// collections tab shows: a dangling item id is not a slot the album counts either.
 async function countCompletedCollections(userId) {
   const user = await User.findById(userId, { inventory: 1 });
   if (!user) return 0;
   const owned = new Set((user.inventory || []).map((e) => String(e._id)));
-  const cases = await Case.find({}, { items: 1 });
+  const cases = await Case.find({}, { items: 1 }).populate("items", "_id");
   let done = 0;
   for (const c of cases) {
-    const items = [...new Set((c.items || []).map(String))];
+    const items = [...new Set((c.items || []).filter(Boolean).map((it) => String(it._id)))];
     if (items.length && items.every((id) => owned.has(id))) done += 1;
   }
   return done;

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -10,6 +10,10 @@ const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 // a "big win" is any single game payout (slots / crash cashout / coin flip win)
 const WIN_TYPES = [TX.SLOT_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 
+// missions currently offered; a disabled one (active:false) stays defined but is
+// never shown, announced, or claimable
+const ACTIVE = CATALOG.filter((m) => m.active !== false);
+
 // how many case collections the user has fully completed (every catalog item owned).
 // populate + drop null (deleted) refs so "complete" matches exactly what the
 // collections tab shows: a dangling item id is not a slot the album counts either.
@@ -120,7 +124,7 @@ function view(mission, ctx) {
 
 async function getMissionsView(userId) {
   const ctx = await buildContext(userId);
-  const missions = CATALOG.map((m) => view(m, ctx));
+  const missions = ACTIVE.map((m) => view(m, ctx));
   const totals = {
     total: missions.length,
     completed: missions.filter((m) => m.complete).length,
@@ -140,7 +144,7 @@ async function getPendingAnnouncements(userId, { light = false } = {}) {
   if (!state.seeded) {
     // seed is always full so nothing pre-existing (incl. collections) ever toasts
     const fullCtx = await buildContext(userId, { includeCollections: true, state });
-    const keys = CATALOG.filter((m) => {
+    const keys = ACTIVE.filter((m) => {
       const v = view(m, fullCtx);
       return v.complete && !v.claimed;
     }).map((m) => m.key);
@@ -152,7 +156,7 @@ async function getPendingAnnouncements(userId, { light = false } = {}) {
 
   const ctx = await buildContext(userId, { includeCollections: !light, state });
   const pending = [];
-  for (const m of CATALOG) {
+  for (const m of ACTIVE) {
     const v = view(m, ctx);
     if (!v.complete || v.claimed || ctx.announced.has(m.key)) continue;
     const res = await MissionState.updateOne(
@@ -183,7 +187,7 @@ async function markVisited(userId, key) {
 // is credited only after the claim is marked, so a failure never double-pays.
 async function claimMission(userId, key, io) {
   const mission = byKey(key);
-  if (!mission) return { code: 404, body: { message: "Mission not found" } };
+  if (!mission || mission.active === false) return { code: 404, body: { message: "Mission not found" } };
 
   const ctx = await buildContext(userId);
   const v = view(mission, ctx);

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -34,7 +34,7 @@ async function getState(userId) {
 
 // gather every signal the catalog needs in one pass. progress is derived, never
 // stored, and only activity at/after the launch timestamp counts.
-async function buildContext(userId) {
+async function buildContext(userId, { includeCollections = true } = {}) {
   const launch = missionsLaunchAt();
   const [txAgg, battlesWon, collectionsCompleted, user, state] = await Promise.all([
     Transaction.aggregate([
@@ -49,7 +49,8 @@ async function buildContext(userId) {
       },
     ]),
     Battle.countDocuments({ winnerUserIds: userId, status: "finished", finishedAt: { $gte: launch } }),
-    countCompletedCollections(userId),
+    // the collections scan is the one heavy read; skip it on frequent hot-path calls
+    includeCollections ? countCompletedCollections(userId) : Promise.resolve(0),
     User.findById(userId, { profilePicture: 1, friends: 1 }),
     getState(userId),
   ]);
@@ -74,6 +75,7 @@ async function buildContext(userId) {
     friendsCount: user && user.friends ? user.friends.length : 0,
     claimed: new Set((state && state.claimed) || []),
     visited: new Set((state && state.visited) || []),
+    announced: new Set((state && state.announced) || []),
   };
 }
 
@@ -125,6 +127,39 @@ async function getMissionsView(userId) {
     claimed: missions.filter((m) => m.claimed).length,
   };
   return { missions, totals };
+}
+
+// missions that just became claimable and have not been announced yet, for the
+// real-time "mission complete" toast. exactly-once: each key is announced via an
+// atomic per-key guard, so concurrent /pending calls never double-toast. the first
+// call ever for a user SEEDS silently (records current completions without returning
+// them), so completions from before real-time tracking do not stack a burst.
+async function getPendingAnnouncements(userId, { light = false } = {}) {
+  const state = await getState(userId);
+  if (!state.seeded) {
+    const fullCtx = await buildContext(userId, { includeCollections: true });
+    const keys = CATALOG.filter((m) => {
+      const v = view(m, fullCtx);
+      return v.complete && !v.claimed;
+    }).map((m) => m.key);
+    const update = { $set: { seeded: true } };
+    if (keys.length) update.$addToSet = { announced: { $each: keys } };
+    await MissionState.updateOne({ userId }, update);
+    return [];
+  }
+
+  const ctx = await buildContext(userId, { includeCollections: !light });
+  const pending = [];
+  for (const m of CATALOG) {
+    const v = view(m, ctx);
+    if (!v.complete || v.claimed || ctx.announced.has(m.key)) continue;
+    const res = await MissionState.updateOne(
+      { userId, announced: { $ne: m.key } },
+      { $addToSet: { announced: m.key } }
+    );
+    if (res.modifiedCount === 1) pending.push({ key: m.key, title: m.title, reward: m.reward });
+  }
+  return pending;
 }
 
 // mark a social mission's link as clicked. honor-system: the server cannot verify
@@ -186,4 +221,11 @@ async function claimMission(userId, key, io) {
   };
 }
 
-module.exports = { getMissionsView, markVisited, claimMission, buildContext, countCompletedCollections };
+module.exports = {
+  getMissionsView,
+  getPendingAnnouncements,
+  markVisited,
+  claimMission,
+  buildContext,
+  countCompletedCollections,
+};

--- a/backend/utils/missionsCatalog.js
+++ b/backend/utils/missionsCatalog.js
@@ -35,6 +35,20 @@ const CATALOG = [
   { key: "add-friend", category: "community", title: "Not alone", description: "Add your first friend.", metric: "friendsAdded", target: 1, reward: 300 },
   { key: "join-discord", category: "community", title: "Join the Discord", description: "Hop into the KaniCasino Discord.", metric: "social", social: "discord", target: 1, reward: 150 },
   { key: "follow-x", category: "community", title: "Follow on X", description: "Follow KaniCasino on X.", metric: "social", social: "x", target: 1, reward: 150 },
+
+  // endgame: long-horizon goals across every system. grind-based ones count only
+  // activity since launch; the state-based ones (level, balance, all collections)
+  // are one-time achievements a top player may already qualify for.
+  { key: "market-10", category: "endgame", title: "Marketeer", description: "Sell 10 items on the marketplace.", metric: "marketSales", target: 10, reward: 5000 },
+  { key: "coinflip-25", category: "endgame", title: "Hot streak", description: "Win 25 coin flips.", metric: "coinflipWins", target: 25, reward: 6000 },
+  { key: "crash-50", category: "endgame", title: "Nerves of titanium", description: "Cash out of Crash 50 times.", metric: "crashCashouts", target: 50, reward: 6000 },
+  { key: "battles-10", category: "endgame", title: "Battle-hardened", description: "Win 10 case battles.", metric: "battlesWon", target: 10, reward: 8000 },
+  { key: "jackpot", category: "endgame", title: "Jackpot", description: "Land a 100,000 K₽ payout in a single play.", metric: "bigWin", target: 100000, reward: 15000 },
+  { key: "cases-1000", category: "endgame", title: "Case fiend", description: "Open 1,000 cases.", metric: "casesOpened", target: 1000, reward: 25000 },
+  { key: "wager-million", category: "endgame", title: "High roller", description: "Stake a total of 1,000,000 K₽ across all games.", metric: "totalWagered", target: 1000000, reward: 20000 },
+  { key: "level-30", category: "endgame", title: "Ascended", description: "Reach level 30.", metric: "level", target: 30, reward: 15000 },
+  { key: "collections-all", category: "endgame", title: "Master collector", description: "Complete every collection.", metric: "allCollectionsComplete", target: 1, reward: 50000 },
+  { key: "millionaire", category: "endgame", title: "Millionaire", description: "Hold a balance of 1,000,000 K₽.", metric: "walletBalance", target: 1000000, reward: 30000 },
 ];
 
 const BY_KEY = new Map(CATALOG.map((m) => [m.key, m]));

--- a/backend/utils/missionsCatalog.js
+++ b/backend/utils/missionsCatalog.js
@@ -14,7 +14,8 @@ const CATALOG = [
   // onboarding
   { key: "first-bonus", category: "onboarding", title: "Free money", description: "Claim your bonus for the first time.", metric: "bonusesClaimed", target: 1, reward: 250 },
   { key: "first-case", category: "onboarding", title: "Crack one open", description: "Open your very first case.", metric: "casesOpened", target: 1, reward: 250 },
-  { key: "set-avatar", category: "onboarding", title: "Show your face", description: "Set a profile picture.", metric: "profilePictureSet", target: 1, reward: 250 },
+  // disabled until there is a UI to set a profile picture (active:false hides it everywhere)
+  { key: "set-avatar", category: "onboarding", title: "Show your face", description: "Set a profile picture.", metric: "profilePictureSet", target: 1, reward: 250, active: false },
   { key: "first-sale", category: "onboarding", title: "Open for business", description: "Sell an item on the marketplace.", metric: "marketSales", target: 1, reward: 300 },
 
   // games

--- a/backend/utils/missionsCatalog.js
+++ b/backend/utils/missionsCatalog.js
@@ -1,0 +1,42 @@
+// the mission catalog. definitions live here as data; the per-metric evaluation
+// lives in missions.js keyed by `metric`. rewards are KP credited on manual claim.
+// counters are derived from activity AT OR AFTER the launch timestamp, so shipping
+// this never retroactively pays out a veteran's pre-launch history.
+
+// read at call time (not module load) so tests and deploys can override the env
+function missionsLaunchAt() {
+  return process.env.MISSIONS_LAUNCH_AT
+    ? new Date(process.env.MISSIONS_LAUNCH_AT)
+    : new Date("2026-07-15T00:00:00.000Z");
+}
+
+const CATALOG = [
+  // onboarding
+  { key: "first-bonus", category: "onboarding", title: "Free money", description: "Claim your bonus for the first time.", metric: "bonusesClaimed", target: 1, reward: 250 },
+  { key: "first-case", category: "onboarding", title: "Crack one open", description: "Open your very first case.", metric: "casesOpened", target: 1, reward: 250 },
+  { key: "set-avatar", category: "onboarding", title: "Show your face", description: "Set a profile picture.", metric: "profilePictureSet", target: 1, reward: 250 },
+  { key: "first-sale", category: "onboarding", title: "Open for business", description: "Sell an item on the marketplace.", metric: "marketSales", target: 1, reward: 300 },
+
+  // games
+  { key: "try-crash", category: "games", title: "Nerves of steel", description: "Place a bet on Crash.", metric: "gamesPlayed:crash", target: 1, reward: 200 },
+  { key: "try-coinflip", category: "games", title: "Heads or tails", description: "Place a bet on Coin Flip.", metric: "gamesPlayed:coinflip", target: 1, reward: 200 },
+  { key: "try-slots", category: "games", title: "One more spin", description: "Spin the slot machine.", metric: "gamesPlayed:slots", target: 1, reward: 200 },
+  { key: "coinflip-win", category: "games", title: "Called it", description: "Win a round of Coin Flip.", metric: "coinflipWins", target: 1, reward: 500 },
+  { key: "battle-win", category: "games", title: "Last one standing", description: "Win a case battle.", metric: "battlesWon", target: 1, reward: 1000 },
+  { key: "cases-10", category: "games", title: "Case cracker", description: "Open 10 cases.", metric: "casesOpened", target: 10, reward: 1500 },
+  { key: "cases-100", category: "games", title: "Case connoisseur", description: "Open 100 cases.", metric: "casesOpened", target: 100, reward: 6000 },
+  { key: "big-win", category: "games", title: "Big score", description: "Land a 10,000 K₽ payout in a single play.", metric: "bigWin", target: 10000, reward: 2500 },
+
+  // collection
+  { key: "complete-collection", category: "collection", title: "Completionist", description: "Complete any case collection.", metric: "collectionsCompleted", target: 1, reward: 5000 },
+
+  // community
+  { key: "add-friend", category: "community", title: "Not alone", description: "Add your first friend.", metric: "friendsAdded", target: 1, reward: 300 },
+  { key: "join-discord", category: "community", title: "Join the Discord", description: "Hop into the KaniCasino Discord.", metric: "social", social: "discord", target: 1, reward: 150 },
+  { key: "follow-x", category: "community", title: "Follow on X", description: "Follow KaniCasino on X.", metric: "social", social: "x", target: 1, reward: 150 },
+];
+
+const BY_KEY = new Map(CATALOG.map((m) => [m.key, m]));
+const byKey = (key) => BY_KEY.get(key) || null;
+
+module.exports = { CATALOG, byKey, missionsLaunchAt };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter as Router } from "react-router-dom";
-import { Suspense, lazy, useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import UserContext from "./UserContext";
 import { SkeletonTheme } from "react-loading-skeleton";
 import "react-tooltip/dist/react-tooltip.css";
@@ -12,6 +12,8 @@ import ScrollToTop from "./components/ScrollToTop";
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import Footer from "./components/Footer";
 import {disableReactDevTools} from '@fvilers/disable-react-devtools';
+import { getPendingMissions } from "./services/missions/MissionService";
+import { toastMissionComplete } from "./pages/Missions/components/missionCompleteToast";
 
 const Header = lazy(() => import("./components/header/index"));
 const AppRoutes = lazy(() => import("./Routes"));
@@ -35,10 +37,32 @@ function App() {
   const [notification, setNotification] = useState<any>();
 
   const socket = SocketConnection.getInstance();
+  const missionCheck = useRef<{ inFlight: boolean; last: number }>({ inFlight: false, last: 0 });
 
   if(environment == "production"){
     disableReactDevTools();
   }
+
+  // ask the server for missions that just became claimable and toast them once.
+  // best-effort: throttled on the frequent light path, never blocks anything.
+  const checkMissions = (light: boolean) => {
+    if (!localStorage.getItem("accessToken")) return;
+    const c = missionCheck.current;
+    if (c.inFlight) return;
+    if (light && Date.now() - c.last < 1500) return;
+    c.inFlight = true;
+    getPendingMissions(light)
+      .then((pending) => {
+        pending.forEach(toastMissionComplete);
+        c.last = Date.now();
+      })
+      .catch(() => {
+        // best-effort: never let a mission check surface an error
+      })
+      .finally(() => {
+        c.inFlight = false;
+      });
+  };
 
   const userDataSocket = () => {
     socket.on("userDataUpdated", (payload: userDataSocketProps) => {
@@ -48,6 +72,8 @@ function App() {
         xp: payload.xp,
         level: payload.level
       } : null);
+      // a balance change usually means an action just resolved: check for completions
+      checkMissions(true);
     });
 
     return () => {
@@ -83,6 +109,9 @@ function App() {
       socket.disconnect();
       socket.connect();
       setJoinedRoom(true);
+      // full catch-up check on login: seeds silently the first time, then toasts
+      // anything completed while away
+      checkMissions(false);
     }
   }, [joinedRoom, socket, userData]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Footer from "./components/Footer";
 import {disableReactDevTools} from '@fvilers/disable-react-devtools';
 import { getPendingMissions } from "./services/missions/MissionService";
 import { toastMissionComplete } from "./pages/Missions/components/missionCompleteToast";
+import NavigationBridge from "./components/NavigationBridge";
 
 const Header = lazy(() => import("./components/header/index"));
 const AppRoutes = lazy(() => import("./Routes"));
@@ -38,6 +39,7 @@ function App() {
 
   const socket = SocketConnection.getInstance();
   const missionCheck = useRef<{ inFlight: boolean; last: number }>({ inFlight: false, last: 0 });
+  const userIdRef = useRef<string | null>(null);
 
   if(environment == "production"){
     disableReactDevTools();
@@ -51,9 +53,10 @@ function App() {
     if (c.inFlight) return;
     if (light && Date.now() - c.last < 1500) return;
     c.inFlight = true;
+    const missionsPath = userIdRef.current ? `/profile/${userIdRef.current}?tab=missions` : undefined;
     getPendingMissions(light)
       .then((pending) => {
-        pending.forEach(toastMissionComplete);
+        pending.forEach((m) => toastMissionComplete(m, missionsPath));
         c.last = Date.now();
       })
       .catch(() => {
@@ -104,6 +107,7 @@ function App() {
 
   useEffect(() => {
     if (userData && userData.id && !joinedRoom) {
+      userIdRef.current = userData.id;
       // reconnect so the handshake re-runs with the now-available token; the
       // server authenticates it and joins this user's private room
       socket.disconnect();
@@ -188,6 +192,7 @@ function App() {
             <Router>
               <SkeletonTheme highlightColor="#161427" baseColor="#1c1a31">
                 <ScrollToTop />
+                <NavigationBridge />
                 <ToastContainer
                   position="top-right"
                   autoClose={4000}

--- a/src/components/NavigationBridge.tsx
+++ b/src/components/NavigationBridge.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { setNavigator } from "../services/navigation";
+
+// registers react-router's navigate with the navigation bridge so out-of-tree code
+// (toasts fired from App) can navigate client-side. Renders nothing.
+const NavigationBridge = () => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    setNavigator(navigate);
+    return () => setNavigator(null);
+  }, [navigate]);
+  return null;
+};
+
+export default NavigationBridge;

--- a/src/pages/Missions/Missions.services.ts
+++ b/src/pages/Missions/Missions.services.ts
@@ -7,11 +7,12 @@ import {
   MissionsData,
 } from "../../services/missions/MissionService";
 
-// remembers which claimable missions have already been announced, so the
-// "mission complete" toast fires once per mission and not on every refetch
-const SEEN_KEY = "kani.seenClaimable";
+// remembers which claimable missions have already been announced (per user, so a
+// shared browser doesn't suppress another account's toasts), so the "mission
+// complete" toast fires once per mission and not on every refetch
+const seenKeyFor = (userId: string) => `kani.seenClaimable.${userId}`;
 
-export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
+export const useMissionsServices = ({ isOwner, userId }: { isOwner: boolean; userId: string }) => {
   const [data, setData] = useState<MissionsData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
@@ -21,8 +22,10 @@ export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
     try {
       const res = await getMissions();
       setData(res);
+      setError(false);
     } catch {
-      setError(true);
+      // a refetch failure must not blank an already-loaded panel; the triggering
+      // action reports its own success/failure via a toast
     }
   }, []);
 
@@ -50,19 +53,31 @@ export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
   }, [isOwner]);
 
   useEffect(() => {
-    if (!data) return;
+    if (!data || !userId) return;
+    const seenKey = seenKeyFor(userId);
+    const claimableKeys = data.missions.filter((m) => m.claimable).map((m) => m.key);
+    const raw = localStorage.getItem(seenKey);
+    // first ever view for this user: seed silently so pre-existing completions do
+    // not stack a burst of toasts. only genuinely-new completions toast afterwards.
+    if (raw === null) {
+      localStorage.setItem(seenKey, JSON.stringify(claimableKeys));
+      return;
+    }
     let seen: string[] = [];
     try {
-      seen = JSON.parse(localStorage.getItem(SEEN_KEY) || "[]");
+      seen = JSON.parse(raw);
     } catch {
       seen = [];
     }
-    const fresh = data.missions.filter((m) => m.claimable && !seen.includes(m.key));
+    const fresh = claimableKeys.filter((k) => !seen.includes(k));
     if (fresh.length) {
-      fresh.forEach((m) => toast.info(`Mission complete: ${m.title}`));
-      localStorage.setItem(SEEN_KEY, JSON.stringify([...seen, ...fresh.map((m) => m.key)]));
+      fresh.forEach((k) => {
+        const m = data.missions.find((x) => x.key === k);
+        if (m) toast.info(`Mission complete: ${m.title}`);
+      });
+      localStorage.setItem(seenKey, JSON.stringify([...new Set([...seen, ...claimableKeys])]));
     }
-  }, [data]);
+  }, [data, userId]);
 
   const claim = async (key: string) => {
     setClaimingKey(key);

--- a/src/pages/Missions/Missions.services.ts
+++ b/src/pages/Missions/Missions.services.ts
@@ -50,7 +50,7 @@ export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
     // checks skip (collections, and social/state missions); the server announces each once
     getPendingMissions(false)
       .then((pending) => {
-        if (active) pending.forEach(toastMissionComplete);
+        if (active) pending.forEach((m) => toastMissionComplete(m));
       })
       .catch(() => {
         // best-effort: a failed pending check just means no toast this time

--- a/src/pages/Missions/Missions.services.ts
+++ b/src/pages/Missions/Missions.services.ts
@@ -7,6 +7,7 @@ import {
   visitMission,
   MissionsData,
 } from "../../services/missions/MissionService";
+import { getCases } from "../../services/cases/CaseServices";
 import { toastMissionComplete } from "./components/missionCompleteToast";
 
 export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
@@ -14,6 +15,7 @@ export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
   const [claimingKey, setClaimingKey] = useState<string | null>(null);
+  const [caseImage, setCaseImage] = useState<string | undefined>(undefined);
 
   const load = useCallback(async () => {
     try {
@@ -53,6 +55,15 @@ export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
       .catch(() => {
         // best-effort: a failed pending check just means no toast this time
       });
+    // a real case image for the case/collection missions; icon fallback if it fails
+    getCases()
+      .then((cases) => {
+        const img = Array.isArray(cases) ? cases.find((c) => c && c.image)?.image : undefined;
+        if (active && img) setCaseImage(img);
+      })
+      .catch(() => {
+        // fall back to the chest icon
+      });
     return () => {
       active = false;
     };
@@ -82,5 +93,5 @@ export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
     await load();
   };
 
-  return { data, loading, error, claimingKey, claim, visit, isOwner };
+  return { data, loading, error, claimingKey, claim, visit, isOwner, caseImage };
 };

--- a/src/pages/Missions/Missions.services.ts
+++ b/src/pages/Missions/Missions.services.ts
@@ -2,17 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import {
   getMissions,
+  getPendingMissions,
   claimMission,
   visitMission,
   MissionsData,
 } from "../../services/missions/MissionService";
+import { toastMissionComplete } from "./components/missionCompleteToast";
 
-// remembers which claimable missions have already been announced (per user, so a
-// shared browser doesn't suppress another account's toasts), so the "mission
-// complete" toast fires once per mission and not on every refetch
-const seenKeyFor = (userId: string) => `kani.seenClaimable.${userId}`;
-
-export const useMissionsServices = ({ isOwner, userId }: { isOwner: boolean; userId: string }) => {
+export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
   const [data, setData] = useState<MissionsData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
@@ -47,37 +44,19 @@ export const useMissionsServices = ({ isOwner, userId }: { isOwner: boolean; use
       .finally(() => {
         if (active) setLoading(false);
       });
+    // a full pending check on tab open catches completions the frequent balance-change
+    // checks skip (collections, and social/state missions); the server announces each once
+    getPendingMissions(false)
+      .then((pending) => {
+        if (active) pending.forEach(toastMissionComplete);
+      })
+      .catch(() => {
+        // best-effort: a failed pending check just means no toast this time
+      });
     return () => {
       active = false;
     };
   }, [isOwner]);
-
-  useEffect(() => {
-    if (!data || !userId) return;
-    const seenKey = seenKeyFor(userId);
-    const claimableKeys = data.missions.filter((m) => m.claimable).map((m) => m.key);
-    const raw = localStorage.getItem(seenKey);
-    // first ever view for this user: seed silently so pre-existing completions do
-    // not stack a burst of toasts. only genuinely-new completions toast afterwards.
-    if (raw === null) {
-      localStorage.setItem(seenKey, JSON.stringify(claimableKeys));
-      return;
-    }
-    let seen: string[] = [];
-    try {
-      seen = JSON.parse(raw);
-    } catch {
-      seen = [];
-    }
-    const fresh = claimableKeys.filter((k) => !seen.includes(k));
-    if (fresh.length) {
-      fresh.forEach((k) => {
-        const m = data.missions.find((x) => x.key === k);
-        if (m) toast.info(`Mission complete: ${m.title}`);
-      });
-      localStorage.setItem(seenKey, JSON.stringify([...new Set([...seen, ...claimableKeys])]));
-    }
-  }, [data, userId]);
 
   const claim = async (key: string) => {
     setClaimingKey(key);

--- a/src/pages/Missions/Missions.services.ts
+++ b/src/pages/Missions/Missions.services.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  getMissions,
+  claimMission,
+  visitMission,
+  MissionsData,
+} from "../../services/missions/MissionService";
+
+// remembers which claimable missions have already been announced, so the
+// "mission complete" toast fires once per mission and not on every refetch
+const SEEN_KEY = "kani.seenClaimable";
+
+export const useMissionsServices = ({ isOwner }: { isOwner: boolean }) => {
+  const [data, setData] = useState<MissionsData | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+  const [claimingKey, setClaimingKey] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await getMissions();
+      setData(res);
+    } catch {
+      setError(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOwner) {
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    setError(false);
+    getMissions()
+      .then((res) => {
+        if (active) setData(res);
+      })
+      .catch(() => {
+        if (active) setError(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isOwner]);
+
+  useEffect(() => {
+    if (!data) return;
+    let seen: string[] = [];
+    try {
+      seen = JSON.parse(localStorage.getItem(SEEN_KEY) || "[]");
+    } catch {
+      seen = [];
+    }
+    const fresh = data.missions.filter((m) => m.claimable && !seen.includes(m.key));
+    if (fresh.length) {
+      fresh.forEach((m) => toast.info(`Mission complete: ${m.title}`));
+      localStorage.setItem(SEEN_KEY, JSON.stringify([...seen, ...fresh.map((m) => m.key)]));
+    }
+  }, [data]);
+
+  const claim = async (key: string) => {
+    setClaimingKey(key);
+    try {
+      const res = await claimMission(key);
+      if (res.claimed) toast.success(`Reward claimed: +${res.reward} K₽`);
+      else if (res.alreadyClaimed) toast.info("Already claimed");
+      await load();
+    } catch {
+      toast.error("Could not claim reward");
+    } finally {
+      setClaimingKey(null);
+    }
+  };
+
+  const visit = async (key: string, url: string) => {
+    window.open(url, "_blank", "noopener,noreferrer");
+    try {
+      await visitMission(key);
+    } catch {
+      // honor-system: marking the visit is best-effort
+    }
+    await load();
+  };
+
+  return { data, loading, error, claimingKey, claim, visit, isOwner };
+};

--- a/src/pages/Missions/Missions.view.tsx
+++ b/src/pages/Missions/Missions.view.tsx
@@ -10,6 +10,7 @@ interface Props {
   claim: (key: string) => void;
   visit: (key: string, url: string) => void;
   isOwner: boolean;
+  caseImage?: string;
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -28,6 +29,7 @@ const MissionsView: React.FC<Props> = ({
   claim,
   visit,
   isOwner,
+  caseImage,
 }) => {
   if (!isOwner) {
     return <p className="text-ink-muted py-8 text-center">Missions are private.</p>;
@@ -81,6 +83,7 @@ const MissionsView: React.FC<Props> = ({
                 claiming={claimingKey === m.key}
                 claim={claim}
                 visit={visit}
+                caseImage={caseImage}
               />
             ))}
           </div>

--- a/src/pages/Missions/Missions.view.tsx
+++ b/src/pages/Missions/Missions.view.tsx
@@ -1,0 +1,93 @@
+import Skeleton from "react-loading-skeleton";
+import MissionCard from "./components/MissionCard";
+import { MissionsData } from "../../services/missions/MissionService";
+
+interface Props {
+  data: MissionsData | null;
+  loading: boolean;
+  error: boolean;
+  claimingKey: string | null;
+  claim: (key: string) => void;
+  visit: (key: string, url: string) => void;
+  isOwner: boolean;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  onboarding: "Getting started",
+  games: "Games",
+  collection: "Collection",
+  community: "Community",
+};
+const CATEGORY_ORDER = ["onboarding", "games", "collection", "community"];
+
+const MissionsView: React.FC<Props> = ({
+  data,
+  loading,
+  error,
+  claimingKey,
+  claim,
+  visit,
+  isOwner,
+}) => {
+  if (!isOwner) {
+    return <p className="text-ink-muted py-8 text-center">Missions are private.</p>;
+  }
+  if (loading) {
+    return (
+      <div className="w-full max-w-[900px] flex flex-col gap-3">
+        {Array(6)
+          .fill(0)
+          .map((_, i) => (
+            <Skeleton key={i} height={92} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />
+          ))}
+      </div>
+    );
+  }
+  if (error || !data) {
+    return <p className="text-ink-muted py-8 text-center">Could not load missions.</p>;
+  }
+
+  const grouped = CATEGORY_ORDER.map((cat) => ({
+    cat,
+    items: data.missions.filter((m) => m.category === cat),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <div className="w-full max-w-[900px] flex flex-col gap-8">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="flex flex-col">
+          <h2 className="text-xl font-semibold text-ink">Missions</h2>
+          <span className="text-sm text-ink-muted">
+            {data.totals.claimed}/{data.totals.total} completed
+          </span>
+        </div>
+        {data.totals.claimable > 0 && (
+          <span className="px-3 py-1.5 rounded-lg bg-accent-gold/15 text-accent-gold text-sm font-semibold">
+            {data.totals.claimable} ready to claim
+          </span>
+        )}
+      </div>
+
+      {grouped.map(({ cat, items }) => (
+        <div key={cat} className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-ink-muted">
+            {CATEGORY_LABELS[cat] || cat}
+          </h3>
+          <div className="flex flex-col gap-3">
+            {items.map((m) => (
+              <MissionCard
+                key={m.key}
+                mission={m}
+                claiming={claimingKey === m.key}
+                claim={claim}
+                visit={visit}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MissionsView;

--- a/src/pages/Missions/Missions.view.tsx
+++ b/src/pages/Missions/Missions.view.tsx
@@ -18,7 +18,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   games: "Games",
   collection: "Collection",
   community: "Community",
-  endgame: "Endgame",
+  endgame: "All In",
 };
 const CATEGORY_ORDER = ["onboarding", "games", "collection", "community", "endgame"];
 

--- a/src/pages/Missions/Missions.view.tsx
+++ b/src/pages/Missions/Missions.view.tsx
@@ -18,8 +18,9 @@ const CATEGORY_LABELS: Record<string, string> = {
   games: "Games",
   collection: "Collection",
   community: "Community",
+  endgame: "Endgame",
 };
-const CATEGORY_ORDER = ["onboarding", "games", "collection", "community"];
+const CATEGORY_ORDER = ["onboarding", "games", "collection", "community", "endgame"];
 
 const MissionsView: React.FC<Props> = ({
   data,
@@ -36,7 +37,7 @@ const MissionsView: React.FC<Props> = ({
   }
   if (loading) {
     return (
-      <div className="w-full max-w-[900px] flex flex-col gap-3">
+      <div className="w-full max-w-[1100px] grid grid-cols-1 lg:grid-cols-2 gap-3">
         {Array(6)
           .fill(0)
           .map((_, i) => (
@@ -55,16 +56,13 @@ const MissionsView: React.FC<Props> = ({
   })).filter((g) => g.items.length > 0);
 
   return (
-    <div className="w-full max-w-[900px] flex flex-col gap-8">
+    <div className="w-full max-w-[1100px] flex flex-col gap-8">
       <div className="flex items-center justify-between flex-wrap gap-2">
-        <div className="flex flex-col">
-          <h2 className="text-xl font-semibold text-ink">Missions</h2>
-          <span className="text-sm text-ink-muted">
-            {data.totals.claimed}/{data.totals.total} completed
-          </span>
-        </div>
+        <span className="text-sm text-ink-muted">
+          <span className="text-ink font-semibold">{data.totals.claimed}</span> of {data.totals.total} missions claimed
+        </span>
         {data.totals.claimable > 0 && (
-          <span className="px-3 py-1.5 rounded-lg bg-accent-gold/15 text-accent-gold text-sm font-semibold">
+          <span className="px-3 py-1.5 rounded-lg bg-accent-gold/15 text-accent-gold text-sm font-semibold animate-pulse">
             {data.totals.claimable} ready to claim
           </span>
         )}
@@ -72,10 +70,14 @@ const MissionsView: React.FC<Props> = ({
 
       {grouped.map(({ cat, items }) => (
         <div key={cat} className="flex flex-col gap-3">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-ink-muted">
+          <h3
+            className={`text-sm font-semibold uppercase tracking-wide ${
+              cat === "endgame" ? "text-accent-gold" : "text-ink-muted"
+            }`}
+          >
             {CATEGORY_LABELS[cat] || cat}
           </h3>
-          <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
             {items.map((m) => (
               <MissionCard
                 key={m.key}
@@ -84,6 +86,7 @@ const MissionsView: React.FC<Props> = ({
                 claim={claim}
                 visit={visit}
                 caseImage={caseImage}
+                endgame={cat === "endgame"}
               />
             ))}
           </div>

--- a/src/pages/Missions/MissionsPanel.tsx
+++ b/src/pages/Missions/MissionsPanel.tsx
@@ -1,0 +1,21 @@
+import { useMissionsServices } from "./Missions.services";
+import MissionsView from "./Missions.view";
+
+interface Props {
+  userId: string;
+  isOwner: boolean;
+}
+
+// the missions tab. missions are always the logged-in user's own progress, so the
+// tab is only shown on your own profile (userId is accepted for a consistent tab
+// interface but the API resolves the caller from the token).
+const MissionsPanel: React.FC<Props> = ({ isOwner }) => {
+  const service = useMissionsServices({ isOwner });
+  return (
+    <div className="w-full flex justify-center">
+      <MissionsView {...service} />
+    </div>
+  );
+};
+
+export default MissionsPanel;

--- a/src/pages/Missions/MissionsPanel.tsx
+++ b/src/pages/Missions/MissionsPanel.tsx
@@ -9,8 +9,8 @@ interface Props {
 // the missions tab. missions are always the logged-in user's own progress, so the
 // tab is only shown on your own profile (userId is accepted for a consistent tab
 // interface but the API resolves the caller from the token).
-const MissionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
-  const service = useMissionsServices({ isOwner, userId });
+const MissionsPanel: React.FC<Props> = ({ isOwner }) => {
+  const service = useMissionsServices({ isOwner });
   return (
     <div className="w-full flex justify-center">
       <MissionsView {...service} />

--- a/src/pages/Missions/MissionsPanel.tsx
+++ b/src/pages/Missions/MissionsPanel.tsx
@@ -9,8 +9,8 @@ interface Props {
 // the missions tab. missions are always the logged-in user's own progress, so the
 // tab is only shown on your own profile (userId is accepted for a consistent tab
 // interface but the API resolves the caller from the token).
-const MissionsPanel: React.FC<Props> = ({ isOwner }) => {
-  const service = useMissionsServices({ isOwner });
+const MissionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
+  const service = useMissionsServices({ isOwner, userId });
   return (
     <div className="w-full flex justify-center">
       <MissionsView {...service} />

--- a/src/pages/Missions/components/MissionCard.tsx
+++ b/src/pages/Missions/components/MissionCard.tsx
@@ -3,6 +3,7 @@ import { FaDiscord, FaTwitter } from "react-icons/fa";
 import MainButton from "../../../components/MainButton";
 import Monetary from "../../../components/Monetary";
 import { Mission } from "../../../services/missions/MissionService";
+import { resolveMissionArt, MissionArtTile } from "../missionArt";
 
 // discord invite comes from the frontend env; the x handle is a plain constant to edit
 const SOCIAL_URLS: Record<string, string> = {
@@ -15,9 +16,10 @@ interface Props {
   claiming: boolean;
   claim: (key: string) => void;
   visit: (key: string, url: string) => void;
+  caseImage?: string;
 }
 
-const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit }) => {
+const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit, caseImage }) => {
   const pct =
     mission.target > 0 ? Math.min(100, Math.round((mission.current / mission.target) * 100)) : 0;
   const showBar = mission.target > 1 && !mission.claimed;
@@ -32,6 +34,7 @@ const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit }) => {
           : "bg-surface border-line"
       }`}
     >
+      <MissionArtTile art={resolveMissionArt(mission.key, caseImage)} dim={mission.claimed} />
       <div className="flex flex-col min-w-0 flex-1 gap-1">
         <div className="flex items-center gap-2">
           <span className={`text-sm font-semibold ${mission.claimed ? "text-ink-muted" : "text-ink"}`}>

--- a/src/pages/Missions/components/MissionCard.tsx
+++ b/src/pages/Missions/components/MissionCard.tsx
@@ -1,3 +1,4 @@
+import { TailSpin } from "react-loader-spinner";
 import { FiCheck, FiLock } from "react-icons/fi";
 import { FaDiscord, FaTwitter } from "react-icons/fa";
 import MainButton from "../../../components/MainButton";
@@ -17,60 +18,68 @@ interface Props {
   claim: (key: string) => void;
   visit: (key: string, url: string) => void;
   caseImage?: string;
+  endgame?: boolean;
 }
 
-const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit, caseImage }) => {
+const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit, caseImage, endgame }) => {
   const pct =
     mission.target > 0 ? Math.min(100, Math.round((mission.current / mission.target) * 100)) : 0;
   const showBar = mission.target > 1 && !mission.claimed;
 
+  const cardClass = mission.claimed
+    ? "bg-surface/60 border-line"
+    : mission.claimable
+    ? "bg-accent-gold/[0.06] border-accent-gold/60 ring-1 ring-accent-gold/20"
+    : endgame
+    ? "bg-[#e5308c]/[0.04] border-line border-l-2 border-l-[#e5308c]/60"
+    : "bg-surface border-line";
+
   return (
     <div
-      className={`w-full rounded-xl border p-4 flex items-center gap-4 transition-colors ${
-        mission.claimed
-          ? "bg-surface/60 border-line"
-          : mission.claimable
-          ? "bg-surface border-accent-gold/40"
-          : "bg-surface border-line"
-      }`}
+      className={`w-full rounded-xl border p-4 flex flex-col sm:flex-row sm:items-center gap-3 transition-colors ${cardClass}`}
     >
-      <MissionArtTile art={resolveMissionArt(mission.key, caseImage)} dim={mission.claimed} />
-      <div className="flex flex-col min-w-0 flex-1 gap-1">
-        <div className="flex items-center gap-2">
-          <span className={`text-sm font-semibold ${mission.claimed ? "text-ink-muted" : "text-ink"}`}>
-            {mission.title}
-          </span>
-          <span className="text-xs text-accent-gold font-medium">
-            <Monetary value={mission.reward} />
-          </span>
-        </div>
-        <span className="text-xs text-ink-muted">{mission.description}</span>
-        {showBar && (
-          <div className="mt-2 flex items-center gap-2">
-            <div className="h-1.5 flex-1 rounded-full bg-surface-nav overflow-hidden">
-              <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${pct}%` }} />
-            </div>
-            <span className="text-[11px] text-ink-muted shrink-0">
-              {mission.current}/{mission.target}
+      <div className="flex items-center gap-3 min-w-0 flex-1">
+        <MissionArtTile art={resolveMissionArt(mission.key, caseImage)} dim={mission.claimed} />
+        <div className="flex flex-col min-w-0 flex-1 gap-1">
+          <div className="flex items-baseline gap-2 min-w-0">
+            <span
+              className={`flex-1 min-w-0 truncate text-sm font-semibold ${
+                mission.claimed ? "text-ink-muted" : "text-ink"
+              }`}
+            >
+              {mission.title}
+            </span>
+            <span className="shrink-0 whitespace-nowrap text-sm font-semibold text-accent-gold">
+              <Monetary value={mission.reward} />
             </span>
           </div>
-        )}
+          <span className="text-xs text-ink-muted">{mission.description}</span>
+          {showBar && (
+            <div className="mt-2 flex items-center gap-2">
+              <div className="h-1.5 flex-1 rounded-full bg-surface-nav overflow-hidden">
+                <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${pct}%` }} />
+              </div>
+              <span className="text-[11px] text-ink-muted shrink-0">
+                {mission.current}/{mission.target}
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className="w-36 shrink-0">
+      <div className="w-full sm:w-28 shrink-0">
         {mission.claimed ? (
           <span className="flex items-center justify-center gap-1 h-10 text-sm text-ink-muted">
             <FiCheck /> Claimed
           </span>
         ) : mission.claimable ? (
-          <MainButton
-            text={<span className="flex items-center gap-1">Claim</span>}
+          <button
             onClick={() => claim(mission.key)}
-            type="success"
-            loading={claiming}
             disabled={claiming}
-            textSize="text-sm"
-          />
+            className="w-full h-10 rounded-md text-sm font-semibold bg-accent-gold text-black hover:bg-accent-amber disabled:opacity-50 flex items-center justify-center gap-1 transition-colors"
+          >
+            {claiming ? <TailSpin height="18" width="18" color="#000" ariaLabel="claiming" /> : "Claim"}
+          </button>
         ) : mission.social ? (
           <MainButton
             text={mission.social === "discord" ? "Join" : "Follow"}

--- a/src/pages/Missions/components/MissionCard.tsx
+++ b/src/pages/Missions/components/MissionCard.tsx
@@ -31,7 +31,7 @@ const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit, caseIma
     : mission.claimable
     ? "bg-accent-gold/[0.06] border-accent-gold/60 ring-1 ring-accent-gold/20"
     : endgame
-    ? "bg-[#e5308c]/[0.04] border-line border-l-2 border-l-[#e5308c]/60"
+    ? "bg-[#e5308c]/[0.04] border-line border-l-4 border-l-[#e5308c] rounded-l-none"
     : "bg-surface border-line";
 
   return (

--- a/src/pages/Missions/components/MissionCard.tsx
+++ b/src/pages/Missions/components/MissionCard.tsx
@@ -5,10 +5,10 @@ import Monetary from "../../../components/Monetary";
 import { Mission } from "../../../services/missions/MissionService";
 import { resolveMissionArt, MissionArtTile } from "../missionArt";
 
-// discord invite comes from the frontend env; the x handle is a plain constant to edit
+// both social links come from the frontend env (set VITE_X_URL on Render for prod)
 const SOCIAL_URLS: Record<string, string> = {
-  discord: (import.meta.env.VITE_DISCORD_INVITE as string) || "https://discord.gg",
-  x: "https://x.com/kanicasino",
+  discord: (import.meta.env.VITE_DISCORD_INVITE as string) || "https://discord.gg/NMdYb2aBZK",
+  x: (import.meta.env.VITE_X_URL as string) || "https://x.com/kani_casino",
 };
 
 interface Props {

--- a/src/pages/Missions/components/MissionCard.tsx
+++ b/src/pages/Missions/components/MissionCard.tsx
@@ -1,0 +1,89 @@
+import { FiCheck, FiLock } from "react-icons/fi";
+import { FaDiscord, FaTwitter } from "react-icons/fa";
+import MainButton from "../../../components/MainButton";
+import Monetary from "../../../components/Monetary";
+import { Mission } from "../../../services/missions/MissionService";
+
+// discord invite comes from the frontend env; the x handle is a plain constant to edit
+const SOCIAL_URLS: Record<string, string> = {
+  discord: (import.meta.env.VITE_DISCORD_INVITE as string) || "https://discord.gg",
+  x: "https://x.com/kanicasino",
+};
+
+interface Props {
+  mission: Mission;
+  claiming: boolean;
+  claim: (key: string) => void;
+  visit: (key: string, url: string) => void;
+}
+
+const MissionCard: React.FC<Props> = ({ mission, claiming, claim, visit }) => {
+  const pct =
+    mission.target > 0 ? Math.min(100, Math.round((mission.current / mission.target) * 100)) : 0;
+  const showBar = mission.target > 1 && !mission.claimed;
+
+  return (
+    <div
+      className={`w-full rounded-xl border p-4 flex items-center gap-4 transition-colors ${
+        mission.claimed
+          ? "bg-surface/60 border-line"
+          : mission.claimable
+          ? "bg-surface border-accent-gold/40"
+          : "bg-surface border-line"
+      }`}
+    >
+      <div className="flex flex-col min-w-0 flex-1 gap-1">
+        <div className="flex items-center gap-2">
+          <span className={`text-sm font-semibold ${mission.claimed ? "text-ink-muted" : "text-ink"}`}>
+            {mission.title}
+          </span>
+          <span className="text-xs text-accent-gold font-medium">
+            <Monetary value={mission.reward} />
+          </span>
+        </div>
+        <span className="text-xs text-ink-muted">{mission.description}</span>
+        {showBar && (
+          <div className="mt-2 flex items-center gap-2">
+            <div className="h-1.5 flex-1 rounded-full bg-surface-nav overflow-hidden">
+              <div className="h-full rounded-full bg-accent transition-all" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="text-[11px] text-ink-muted shrink-0">
+              {mission.current}/{mission.target}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="w-36 shrink-0">
+        {mission.claimed ? (
+          <span className="flex items-center justify-center gap-1 h-10 text-sm text-ink-muted">
+            <FiCheck /> Claimed
+          </span>
+        ) : mission.claimable ? (
+          <MainButton
+            text={<span className="flex items-center gap-1">Claim</span>}
+            onClick={() => claim(mission.key)}
+            type="success"
+            loading={claiming}
+            disabled={claiming}
+            textSize="text-sm"
+          />
+        ) : mission.social ? (
+          <MainButton
+            text={mission.social === "discord" ? "Join" : "Follow"}
+            onClick={() => visit(mission.key, SOCIAL_URLS[mission.social as string])}
+            icon={mission.social === "discord" ? <FaDiscord /> : <FaTwitter />}
+            type="info"
+            textSize="text-sm"
+          />
+        ) : (
+          <span className="flex items-center justify-center gap-1 h-10 text-xs text-ink-faint">
+            <FiLock /> Locked
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MissionCard;

--- a/src/pages/Missions/components/missionCompleteToast.tsx
+++ b/src/pages/Missions/components/missionCompleteToast.tsx
@@ -20,7 +20,7 @@ export function toastMissionComplete(m: PendingMission, targetPath?: string) {
         </span>
       </div>
       {targetPath && (
-        <span className="ml-auto flex items-center gap-1 text-xs text-ink-soft shrink-0">
+        <span className="ml-auto flex items-center gap-1 text-xs font-medium text-accent-gold shrink-0">
           Claim <FiArrowRight />
         </span>
       )}

--- a/src/pages/Missions/components/missionCompleteToast.tsx
+++ b/src/pages/Missions/components/missionCompleteToast.tsx
@@ -1,0 +1,22 @@
+import { toast } from "react-toastify";
+import { GiTrophyCup } from "react-icons/gi";
+import Monetary from "../../../components/Monetary";
+import { PendingMission } from "../../../services/missions/MissionService";
+
+// the styled real-time "mission complete" toast, shown app-wide the moment a
+// mission becomes claimable (server guarantees it fires once per mission).
+export function toastMissionComplete(m: PendingMission) {
+  toast(
+    <div className="flex items-center gap-3">
+      <GiTrophyCup className="text-3xl text-accent-gold shrink-0" />
+      <div className="flex flex-col">
+        <span className="text-[11px] uppercase tracking-wide text-ink-muted">Mission complete</span>
+        <span className="text-sm font-semibold text-ink">{m.title}</span>
+        <span className="text-xs text-accent-gold font-medium">
+          <Monetary value={m.reward} /> ready to claim
+        </span>
+      </div>
+    </div>,
+    { autoClose: 6000 }
+  );
+}

--- a/src/pages/Missions/components/missionCompleteToast.tsx
+++ b/src/pages/Missions/components/missionCompleteToast.tsx
@@ -1,22 +1,34 @@
 import { toast } from "react-toastify";
 import { GiTrophyCup } from "react-icons/gi";
+import { FiArrowRight } from "react-icons/fi";
 import Monetary from "../../../components/Monetary";
+import { navigateTo } from "../../../services/navigation";
 import { PendingMission } from "../../../services/missions/MissionService";
 
 // the styled real-time "mission complete" toast, shown app-wide the moment a
-// mission becomes claimable (server guarantees it fires once per mission).
-export function toastMissionComplete(m: PendingMission) {
+// mission becomes claimable (server guarantees it fires once per mission). When a
+// targetPath is given the whole toast is a link to the missions page.
+export function toastMissionComplete(m: PendingMission, targetPath?: string) {
   toast(
-    <div className="flex items-center gap-3">
+    <div className={`flex items-center gap-3 ${targetPath ? "cursor-pointer" : ""}`}>
       <GiTrophyCup className="text-3xl text-accent-gold shrink-0" />
-      <div className="flex flex-col">
+      <div className="flex flex-col min-w-0">
         <span className="text-[11px] uppercase tracking-wide text-ink-muted">Mission complete</span>
-        <span className="text-sm font-semibold text-ink">{m.title}</span>
+        <span className="text-sm font-semibold text-ink truncate">{m.title}</span>
         <span className="text-xs text-accent-gold font-medium">
           <Monetary value={m.reward} /> ready to claim
         </span>
       </div>
+      {targetPath && (
+        <span className="ml-auto flex items-center gap-1 text-xs text-ink-soft shrink-0">
+          Claim <FiArrowRight />
+        </span>
+      )}
     </div>,
-    { autoClose: 6000 }
+    {
+      autoClose: 6000,
+      closeOnClick: !!targetPath,
+      onClick: targetPath ? () => navigateTo(targetPath) : undefined,
+    }
   );
 }

--- a/src/pages/Missions/missionArt.tsx
+++ b/src/pages/Missions/missionArt.tsx
@@ -1,0 +1,55 @@
+import { IconType } from "react-icons";
+import { GiOpenChest } from "react-icons/gi";
+import { FiUser, FiUsers } from "react-icons/fi";
+import { FaDiscord, FaTwitter } from "react-icons/fa";
+
+// contextual art per mission: reuse the app's real game/case assets where a mission
+// maps to one, and fall back to a themed icon for the rest (avatar, friend, socials).
+
+// static public assets, the same art the home game listing and slot big-win use
+const IMG: Record<string, string> = {
+  "try-crash": "/images/crash/idle.gif",
+  "try-coinflip": "/images/coinHeads.webp",
+  "coinflip-win": "/images/coinTails.webp",
+  "try-slots": "/images/slot/wild.webp",
+  "battle-win": "/images/boo.webp",
+  "big-win": "/images/slot/bigwin.webp",
+  "first-bonus": "/images/clock.webp",
+  "first-sale": "/images/item1.webp",
+};
+
+// missions that show a real case image, supplied at runtime from the cases list
+const CASE_ART = new Set(["first-case", "cases-10", "cases-100", "complete-collection"]);
+
+const ICON: Record<string, IconType> = {
+  "set-avatar": FiUser,
+  "add-friend": FiUsers,
+  "join-discord": FaDiscord,
+  "follow-x": FaTwitter,
+};
+
+export interface MissionArt {
+  img?: string;
+  Icon?: IconType;
+}
+
+export function resolveMissionArt(key: string, caseImage?: string): MissionArt {
+  if (IMG[key]) return { img: IMG[key] };
+  if (CASE_ART.has(key)) return caseImage ? { img: caseImage } : { Icon: GiOpenChest };
+  if (ICON[key]) return { Icon: ICON[key] };
+  return { Icon: GiOpenChest };
+}
+
+export const MissionArtTile: React.FC<{ art: MissionArt; dim?: boolean }> = ({ art, dim }) => (
+  <div
+    className={`w-14 h-14 shrink-0 rounded-lg bg-surface-nav border border-line flex items-center justify-center overflow-hidden ${
+      dim ? "opacity-50 grayscale" : ""
+    }`}
+  >
+    {art.img ? (
+      <img src={art.img} alt="" className="max-h-12 max-w-12 object-contain" />
+    ) : art.Icon ? (
+      <art.Icon className="text-2xl text-accent-gold" />
+    ) : null}
+  </div>
+);

--- a/src/pages/Missions/missionArt.tsx
+++ b/src/pages/Missions/missionArt.tsx
@@ -1,10 +1,11 @@
 import { IconType } from "react-icons";
-import { GiOpenChest } from "react-icons/gi";
+import { GiOpenChest, GiTwoCoins, GiMoneyStack } from "react-icons/gi";
 import { FiUser, FiUsers } from "react-icons/fi";
-import { FaDiscord, FaTwitter } from "react-icons/fa";
+import { FaDiscord, FaTwitter, FaMedal, FaCoins } from "react-icons/fa";
+import { MdStorefront } from "react-icons/md";
 
 // contextual art per mission: reuse the app's real game/case assets where a mission
-// maps to one, and fall back to a themed icon for the rest (avatar, friend, socials).
+// maps to one, and a themed icon otherwise (money, store, level, socials).
 
 // static public assets, the same art the home game listing and slot big-win use
 const IMG: Record<string, string> = {
@@ -14,14 +15,29 @@ const IMG: Record<string, string> = {
   "try-slots": "/images/slot/wild.webp",
   "battle-win": "/images/boo.webp",
   "big-win": "/images/slot/bigwin.webp",
-  "first-bonus": "/images/clock.webp",
-  "first-sale": "/images/item1.webp",
+  "battles-10": "/images/boo.webp",
+  "coinflip-25": "/images/coinHeads.webp",
+  "crash-50": "/images/crash/idle.gif",
+  "jackpot": "/images/slot/bigwin.webp",
 };
 
 // missions that show a real case image, supplied at runtime from the cases list
-const CASE_ART = new Set(["first-case", "cases-10", "cases-100", "complete-collection"]);
+const CASE_ART = new Set([
+  "first-case",
+  "cases-10",
+  "cases-100",
+  "cases-1000",
+  "complete-collection",
+  "collections-all",
+]);
 
 const ICON: Record<string, IconType> = {
+  "first-bonus": GiTwoCoins,
+  "first-sale": MdStorefront,
+  "market-10": MdStorefront,
+  "wager-million": FaCoins,
+  "millionaire": GiMoneyStack,
+  "level-30": FaMedal,
   "set-avatar": FiUser,
   "add-friend": FiUsers,
   "join-discord": FaDiscord,
@@ -49,7 +65,7 @@ export const MissionArtTile: React.FC<{ art: MissionArt; dim?: boolean }> = ({ a
     {art.img ? (
       <img src={art.img} alt="" className="max-h-12 max-w-12 object-contain" />
     ) : art.Icon ? (
-      <art.Icon className="text-2xl text-accent-gold" />
+      <art.Icon className="text-3xl text-accent-gold" />
     ) : null}
   </div>
 );

--- a/src/pages/Profile/BalanceHistory.tsx
+++ b/src/pages/Profile/BalanceHistory.tsx
@@ -30,6 +30,7 @@ const TYPE_LABELS: Record<string, string> = {
   market_sale: "Marketplace sale",
   item_sell: "Sold to shop",
   admin_adjust: "Admin adjustment",
+  mission_reward: "Mission reward",
 };
 
 const describe = (tx: Transaction): string => {
@@ -44,6 +45,9 @@ const describe = (tx: Transaction): string => {
   }
   if (tx.type === "item_sell" && m.count) {
     return `Sold ${m.count} item${m.count > 1 ? "s" : ""} to shop`;
+  }
+  if (tx.type === "mission_reward" && m.missionTitle) {
+    return `Mission reward: ${m.missionTitle}`;
   }
   return base;
 };

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -204,32 +204,40 @@ const Profile = () => {
       </div>
 
       <div className="flex flex-col items-center w-full bg-[#141225] min-h-screen">
-        <div className="flex flex-col p-8 gap-2 items-center w-full max-w-[1312px]">
-          <div className="w-full flex justify-center mb-6">
-            <div className="inline-flex gap-1 bg-[#19172d] border border-[#2a2840] rounded-xl p-1 max-w-full overflow-x-auto">
-              {tabs.map((t) => (
-                <button
-                  key={t.key}
-                  onClick={() => {
-                    userPickedTabRef.current = true;
-                    setActiveTab(t.key);
-                  }}
-                  className={`shrink-0 whitespace-nowrap px-5 py-2 rounded-lg text-sm font-semibold transition-all ${
-                    activeTab === t.key
-                      ? "bg-[#281d3f] text-white shadow"
-                      : "text-[#84819a] hover:text-white hover:bg-[#221f38]"
-                  }`}
-                >
-                  <span className="inline-flex items-center gap-1.5">
-                    {t.label}
-                    {isSameUser && NEW_TABS.includes(t.key) && !seenTabs.includes(t.key) && (
-                      <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent-gold text-[9px] font-bold uppercase leading-none text-black animate-pulse">
-                        New
-                      </span>
-                    )}
-                  </span>
-                </button>
-              ))}
+        <div className="flex flex-col p-4 md:p-8 gap-2 items-center w-full max-w-[1312px]">
+          <div className="w-full flex justify-center mb-8">
+            <div className="w-full max-w-[1100px] border-b border-line">
+              <div className="flex gap-6 md:gap-8 overflow-x-auto pt-3">
+                {tabs.map((t) => {
+                  const active = activeTab === t.key;
+                  const isNew =
+                    isSameUser && NEW_TABS.includes(t.key) && !seenTabs.includes(t.key);
+                  return (
+                    <button
+                      key={t.key}
+                      onClick={() => {
+                        userPickedTabRef.current = true;
+                        setActiveTab(t.key);
+                      }}
+                      className={`relative shrink-0 whitespace-nowrap pb-3 text-sm font-bold uppercase tracking-wider transition-colors ${
+                        active ? "text-white" : "text-[#84819a] hover:text-white"
+                      }`}
+                    >
+                      {t.label}
+                      {isNew && (
+                        <span className="absolute -top-2 -right-2 flex items-center rounded-full bg-accent-gold px-1.5 py-0.5 text-[9px] font-extrabold uppercase leading-none text-black shadow animate-pulse">
+                          New
+                        </span>
+                      )}
+                      <span
+                        className={`absolute left-0 right-0 -bottom-px h-[3px] rounded-full transition-all ${
+                          active ? "bg-[#e5308c]" : "bg-transparent"
+                        }`}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </div>
 

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { getUser, getInventory } from "../../services/users/UserServices";
 import { FiFilter } from 'react-icons/fi'
 import UserInfo from "./UserInfo";
@@ -20,9 +20,12 @@ interface Inventory {
   items: any[];
 }
 
+// tabs that show a "NEW!" badge until the owner opens them for the first time
+const NEW_TABS = ["collections", "missions"];
 
 const Profile = () => {
   const { id } = useParams();
+  const [searchParams] = useSearchParams();
   const [user, setUser] = useState<User>();
   const [loading, setLoading] = useState<boolean>(true);
   const [loadingInventory, setLoadingInventory] = useState<boolean>(true);
@@ -34,6 +37,7 @@ const Profile = () => {
   const [openFilters, setOpenFilters] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
   const [activeTab, setActiveTab] = useState<"inventory" | "collections" | "history" | "missions">("inventory");
+  const [seenTabs, setSeenTabs] = useState<string[]>([]);
   const [filters, setFilters] = useState({
     name: '',
     rarity: '',
@@ -113,6 +117,37 @@ const Profile = () => {
     getUserInfo();
   }, [id]);
 
+  // deep-link support: /profile/:id?tab=missions opens that tab (e.g. from a toast).
+  // runs after the reset above so it wins, and re-applies once ownership is known.
+  useEffect(() => {
+    const tabParam = searchParams.get("tab");
+    if (!tabParam) return;
+    const allowed =
+      tabParam === "inventory" ||
+      tabParam === "collections" ||
+      (isSameUser && (tabParam === "missions" || tabParam === "history"));
+    if (allowed) setActiveTab(tabParam as "inventory" | "collections" | "history" | "missions");
+  }, [searchParams, isSameUser, id]);
+
+  // load which "new" tabs this user has already opened (per user, per browser)
+  useEffect(() => {
+    if (!userData?.id) return;
+    try {
+      setSeenTabs(JSON.parse(localStorage.getItem(`kani.tabSeen.${userData.id}`) || "[]"));
+    } catch {
+      setSeenTabs([]);
+    }
+  }, [userData?.id]);
+
+  // opening a new tab (by click or deep-link) clears its badge for good
+  useEffect(() => {
+    if (!userData?.id || !isSameUser) return;
+    if (!NEW_TABS.includes(activeTab) || seenTabs.includes(activeTab)) return;
+    const next = [...seenTabs, activeTab];
+    setSeenTabs(next);
+    localStorage.setItem(`kani.tabSeen.${userData.id}`, JSON.stringify(next));
+  }, [activeTab, isSameUser, userData?.id, seenTabs]);
+
   useEffect(() => {
     getInventoryInfo();
   }, [page, id]);
@@ -170,7 +205,14 @@ const Profile = () => {
                       : "text-[#84819a] hover:text-white hover:bg-[#221f38]"
                   }`}
                 >
-                  {t.label}
+                  <span className="inline-flex items-center gap-1.5">
+                    {t.label}
+                    {isSameUser && NEW_TABS.includes(t.key) && !seenTabs.includes(t.key) && (
+                      <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-accent-gold text-[9px] font-bold uppercase leading-none text-black animate-pulse">
+                        New
+                      </span>
+                    )}
+                  </span>
                 </button>
               ))}
             </div>

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -11,6 +11,7 @@ import Filters from "../../components/InventoryFilters";
 import Pagination from "../../components/Pagination";
 import BalanceHistory from "./BalanceHistory";
 import CollectionsPanel from "../Collections/CollectionsPanel";
+import MissionsPanel from "../Missions/MissionsPanel";
 import { User } from '../../components/Types'
 
 interface Inventory {
@@ -32,7 +33,7 @@ const Profile = () => {
   const [refresh, setRefresh] = useState<boolean>(false);
   const [openFilters, setOpenFilters] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
-  const [activeTab, setActiveTab] = useState<"inventory" | "collections" | "history">("inventory");
+  const [activeTab, setActiveTab] = useState<"inventory" | "collections" | "history" | "missions">("inventory");
   const [filters, setFilters] = useState({
     name: '',
     rarity: '',
@@ -117,10 +118,15 @@ const Profile = () => {
   }, [page, id]);
 
 
-  const tabs: { key: "inventory" | "collections" | "history"; label: string }[] = [
+  const tabs: { key: "inventory" | "collections" | "history" | "missions"; label: string }[] = [
     { key: "inventory", label: "Inventory" },
     { key: "collections", label: "Collections" },
-    ...(isSameUser ? [{ key: "history" as const, label: "Balance history" }] : []),
+    ...(isSameUser
+      ? [
+          { key: "missions" as const, label: "Missions" },
+          { key: "history" as const, label: "Balance history" },
+        ]
+      : []),
   ];
 
   return (
@@ -172,6 +178,8 @@ const Profile = () => {
 
           {activeTab === "history" ? (
             <BalanceHistory />
+          ) : activeTab === "missions" ? (
+            <MissionsPanel userId={id as string} isOwner={isSameUser} />
           ) : activeTab === "collections" ? (
             <CollectionsPanel userId={id as string} isOwner={isSameUser} />
           ) : (

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -230,7 +230,7 @@ const Profile = () => {
                         </span>
                       )}
                       <span
-                        className={`absolute left-0 right-0 -bottom-px h-[3px] rounded-full transition-all ${
+                        className={`absolute left-0 right-0 -bottom-px h-[3px] transition-all ${
                           active ? "bg-[#e5308c]" : "bg-transparent"
                         }`}
                       />

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -45,6 +45,8 @@ const Profile = () => {
     order: 'asc',
   });
   const delayDebounceFn = useRef<NodeJS.Timeout | null>(null);
+  const deepLinkTabRef = useRef<string | null>(null);
+  const userPickedTabRef = useRef<boolean>(false);
 
   useEffect(() => {
     if (invItems?.length > 0) {
@@ -118,16 +120,26 @@ const Profile = () => {
   }, [id]);
 
   // deep-link support: /profile/:id?tab=missions opens that tab (e.g. from a toast).
-  // runs after the reset above so it wins, and re-applies once ownership is known.
+  // capture the requested tab; a slow /users/me can defer applying an own-only tab.
   useEffect(() => {
-    const tabParam = searchParams.get("tab");
-    if (!tabParam) return;
+    deepLinkTabRef.current = searchParams.get("tab");
+    userPickedTabRef.current = false;
+  }, [id, searchParams]);
+
+  // apply the captured tab once ownership is known, unless the user already picked a
+  // tab manually in the meantime (so the deep-link can never clobber their choice).
+  useEffect(() => {
+    const tabParam = deepLinkTabRef.current;
+    if (!tabParam || userPickedTabRef.current) return;
     const allowed =
       tabParam === "inventory" ||
       tabParam === "collections" ||
       (isSameUser && (tabParam === "missions" || tabParam === "history"));
-    if (allowed) setActiveTab(tabParam as "inventory" | "collections" | "history" | "missions");
-  }, [searchParams, isSameUser, id]);
+    if (allowed) {
+      deepLinkTabRef.current = null;
+      setActiveTab(tabParam as "inventory" | "collections" | "history" | "missions");
+    }
+  }, [isSameUser, id, searchParams]);
 
   // load which "new" tabs this user has already opened (per user, per browser)
   useEffect(() => {
@@ -198,7 +210,10 @@ const Profile = () => {
               {tabs.map((t) => (
                 <button
                   key={t.key}
-                  onClick={() => setActiveTab(t.key)}
+                  onClick={() => {
+                    userPickedTabRef.current = true;
+                    setActiveTab(t.key);
+                  }}
                   className={`shrink-0 whitespace-nowrap px-5 py-2 rounded-lg text-sm font-semibold transition-all ${
                     activeTab === t.key
                       ? "bg-[#281d3f] text-white shadow"

--- a/src/services/missions/MissionService.ts
+++ b/src/services/missions/MissionService.ts
@@ -1,0 +1,42 @@
+import api from "../api";
+
+export interface Mission {
+  key: string;
+  title: string;
+  description: string;
+  category: string;
+  reward: number;
+  social: "discord" | "x" | null;
+  target: number;
+  current: number;
+  complete: boolean;
+  claimed: boolean;
+  claimable: boolean;
+}
+
+export interface MissionsData {
+  missions: Mission[];
+  totals: { total: number; completed: number; claimable: number; claimed: number };
+}
+
+export interface ClaimResult {
+  claimed: boolean;
+  alreadyClaimed?: boolean;
+  reward?: number;
+  walletBalance?: number;
+  missionKey?: string;
+}
+
+export async function getMissions(): Promise<MissionsData> {
+  const res = await api.get("/missions");
+  return res.data;
+}
+
+export async function visitMission(key: string): Promise<void> {
+  await api.post(`/missions/${key}/visit`);
+}
+
+export async function claimMission(key: string): Promise<ClaimResult> {
+  const res = await api.post(`/missions/${key}/claim`);
+  return res.data;
+}

--- a/src/services/missions/MissionService.ts
+++ b/src/services/missions/MissionService.ts
@@ -19,6 +19,12 @@ export interface MissionsData {
   totals: { total: number; completed: number; claimable: number; claimed: number };
 }
 
+export interface PendingMission {
+  key: string;
+  title: string;
+  reward: number;
+}
+
 export interface ClaimResult {
   claimed: boolean;
   alreadyClaimed?: boolean;
@@ -30,6 +36,13 @@ export interface ClaimResult {
 export async function getMissions(): Promise<MissionsData> {
   const res = await api.get("/missions");
   return res.data;
+}
+
+// missions newly complete since the last check, for the "mission complete" toast.
+// pass light=true on frequent calls (balance changes) to skip the heavy collection scan.
+export async function getPendingMissions(light: boolean): Promise<PendingMission[]> {
+  const res = await api.get(`/missions/pending${light ? "?light=1" : ""}`);
+  return res.data.pending || [];
 }
 
 export async function visitMission(key: string): Promise<void> {

--- a/src/services/missions/MissionService.ts
+++ b/src/services/missions/MissionService.ts
@@ -41,7 +41,9 @@ export async function getMissions(): Promise<MissionsData> {
 // missions newly complete since the last check, for the "mission complete" toast.
 // pass light=true on frequent calls (balance changes) to skip the heavy collection scan.
 export async function getPendingMissions(light: boolean): Promise<PendingMission[]> {
-  const res = await api.get(`/missions/pending${light ? "?light=1" : ""}`);
+  // a timeout guarantees the promise settles, so the caller's in-flight guard can
+  // never stay pinned by a stalled connection
+  const res = await api.get(`/missions/pending${light ? "?light=1" : ""}`, { timeout: 10000 });
   return res.data.pending || [];
 }
 

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -1,0 +1,14 @@
+// a tiny navigation bridge so code outside the Router tree (e.g. a toast fired from
+// App, which sits above <Router>) can trigger client-side navigation. A component
+// inside the Router registers react-router's navigate here.
+type NavFn = (to: string) => void;
+
+let navigateFn: NavFn | null = null;
+
+export const setNavigator = (fn: NavFn | null) => {
+  navigateFn = fn;
+};
+
+export const navigateTo = (to: string) => {
+  if (navigateFn) navigateFn(to);
+};


### PR DESCRIPTION
A Profile "Missions" tab: users complete goals across the app and claim a KP reward. Progress is derived at read time from the transaction ledger, case battles, inventory, and user state, so no game/money hot paths were touched. Counters only count activity from a launch timestamp, so shipping does not retroactively pay out pre-launch grinding.

**Backend**
- `Item`-free: two new collections, `Mission` catalog (in code) + `MissionState` (per user: claimed / visited / announced, unique on userId).
- `GET /missions` (catalog + progress), `POST /missions/:key/visit` (honor-system social), `POST /missions/:key/claim` (atomic one-time credit via `creditUser` + new `mission_reward` ledger type; the idempotency guard is in the update filter, so concurrent claims credit exactly once).
- `GET /missions/pending` powers a real-time "mission complete" toast: each mission is announced once (atomic per-key guard), with a one-time silent seed so pre-existing completions do not burst.
- Derived metrics: cases opened, games played, wins, big win, battles won, market sales, bonuses, collections complete, total wagered, crash cashouts, level, balance, all-collections-complete. A disabled mission (`active:false`) is hidden and unclaimable.

**Frontend**
- Missions tab in the Profile (own profile only), a 2-column grid on wide screens, contextual art per mission (real game/case assets, icon fallback), a gold "claimable" state and a distinct "All In" endgame tier.
- Profile tab bar redesigned to an underline style with a floating "New" badge on the collections/missions tabs (cleared per user).
- Real-time styled toast that deep-links to the missions page; social links read from env.

**Tests:** 22 mission integration tests (including 5-way concurrent-claim and concurrent-announce exactly-once), full backend suite green, frontend lint/build/unit and E2E green.
