### PR TITLE
Marketplace: price history, buy orders, 5% fee, and url-restorable profile views

### DIFF
--- a/backend/__tests__/integration/api.test.js
+++ b/backend/__tests__/integration/api.test.js
@@ -98,8 +98,8 @@ describe("marketplace buy", () => {
     const res = await request(app).post(`/marketplace/buy/${listing._id}`).set(...auth(buyer));
     expect(res.status).toBe(200);
 
-    expect((await User.findById(buyer._id)).walletBalance).toBe(400);
-    expect((await User.findById(seller._id)).walletBalance).toBe(100);
+    expect((await User.findById(buyer._id)).walletBalance).toBe(400); // pays the full price
+    expect((await User.findById(seller._id)).walletBalance).toBe(95); // keeps price minus the 5% fee
     const buyerInv = (await User.findById(buyer._id)).inventory;
     const bought = buyerInv.find((i) => i.uniqueId === listing.uniqueId);
     expect(bought).toBeDefined();
@@ -122,7 +122,7 @@ describe("marketplace buy", () => {
     ]);
 
     expect([r1.status, r2.status].sort()).toEqual([200, 404]);
-    expect((await User.findById(seller._id)).walletBalance).toBe(100); // paid exactly once
+    expect((await User.findById(seller._id)).walletBalance).toBe(95); // paid exactly once, net of fee
   });
 });
 

--- a/backend/__tests__/integration/market.test.js
+++ b/backend/__tests__/integration/market.test.js
@@ -1,0 +1,332 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Marketplace = require("../../models/Marketplace");
+const MarketSale = require("../../models/MarketSale");
+const BuyOrder = require("../../models/BuyOrder");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const auth = (user) => ["Authorization", `Bearer ${tokenFor(user)}`];
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 10000,
+    level: 20,
+    ...overrides,
+  });
+}
+
+async function makeItem(overrides = {}) {
+  return Item.create({
+    name: `Knife-${uniqueSuffix()}`,
+    image: "k.png",
+    rarity: "5",
+    baseValue: 1000,
+    ...overrides,
+  });
+}
+
+async function makeListing(seller, item, price = 100) {
+  return Marketplace.create({
+    sellerId: seller._id,
+    item: item._id,
+    price,
+    itemName: item.name,
+    itemImage: item.image,
+    rarity: item.rarity,
+    uniqueId: `uid-${uniqueSuffix()}`,
+  });
+}
+
+function giveItem(user, item, uniqueId) {
+  return User.updateOne(
+    { _id: user._id },
+    {
+      $push: {
+        inventory: {
+          _id: item._id,
+          name: item.name,
+          image: item.image,
+          rarity: item.rarity,
+          uniqueId,
+          createdAt: new Date(),
+        },
+      },
+    }
+  );
+}
+
+describe("market fee + sale history", () => {
+  test("a buy takes the 5% fee, pays the seller the rest, and records the sale", async () => {
+    const seller = await makeUser({ walletBalance: 0 });
+    const buyer = await makeUser({ walletBalance: 500 });
+    const item = await makeItem();
+    const listing = await makeListing(seller, item, 100);
+
+    const res = await request(app).post(`/marketplace/buy/${listing._id}`).set(...auth(buyer));
+    expect(res.status).toBe(200);
+    expect(res.body.price).toBe(100);
+
+    expect((await User.findById(buyer._id)).walletBalance).toBe(400); // paid full price
+    expect((await User.findById(seller._id)).walletBalance).toBe(95); // kept 95%
+
+    const sales = await MarketSale.find({ item: item._id });
+    expect(sales).toHaveLength(1);
+    expect(sales[0].price).toBe(100);
+    expect(sales[0].fee).toBe(5);
+    expect(sales[0].sellerNet).toBe(95);
+    expect(String(sales[0].buyerId)).toBe(String(buyer._id));
+  });
+
+  test("history reports median, volume and the house floor", async () => {
+    const seller = await makeUser();
+    const item = await makeItem({ baseValue: 1000 }); // floor = 750
+    const now = Date.now();
+    for (const p of [100, 200, 300]) {
+      await MarketSale.create({
+        item: item._id,
+        itemName: item.name,
+        price: p,
+        fee: 0,
+        sellerNet: p,
+        sellerId: seller._id,
+        soldAt: new Date(now - 3600 * 1000),
+      });
+    }
+    await makeListing(seller, item, 180);
+
+    const res = await request(app).get(`/marketplace/item/${item._id}/history?range=week`);
+    expect(res.status).toBe(200);
+    expect(res.body.stats.median7d).toBe(200);
+    expect(res.body.stats.volume7d).toBe(3);
+    expect(res.body.stats.floor).toBe(750);
+    expect(res.body.stats.lowestListing).toBe(180);
+    expect(res.body.stats.feeRate).toBe(0.05);
+    expect(res.body.points.length).toBeGreaterThan(0);
+    expect(res.body.points[0].median).toBe(200);
+  });
+
+  test("history only counts sales inside the range", async () => {
+    const seller = await makeUser();
+    const item = await makeItem();
+    await MarketSale.create({
+      item: item._id,
+      price: 999,
+      sellerId: seller._id,
+      soldAt: new Date(Date.now() - 60 * 24 * 3600 * 1000), // 60 days ago
+    });
+    const res = await request(app).get(`/marketplace/item/${item._id}/history?range=week`);
+    expect(res.body.stats.volume7d).toBe(0);
+    expect(res.body.stats.median7d).toBeNull();
+    expect(res.body.points).toHaveLength(0);
+  });
+});
+
+describe("browse sorting", () => {
+  test("sortBy=price orders by cheapest listing (used to be ignored)", async () => {
+    const seller = await makeUser();
+    const cheap = await makeItem({ name: `AAA-${uniqueSuffix()}` });
+    const pricey = await makeItem({ name: `BBB-${uniqueSuffix()}` });
+    await makeListing(seller, cheap, 10);
+    await makeListing(seller, pricey, 900);
+
+    const res = await request(app).get("/marketplace/?sortBy=price&order=asc&listedOnly=1");
+    expect(res.status).toBe(200);
+    const names = res.body.items.map((i) => i.name);
+    expect(names.indexOf(cheap.name)).toBeLessThan(names.indexOf(pricey.name));
+
+    const desc = await request(app).get("/marketplace/?sortBy=price&order=desc&listedOnly=1");
+    const dnames = desc.body.items.map((i) => i.name);
+    expect(dnames.indexOf(pricey.name)).toBeLessThan(dnames.indexOf(cheap.name));
+  });
+
+  test("listedOnly hides items with no listings", async () => {
+    const seller = await makeUser();
+    const listed = await makeItem();
+    const bare = await makeItem();
+    await makeListing(seller, listed, 50);
+
+    const all = await request(app).get("/marketplace/");
+    expect(all.body.items.some((i) => i.name === bare.name)).toBe(true);
+
+    const only = await request(app).get("/marketplace/?listedOnly=1");
+    expect(only.body.items.some((i) => i.name === bare.name)).toBe(false);
+    expect(only.body.items.some((i) => i.name === listed.name)).toBe(true);
+  });
+});
+
+describe("buy orders", () => {
+  test("placing an order fills instantly from cheap listings and escrows the rest", async () => {
+    const seller = await makeUser({ walletBalance: 0 });
+    const buyer = await makeUser({ walletBalance: 1000 });
+    const item = await makeItem();
+    await makeListing(seller, item, 100);
+
+    const res = await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(buyer))
+      .send({ itemId: item._id, price: 150, quantity: 3 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.filled).toBe(1); // one listing existed at <= 150
+    expect(res.body.order.quantity).toBe(2); // the rest rests as an order
+    expect(res.body.order.escrow).toBe(300); // 2 x 150 held
+
+    // 100 spent on the fill + 300 escrowed
+    expect((await User.findById(buyer._id)).walletBalance).toBe(600);
+    expect((await User.findById(seller._id)).walletBalance).toBe(95);
+  });
+
+  test("a new listing fills a resting order at the bid price and pays the seller net", async () => {
+    const buyer = await makeUser({ walletBalance: 1000 });
+    const seller = await makeUser({ walletBalance: 0, level: 20 });
+    const item = await makeItem();
+
+    // buyer bids 200, nothing to fill -> rests with 200 escrowed
+    const placed = await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(buyer))
+      .send({ itemId: item._id, price: 200, quantity: 1 });
+    expect(placed.body.order.escrow).toBe(200);
+    expect((await User.findById(buyer._id)).walletBalance).toBe(800);
+
+    // seller lists at 120: crosses the resting 200 bid, so it clears at 200
+    await giveItem(seller, item, "sell-me");
+    const listed = await request(app)
+      .post("/marketplace/")
+      .set(...auth(seller))
+      .send({ item: "sell-me", price: 120 });
+
+    expect(listed.status).toBe(200);
+    expect(listed.body.soldInstantly).toBe(true);
+    expect(listed.body.soldFor).toBe(200); // price improvement to the seller
+    expect(listed.body.received).toBe(190); // 200 minus the 5% fee
+
+    expect((await User.findById(seller._id)).walletBalance).toBe(190);
+    // buyer already paid via escrow, so the wallet does not move again
+    expect((await User.findById(buyer._id)).walletBalance).toBe(800);
+    const buyerInv = (await User.findById(buyer._id)).inventory;
+    expect(buyerInv.some((i) => i.uniqueId === "sell-me")).toBe(true);
+
+    const order = await BuyOrder.findById(placed.body.order._id);
+    expect(order.filled).toBe(1);
+    expect(order.escrow).toBe(0);
+    expect(order.status).toBe("filled");
+    expect(await Marketplace.countDocuments({ item: item._id })).toBe(0); // listing consumed
+
+    const sale = await MarketSale.findOne({ item: item._id });
+    expect(sale.price).toBe(200);
+    expect(sale.viaOrder).toBe(true);
+  });
+
+  test("cancelling an order refunds exactly the remaining escrow, once", async () => {
+    const buyer = await makeUser({ walletBalance: 1000 });
+    const item = await makeItem();
+    const placed = await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(buyer))
+      .send({ itemId: item._id, price: 100, quantity: 4 });
+    expect((await User.findById(buyer._id)).walletBalance).toBe(600); // 400 escrowed
+
+    const id = placed.body.order._id;
+    const [c1, c2] = await Promise.all([
+      request(app).delete(`/marketplace/orders/${id}`).set(...auth(buyer)),
+      request(app).delete(`/marketplace/orders/${id}`).set(...auth(buyer)),
+    ]);
+    // exactly one cancel wins
+    expect([c1.status, c2.status].sort()).toEqual([200, 404]);
+    expect((await User.findById(buyer._id)).walletBalance).toBe(1000); // refunded once
+    const refunds = await Transaction.find({ userId: buyer._id, type: TX.MARKET_ORDER_REFUND });
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0].amount).toBe(400);
+  });
+
+  test("two listings cannot overfill a one-unit order", async () => {
+    const buyer = await makeUser({ walletBalance: 1000 });
+    const s1 = await makeUser({ walletBalance: 0 });
+    const s2 = await makeUser({ walletBalance: 0 });
+    const item = await makeItem();
+
+    await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(buyer))
+      .send({ itemId: item._id, price: 100, quantity: 1 });
+
+    await giveItem(s1, item, "a-1");
+    await giveItem(s2, item, "b-1");
+
+    const [r1, r2] = await Promise.all([
+      request(app).post("/marketplace/").set(...auth(s1)).send({ item: "a-1", price: 90 }),
+      request(app).post("/marketplace/").set(...auth(s2)).send({ item: "b-1", price: 90 }),
+    ]);
+
+    const sold = [r1.body, r2.body].filter((b) => b.soldInstantly);
+    expect(sold).toHaveLength(1); // only one filled the single-unit order
+
+    const order = await BuyOrder.findOne({ userId: buyer._id });
+    expect(order.filled).toBe(1);
+    expect(order.escrow).toBe(0);
+    // the loser stays listed on the market
+    expect(await Marketplace.countDocuments({ item: item._id })).toBe(1);
+    expect(await MarketSale.countDocuments({ item: item._id })).toBe(1);
+  });
+
+  test("you cannot fill your own buy order", async () => {
+    const u = await makeUser({ walletBalance: 1000 });
+    const item = await makeItem();
+    await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(u))
+      .send({ itemId: item._id, price: 200, quantity: 1 });
+
+    await giveItem(u, item, "mine-1");
+    const listed = await request(app).post("/marketplace/").set(...auth(u)).send({ item: "mine-1", price: 100 });
+    expect(listed.body.soldInstantly).toBeUndefined(); // just listed, not self-filled
+    expect(await MarketSale.countDocuments({ item: item._id })).toBe(0);
+  });
+
+  test("an order needs the funds to escrow", async () => {
+    const buyer = await makeUser({ walletBalance: 50 });
+    const item = await makeItem();
+    const res = await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(buyer))
+      .send({ itemId: item._id, price: 100, quantity: 1 });
+    expect(res.status).toBe(400);
+    expect(await BuyOrder.countDocuments({ userId: buyer._id })).toBe(0);
+    expect((await User.findById(buyer._id)).walletBalance).toBe(50);
+  });
+
+  test("the order book aggregates open bids by price", async () => {
+    const b1 = await makeUser({ walletBalance: 5000 });
+    const b2 = await makeUser({ walletBalance: 5000 });
+    const item = await makeItem();
+    await request(app).post("/marketplace/orders").set(...auth(b1)).send({ itemId: item._id, price: 100, quantity: 2 });
+    await request(app).post("/marketplace/orders").set(...auth(b2)).send({ itemId: item._id, price: 100, quantity: 3 });
+    await request(app).post("/marketplace/orders").set(...auth(b2)).send({ itemId: item._id, price: 50, quantity: 1 });
+
+    const res = await request(app).get(`/marketplace/item/${item._id}/orders`);
+    expect(res.status).toBe(200);
+    expect(res.body.orders[0]).toEqual({ price: 100, quantity: 5 }); // highest bid first, merged
+    expect(res.body.orders[1]).toEqual({ price: 50, quantity: 1 });
+  });
+});

--- a/backend/__tests__/integration/market.test.js
+++ b/backend/__tests__/integration/market.test.js
@@ -97,6 +97,24 @@ describe("market fee + sale history", () => {
     expect(String(sales[0].buyerId)).toBe(String(buyer._id));
   });
 
+  test("a failed purchase leaves the listing buyable at the same id", async () => {
+    const seller = await makeUser({ walletBalance: 0 });
+    const broke = await makeUser({ walletBalance: 0 });
+    const rich = await makeUser({ walletBalance: 1000 });
+    const item = await makeItem();
+    const listing = await makeListing(seller, item, 100);
+
+    // a broke account claims the listing and fails to pay: it must go back untouched
+    const fail = await request(app).post(`/marketplace/buy/${listing._id}`).set(...auth(broke));
+    expect(fail.status).toBe(400);
+
+    // the id every client was shown must still work, or a zero-balance account could
+    // re-key any listing at will just by failing to pay for it
+    const ok = await request(app).post(`/marketplace/buy/${listing._id}`).set(...auth(rich));
+    expect(ok.status).toBe(200);
+    expect((await User.findById(seller._id)).walletBalance).toBe(95);
+  });
+
   test("history reports median, volume and the house floor", async () => {
     const seller = await makeUser();
     const item = await makeItem({ baseValue: 1000 }); // floor = 750
@@ -288,6 +306,27 @@ describe("buy orders", () => {
     // the loser stays listed on the market
     expect(await Marketplace.countDocuments({ item: item._id })).toBe(1);
     expect(await MarketSale.countDocuments({ item: item._id })).toBe(1);
+  });
+
+  test("the ledger still reconciles with the wallet after an escrow fill", async () => {
+    const buyer = await makeUser({ walletBalance: 1000 });
+    const seller = await makeUser({ walletBalance: 0 });
+    const item = await makeItem();
+
+    await request(app)
+      .post("/marketplace/orders")
+      .set(...auth(buyer))
+      .send({ itemId: item._id, price: 200, quantity: 1 });
+    await giveItem(seller, item, "led-1");
+    await request(app).post("/marketplace/").set(...auth(seller)).send({ item: "led-1", price: 120 });
+
+    // replaying every ledger row from the starting balance must land on the real
+    // wallet: the escrow debit is the spend, the fill must not double-count it
+    const rows = await Transaction.find({ userId: buyer._id });
+    const net = rows.reduce((s, t) => s + (t.direction === "credit" ? t.amount : -t.amount), 0);
+    const wallet = (await User.findById(buyer._id)).walletBalance;
+    expect(1000 + net).toBe(wallet);
+    expect(wallet).toBe(800);
   });
 
   test("you cannot fill your own buy order", async () => {

--- a/backend/__tests__/integration/transactions.test.js
+++ b/backend/__tests__/integration/transactions.test.js
@@ -164,7 +164,8 @@ describe("money paths record a transaction", () => {
     const sellerTx = (await txFor(seller._id)).filter((t) => t.type === "market_sale");
     expect(sellerTx).toHaveLength(1);
     expect(sellerTx[0].direction).toBe("credit");
-    expect(sellerTx[0].amount).toBe(100);
+    expect(sellerTx[0].amount).toBe(95); // price minus the 5% house fee
+    expect(sellerTx[0].meta.fee).toBe(5);
   });
 
   test("a buy reverses cleanly when the seller no longer exists", async () => {

--- a/backend/models/BuyOrder.js
+++ b/backend/models/BuyOrder.js
@@ -1,0 +1,27 @@
+const mongoose = require("mongoose");
+
+// a standing offer to buy an item at up to `price` each. funds are ESCROWED when the
+// order is placed (charged off the wallet up front), so a match can never fail for
+// insufficient balance: every remaining unit is already paid for. `escrow` is the KP
+// still held; cancelling refunds exactly that.
+const BuyOrderSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+  item: { type: mongoose.Schema.Types.ObjectId, ref: "Item", required: true },
+  // snapshot so the order can be listed without populating
+  itemName: { type: String },
+  itemImage: { type: String },
+  rarity: { type: String },
+  case: { type: mongoose.Schema.Types.ObjectId, ref: "Case" },
+  price: { type: Number, required: true }, // max paid per unit
+  quantity: { type: Number, required: true },
+  filled: { type: Number, default: 0 },
+  escrow: { type: Number, default: 0 }, // KP still held for the unfilled units
+  status: { type: String, enum: ["open", "filled", "cancelled"], default: "open" },
+  createdAt: { type: Date, default: Date.now },
+});
+
+// matching wants the highest bid on an item, oldest first (price-time priority)
+BuyOrderSchema.index({ item: 1, status: 1, price: -1, createdAt: 1 });
+BuyOrderSchema.index({ userId: 1, status: 1 });
+
+module.exports = mongoose.model("BuyOrder", BuyOrderSchema);

--- a/backend/models/MarketSale.js
+++ b/backend/models/MarketSale.js
@@ -1,0 +1,25 @@
+const mongoose = require("mongoose");
+
+// a completed marketplace sale. listings are hard-deleted on purchase, so this is
+// the only durable record of what an item actually traded for: it is the source of
+// truth for price history. never derive history from Item.baseValue, which is
+// recomputed from the parent case price and would rewrite the past.
+const MarketSaleSchema = new mongoose.Schema({
+  item: { type: mongoose.Schema.Types.ObjectId, ref: "Item", required: true },
+  itemName: { type: String },
+  rarity: { type: String },
+  price: { type: Number, required: true }, // what the buyer paid
+  fee: { type: Number, default: 0 }, // house cut, burned
+  sellerNet: { type: Number, default: 0 }, // what the seller received
+  sellerId: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+  buyerId: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+  listingId: { type: String },
+  viaOrder: { type: Boolean, default: false }, // filled from a resting buy order
+  soldAt: { type: Date, default: Date.now },
+});
+
+// the only hot query is "this item's sales, newest first, within a window"
+MarketSaleSchema.index({ item: 1, soldAt: -1 });
+MarketSaleSchema.index({ soldAt: -1 });
+
+module.exports = mongoose.model("MarketSale", MarketSaleSchema);

--- a/backend/models/Marketplace.js
+++ b/backend/models/Marketplace.js
@@ -45,5 +45,9 @@ const MarketplaceSchema = new mongoose.Schema(
 MarketplaceSchema.index({ itemName: 1 });
 MarketplaceSchema.index({ rarity: 1 });
 MarketplaceSchema.index({ price: 1 });
+// the hot paths: an item's listings cheapest-first, and a seller reclaiming a listing
+MarketplaceSchema.index({ item: 1, price: 1 });
+MarketplaceSchema.index({ sellerId: 1 });
+MarketplaceSchema.index({ uniqueId: 1 });
 
 module.exports = mongoose.model("Marketplace", MarketplaceSchema);

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const mongoose = require("mongoose");
+const jwt = require("jsonwebtoken");
 const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
 
@@ -24,6 +25,20 @@ const BUY_LEVEL = 10;
 const cleanPrice = (raw) => {
   const n = Math.floor(Number(raw));
   return Number.isFinite(n) && n >= 1 && n <= MAX_PRICE ? n : null;
+};
+
+// the history route is public, but if a token happens to be present we use it to hide
+// the caller's own bids: the matcher refuses to cross them, so showing them as "best
+// bid" would promise a sale that can never happen.
+const viewerId = (req) => {
+  try {
+    const header = req.header("Authorization") || "";
+    const [scheme, token] = header.split(" ");
+    if (scheme !== "Bearer" || !token) return null;
+    return jwt.verify(token, process.env.JWT_SECRET).userId || null;
+  } catch {
+    return null;
+  }
 };
 
 const median = (arr) => {
@@ -111,7 +126,7 @@ module.exports = (io) => {
         return res.status(404).json({ message: "Item not found in inventory" });
       }
 
-      const marketplaceItem = new Marketplace({
+      const pending = {
         sellerId: user._id,
         item: itemDocument._id,
         case: itemDocument.case,
@@ -120,27 +135,31 @@ module.exports = (io) => {
         itemImage: itemDocument.image,
         rarity: itemDocument.rarity,
         uniqueId: inventoryItem.uniqueId,
-      });
-      await marketplaceItem.save();
+      };
 
-      // cross against the best resting bid, if any
-      const order = await market.findMatchingOrder({
-        itemId: itemDocument._id,
-        price,
-        excludeUserId: user._id,
-      });
-      if (order) {
-        const filled = await market.fillListingWithOrder({ listing: marketplaceItem, order, io });
+      // cross the best resting bids BEFORE publishing, so nobody can front-run the
+      // bid at the lower ask. a lost claim race just means trying the next best bid.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const order = await market.findMatchingOrder({
+          itemId: itemDocument._id,
+          price,
+          excludeUserId: user._id,
+        });
+        if (!order) break;
+        const filled = await market.fillOrderWithItem({ pending, order, io });
         if (filled.ok) {
           return res.json({
-            ...marketplaceItem.toObject(),
             soldInstantly: true,
             soldFor: filled.price,
             received: sellerNet(filled.price),
+            itemName: itemDocument.name,
           });
         }
+        if (filled.reason === "seller gone") break;
       }
 
+      const marketplaceItem = new Marketplace(pending);
+      await marketplaceItem.save();
       res.json(marketplaceItem);
     } catch (err) {
       console.error(err);
@@ -286,19 +305,30 @@ module.exports = (io) => {
           meta: { itemId: itemDoc._id, itemName: itemDoc.name, price, quantity: remaining },
         });
         if (charged) {
-          const order = await BuyOrder.create({
-            userId: req.user._id,
-            item: itemDoc._id,
-            itemName: itemDoc.name,
-            itemImage: itemDoc.image,
-            rarity: itemDoc.rarity,
-            case: itemDoc.case,
-            price,
-            quantity: remaining,
-            filled: 0,
-            escrow,
-            status: "open",
-          });
+          let order;
+          try {
+            order = await BuyOrder.create({
+              userId: req.user._id,
+              item: itemDoc._id,
+              itemName: itemDoc.name,
+              itemImage: itemDoc.image,
+              rarity: itemDoc.rarity,
+              case: itemDoc.case,
+              price,
+              quantity: remaining,
+              filled: 0,
+              escrow,
+              status: "open",
+            });
+          } catch (createErr) {
+            // the KP is already off the wallet: hand it back rather than burn it
+            console.error(createErr);
+            await creditUser(req.user._id, escrow, 0, {
+              type: TX.MARKET_ORDER_REFUND,
+              meta: { itemId: itemDoc._id, reason: "order could not be created" },
+            });
+            return res.status(500).json({ message: "Could not place the order" });
+          }
           io.to(req.user._id.toString()).emit("userDataUpdated", {
             walletBalance: charged.walletBalance,
             xp: charged.xp,
@@ -365,7 +395,9 @@ module.exports = (io) => {
       const { itemId } = req.params;
       if (!isValidId(itemId)) return res.status(404).json({ message: "Item not found" });
 
-      const rangeKey = RANGES[String(req.query.range)] ? String(req.query.range) : "week";
+      // hasOwnProperty, so ?range=toString can't match an inherited prototype key
+      const asked = String(req.query.range);
+      const rangeKey = Object.prototype.hasOwnProperty.call(RANGES, asked) ? asked : "week";
       const { days, bucketMs } = RANGES[rangeKey];
       const since = days ? new Date(Date.now() - days * 24 * 3600 * 1000) : null;
 
@@ -374,6 +406,13 @@ module.exports = (io) => {
 
       const weekAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000);
       const monthAgo = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+      const me = viewerId(req);
+      const bidFilter = {
+        item: itemId,
+        status: "open",
+        $expr: { $lt: ["$filled", "$quantity"] },
+      };
+      if (me) bidFilter.userId = { $ne: new mongoose.Types.ObjectId(String(me)) };
 
       const [points, cheapest, totalListings, lastSale, recent7, recent30, bestBid] = await Promise.all([
         salesSeries(itemId, since, bucketMs),
@@ -382,9 +421,7 @@ module.exports = (io) => {
         MarketSale.findOne({ item: itemId }).sort({ soldAt: -1 }).select("price soldAt"),
         MarketSale.find({ item: itemId, soldAt: { $gte: weekAgo } }).select("price"),
         MarketSale.find({ item: itemId, soldAt: { $gte: monthAgo } }).select("price"),
-        BuyOrder.findOne({ item: itemId, status: "open", $expr: { $lt: ["$filled", "$quantity"] } })
-          .sort({ price: -1 })
-          .select("price"),
+        BuyOrder.findOne(bidFilter).sort({ price: -1 }).select("price"),
       ]);
 
       const prices7 = recent7.map((s) => s.price);

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -6,52 +6,107 @@ const { isAuthenticated } = require("../middleware/authMiddleware");
 const User = require("../models/User");
 const Item = require("../models/Item");
 const Marketplace = require("../models/Marketplace");
-const Notification = require("../models/Notification");
-const { creditUser, recordTransaction, TX } = require("../utils/economy");
+const MarketSale = require("../models/MarketSale");
+const BuyOrder = require("../models/BuyOrder");
+const { chargeUser, creditUser, TX } = require("../utils/economy");
+const { sellValue, marketFee, sellerNet, MARKET_FEE_RATE } = require("../utils/itemValue");
+const market = require("../utils/market");
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
+
+const MAX_PRICE = 1000000;
+const MAX_ORDER_QTY = 20;
+const SELL_LEVEL = 5;
+const BUY_LEVEL = 10;
+
+// prices are whole KP; floor rather than reject so a client sending 10.5 is not a hard error
+const cleanPrice = (raw) => {
+  const n = Math.floor(Number(raw));
+  return Number.isFinite(n) && n >= 1 && n <= MAX_PRICE ? n : null;
+};
+
+const median = (arr) => {
+  if (!arr.length) return 0;
+  const s = [...arr].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : Math.round((s[mid - 1] + s[mid]) / 2);
+};
+
+// bucket size per range: enough points to read a trend without shipping every sale
+const RANGES = {
+  week: { days: 7, bucketMs: 6 * 3600 * 1000 },
+  month: { days: 30, bucketMs: 24 * 3600 * 1000 },
+  year: { days: 365, bucketMs: 7 * 24 * 3600 * 1000 },
+  lifetime: { days: null, bucketMs: 7 * 24 * 3600 * 1000 },
+};
+
+// aggregate raw sales into time buckets. $toLong/$toDate keep this compatible with
+// mongo 4.x (no $dateTrunc), and the median is computed here since mongo has none.
+async function salesSeries(itemId, since, bucketMs) {
+  const match = { item: new mongoose.Types.ObjectId(String(itemId)) };
+  if (since) match.soldAt = { $gte: since };
+  const rows = await MarketSale.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: {
+          $toDate: {
+            $subtract: [{ $toLong: "$soldAt" }, { $mod: [{ $toLong: "$soldAt" }, bucketMs] }],
+          },
+        },
+        volume: { $sum: 1 },
+        avg: { $avg: "$price" },
+        min: { $min: "$price" },
+        max: { $max: "$price" },
+        prices: { $push: "$price" },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ]);
+  return rows.map((r) => ({
+    t: r._id,
+    volume: r.volume,
+    avg: Math.round(r.avg),
+    min: r.min,
+    max: r.max,
+    median: median(r.prices),
+  }));
+}
 
 module.exports = (io) => {
-  // Create new listing
+  // ---------------------------------------------------------------- listings
+
+  // Create new listing. if a resting buy order already bids at or above the asking
+  // price, the item sells instantly at that (better) bid.
   router.post("/", isAuthenticated, async (req, res) => {
     try {
-      const { item: uniqueId, price } = req.body;
-
-      // if price is not a number, if is less than 1 or if is greater than 1000000, return error
-      if (isNaN(price) || price < 1 || price > 1000000) {
+      const { item: uniqueId } = req.body;
+      const price = cleanPrice(req.body.price);
+      if (price === null) {
         return res.status(400).json({ message: "Invalid price" });
       }
 
       const user = await User.findById(req.user._id);
-
       if (!user) {
         return res.status(404).json({ message: "User not found" });
       }
-
-      if (user.level < 5) {
-        return res.status(400).json({ message: "You must be at least level 5 to sell items" });
+      if (user.level < SELL_LEVEL) {
+        return res.status(400).json({ message: `You must be at least level ${SELL_LEVEL} to sell items` });
       }
 
-      // find the item in the inventory by uniqueId
-      const inventoryItem = user.inventory.find(
-        (item) => item.uniqueId === uniqueId
-      );
-
+      const inventoryItem = user.inventory.find((item) => item.uniqueId === uniqueId);
       if (!inventoryItem) {
         return res.status(404).json({ message: "Item not found in inventory" });
       }
 
-      // resolve the original item document (and its case) before touching anything
       const itemDocument = await Item.findById(inventoryItem._id);
       if (!itemDocument) {
         return res.status(404).json({ message: "Item not found" });
       }
 
       // atomically remove exactly this item; if it's already gone, abort without listing
-      const pull = await User.updateOne(
-        { _id: user._id },
-        { $pull: { inventory: { uniqueId } } }
-      );
+      const pull = await User.updateOne({ _id: user._id }, { $pull: { inventory: { uniqueId } } });
       if (pull.modifiedCount === 0) {
         return res.status(404).json({ message: "Item not found in inventory" });
       }
@@ -66,8 +121,25 @@ module.exports = (io) => {
         rarity: itemDocument.rarity,
         uniqueId: inventoryItem.uniqueId,
       });
-
       await marketplaceItem.save();
+
+      // cross against the best resting bid, if any
+      const order = await market.findMatchingOrder({
+        itemId: itemDocument._id,
+        price,
+        excludeUserId: user._id,
+      });
+      if (order) {
+        const filled = await market.fillListingWithOrder({ listing: marketplaceItem, order, io });
+        if (filled.ok) {
+          return res.json({
+            ...marketplaceItem.toObject(),
+            soldInstantly: true,
+            soldFor: filled.price,
+            received: sellerNet(filled.price),
+          });
+        }
+      }
 
       res.json(marketplaceItem);
     } catch (err) {
@@ -76,22 +148,21 @@ module.exports = (io) => {
     }
   });
 
-  // Get all listings
+  // Browse items on the market
   router.get("/", async (req, res) => {
     try {
       const page = Math.max(1, Math.floor(Number(req.query.page)) || 1);
       const limit = Math.min(Math.max(1, Math.floor(Number(req.query.limit)) || 30), 100);
       const skip = (page - 1) * limit;
-      const { name, rarity, sortBy, order } = req.query;
+      const { name, rarity, sortBy, order, listedOnly } = req.query;
 
-      let itemFilter = {};
+      const itemFilter = {};
       if (name) itemFilter.name = { $regex: new RegExp(escapeRegex(String(name)), "i") };
       if (rarity) itemFilter.rarity = rarity;
 
       const items = await Item.find(itemFilter).exec();
-      const totalItemsCount = await Item.countDocuments(itemFilter);
+      const itemIds = items.map((item) => item._id);
 
-      const itemIds = items.map(item => item._id);
       const marketplaceData = await Marketplace.aggregate([
         { $match: { item: { $in: itemIds } } },
         {
@@ -99,37 +170,273 @@ module.exports = (io) => {
             _id: "$item",
             cheapestPrice: { $min: "$price" },
             totalListings: { $sum: 1 },
-            mostRecent: { $max: "$createdAt" }
-          }
-        }
+            mostRecent: { $max: "$createdAt" },
+          },
+        },
       ]);
+      const byItem = new Map(marketplaceData.map((m) => [m._id.toString(), m]));
 
-      const itemsWithMarketplaceData = items.map(item => {
-        const marketplaceItem = marketplaceData.find(md => md._id.toString() === item._id.toString());
+      let rows = items.map((item) => {
+        const md = byItem.get(item._id.toString());
         return {
           ...item.toObject(),
-          cheapestPrice: marketplaceItem ? marketplaceItem.cheapestPrice : null,
-          totalListings: marketplaceItem ? marketplaceItem.totalListings : 0,
-          mostRecent: marketplaceItem ? marketplaceItem.mostRecent : new Date(0)
+          sellValue: sellValue(item.baseValue),
+          cheapestPrice: md ? md.cheapestPrice : null,
+          totalListings: md ? md.totalListings : 0,
+          mostRecent: md ? md.mostRecent : new Date(0),
         };
       });
 
-      const itemsWithListings = itemsWithMarketplaceData.filter(item => item.totalListings > 0);
-      const itemsWithoutListings = itemsWithMarketplaceData.filter(item => item.totalListings === 0);
+      if (listedOnly === "1" || listedOnly === "true") {
+        rows = rows.filter((r) => r.totalListings > 0);
+      }
 
-      itemsWithListings.sort((a, b) => {
-        return new Date(b.mostRecent) - new Date(a.mostRecent);
-      });
-
-      const sortedItems = [...itemsWithListings, ...itemsWithoutListings];
-
-      const paginatedItems = sortedItems.slice(skip, skip + limit);
+      // whitelisted sort (these params used to be accepted and silently ignored)
+      const dir = order === "asc" ? 1 : -1;
+      const listedFirst = (a, b) => (b.totalListings > 0) - (a.totalListings > 0);
+      const comparators = {
+        price: (a, b) => {
+          const av = a.cheapestPrice ?? Infinity;
+          const bv = b.cheapestPrice ?? Infinity;
+          return (av - bv) * (order === "desc" ? -1 : 1);
+        },
+        name: (a, b) => String(a.name).localeCompare(String(b.name)) * (order === "desc" ? -1 : 1),
+        listings: (a, b) => (a.totalListings - b.totalListings) * dir,
+        rarity: (a, b) => (Number(a.rarity) - Number(b.rarity)) * dir,
+        recent: (a, b) => (new Date(a.mostRecent) - new Date(b.mostRecent)) * dir,
+      };
+      const cmp = comparators[String(sortBy)] || comparators.recent;
+      rows.sort((a, b) => listedFirst(a, b) || cmp(a, b));
 
       res.json({
-        totalPages: Math.ceil(totalItemsCount / limit),
+        totalPages: Math.max(1, Math.ceil(rows.length / limit)),
         currentPage: page,
-        items: paginatedItems,
+        items: rows.slice(skip, skip + limit),
       });
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // ------------------------------------------------------------ buy orders
+  // (registered before /:id so "orders" is never read as a listing id)
+
+  // my open buy orders
+  router.get("/orders/me", isAuthenticated, async (req, res) => {
+    try {
+      const orders = await BuyOrder.find({ userId: req.user._id, status: "open" }).sort({ createdAt: -1 });
+      res.json({ orders });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // place a buy order: fill instantly from the cheapest listings at or below the bid,
+  // then escrow the remainder so a later match can never fail for lack of funds.
+  router.post("/orders", isAuthenticated, async (req, res) => {
+    try {
+      const { itemId } = req.body;
+      const price = cleanPrice(req.body.price);
+      const quantity = Math.floor(Number(req.body.quantity) || 1);
+
+      if (!isValidId(itemId)) return res.status(400).json({ message: "Invalid item" });
+      if (price === null) return res.status(400).json({ message: "Invalid price" });
+      if (!Number.isFinite(quantity) || quantity < 1 || quantity > MAX_ORDER_QTY) {
+        return res.status(400).json({ message: `Quantity must be between 1 and ${MAX_ORDER_QTY}` });
+      }
+      if (req.user.level < BUY_LEVEL) {
+        return res.status(400).json({ message: `You must be at least level ${BUY_LEVEL} to buy items` });
+      }
+
+      const itemDoc = await Item.findById(itemId);
+      if (!itemDoc) return res.status(404).json({ message: "Item not found" });
+
+      let filled = 0;
+      let spent = 0;
+      let ranOutOfFunds = false;
+      for (let i = 0; i < quantity; i++) {
+        const listing = await Marketplace.findOne({
+          item: itemDoc._id,
+          price: { $lte: price },
+          sellerId: { $ne: req.user._id },
+        }).sort({ price: 1 });
+        if (!listing) break;
+
+        const r = await market.purchaseListing({ listingId: listing._id, buyerId: req.user._id, io });
+        if (r.ok) {
+          filled += 1;
+          spent += r.price;
+          continue;
+        }
+        if (r.code === 400) {
+          ranOutOfFunds = true; // insufficient balance
+          break;
+        }
+        // 404 (someone else took it) or 410 (seller vanished): try the next listing
+      }
+
+      const remaining = quantity - filled;
+      if (remaining > 0 && !ranOutOfFunds) {
+        const escrow = remaining * price;
+        const charged = await chargeUser(req.user._id, escrow, {
+          awardXp: false,
+          type: TX.MARKET_ORDER,
+          meta: { itemId: itemDoc._id, itemName: itemDoc.name, price, quantity: remaining },
+        });
+        if (charged) {
+          const order = await BuyOrder.create({
+            userId: req.user._id,
+            item: itemDoc._id,
+            itemName: itemDoc.name,
+            itemImage: itemDoc.image,
+            rarity: itemDoc.rarity,
+            case: itemDoc.case,
+            price,
+            quantity: remaining,
+            filled: 0,
+            escrow,
+            status: "open",
+          });
+          io.to(req.user._id.toString()).emit("userDataUpdated", {
+            walletBalance: charged.walletBalance,
+            xp: charged.xp,
+            level: charged.level,
+          });
+          return res.json({ filled, spent, order });
+        }
+        if (filled === 0) {
+          return res.status(400).json({ message: "Insufficient balance" });
+        }
+        // bought what we could afford, could not escrow the rest
+        return res.json({ filled, spent, order: null, message: "Not enough balance to hold the rest" });
+      }
+
+      if (filled === 0) {
+        return res.status(400).json({ message: "Insufficient balance" });
+      }
+      res.json({ filled, spent, order: null });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // cancel an order and refund whatever escrow is still held. the status guard in the
+  // filter means a concurrent fill and a cancel can never both spend the same KP.
+  router.delete("/orders/:id", isAuthenticated, async (req, res) => {
+    try {
+      if (!isValidId(req.params.id)) return res.status(404).json({ message: "Order not found" });
+
+      const order = await BuyOrder.findOneAndUpdate(
+        { _id: req.params.id, userId: req.user._id, status: "open" },
+        { $set: { status: "cancelled", escrow: 0 } },
+        { returnDocument: "before" } // pre-image holds the exact escrow to refund
+      );
+      if (!order) return res.status(404).json({ message: "Order not found" });
+
+      const refund = order.escrow || 0;
+      if (refund > 0) {
+        const user = await creditUser(req.user._id, refund, 0, {
+          type: TX.MARKET_ORDER_REFUND,
+          meta: { orderId: order._id, itemName: order.itemName },
+        });
+        if (user) {
+          io.to(req.user._id.toString()).emit("userDataUpdated", {
+            walletBalance: user.walletBalance,
+            xp: user.xp,
+            level: user.level,
+          });
+        }
+      }
+      res.json({ message: "Order cancelled", refunded: refund });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // ------------------------------------------------------------- item views
+
+  // the price-history series + everything a seller needs to price an item
+  router.get("/item/:itemId/history", async (req, res) => {
+    try {
+      const { itemId } = req.params;
+      if (!isValidId(itemId)) return res.status(404).json({ message: "Item not found" });
+
+      const rangeKey = RANGES[String(req.query.range)] ? String(req.query.range) : "week";
+      const { days, bucketMs } = RANGES[rangeKey];
+      const since = days ? new Date(Date.now() - days * 24 * 3600 * 1000) : null;
+
+      const item = await Item.findById(itemId, { name: 1, image: 1, rarity: 1, baseValue: 1, case: 1 });
+      if (!item) return res.status(404).json({ message: "Item not found" });
+
+      const weekAgo = new Date(Date.now() - 7 * 24 * 3600 * 1000);
+      const monthAgo = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+
+      const [points, cheapest, totalListings, lastSale, recent7, recent30, bestBid] = await Promise.all([
+        salesSeries(itemId, since, bucketMs),
+        Marketplace.findOne({ item: itemId }).sort({ price: 1 }).select("price"),
+        Marketplace.countDocuments({ item: itemId }),
+        MarketSale.findOne({ item: itemId }).sort({ soldAt: -1 }).select("price soldAt"),
+        MarketSale.find({ item: itemId, soldAt: { $gte: weekAgo } }).select("price"),
+        MarketSale.find({ item: itemId, soldAt: { $gte: monthAgo } }).select("price"),
+        BuyOrder.findOne({ item: itemId, status: "open", $expr: { $lt: ["$filled", "$quantity"] } })
+          .sort({ price: -1 })
+          .select("price"),
+      ]);
+
+      const prices7 = recent7.map((s) => s.price);
+      const prices30 = recent30.map((s) => s.price);
+
+      res.json({
+        item: {
+          _id: item._id,
+          name: item.name,
+          image: item.image,
+          rarity: item.rarity,
+          baseValue: item.baseValue || 0,
+        },
+        range: rangeKey,
+        points,
+        stats: {
+          floor: sellValue(item.baseValue), // the house always pays this: a hard price floor
+          lowestListing: cheapest ? cheapest.price : null,
+          totalListings,
+          bestBid: bestBid ? bestBid.price : null,
+          lastSale: lastSale ? { price: lastSale.price, soldAt: lastSale.soldAt } : null,
+          median7d: prices7.length ? median(prices7) : null,
+          median30d: prices30.length ? median(prices30) : null,
+          volume7d: prices7.length,
+          volume30d: prices30.length,
+          feeRate: MARKET_FEE_RATE,
+        },
+      });
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // the buy-order book for an item, aggregated by price
+  router.get("/item/:itemId/orders", async (req, res) => {
+    try {
+      const { itemId } = req.params;
+      if (!isValidId(itemId)) return res.status(404).json({ message: "Item not found" });
+      const rows = await BuyOrder.aggregate([
+        {
+          $match: {
+            item: new mongoose.Types.ObjectId(String(itemId)),
+            status: "open",
+            $expr: { $lt: ["$filled", "$quantity"] },
+          },
+        },
+        { $group: { _id: "$price", quantity: { $sum: { $subtract: ["$quantity", "$filled"] } } } },
+        { $sort: { _id: -1 } },
+        { $limit: 20 },
+      ]);
+      res.json({ orders: rows.map((r) => ({ price: r._id, quantity: r.quantity })) });
     } catch (error) {
       console.error(error);
       res.status(500).json({ message: "Internal server error" });
@@ -140,7 +447,7 @@ module.exports = (io) => {
   router.get("/item/:itemId", async (req, res) => {
     try {
       const { itemId } = req.params;
-      if (!mongoose.Types.ObjectId.isValid(itemId)) {
+      if (!isValidId(itemId)) {
         return res.status(404).json({ message: "Item not found" });
       }
 
@@ -167,35 +474,22 @@ module.exports = (io) => {
     }
   });
 
-  // Delete listing
+  // ------------------------------------------------------------------ trade
+
+  // Delete listing (id here is the listing's uniqueId)
   router.delete("/:id", isAuthenticated, async (req, res) => {
     try {
-      // atomically remove only if it belongs to this seller
       const item = await Marketplace.findOneAndDelete({
         uniqueId: req.params.id,
         sellerId: req.user._id,
       });
-
       if (!item) {
         return res.status(404).json({ message: "Item not found" });
       }
 
-      // give the item back to the seller's inventory
       await User.updateOne(
         { _id: req.user._id },
-        {
-          $push: {
-            inventory: {
-              _id: item.item,
-              name: item.itemName,
-              image: item.itemImage,
-              rarity: item.rarity,
-              case: item.case,
-              createdAt: new Date(), // acquired now, so it sorts as newest
-              uniqueId: item.uniqueId,
-            },
-          },
-        }
+        { $push: { inventory: market.inventoryEntryFrom(item) } }
       );
 
       res.json({ message: "Item removed" });
@@ -205,136 +499,25 @@ module.exports = (io) => {
     }
   });
 
-  // Buy an item
+  // Buy a listing outright (id here is the listing's _id)
   router.post("/buy/:id", isAuthenticated, async (req, res) => {
     try {
-      const buyerId = req.user._id;
-
-      const listing = await Marketplace.findById(req.params.id);
-      if (!listing) {
+      if (!isValidId(req.params.id)) {
         return res.status(404).json({ message: "Item not found" });
       }
-
-      if (req.user.level < 10) {
-        return res.status(400).json({ message: "You must be at least level 10 to buy items" });
+      if (req.user.level < BUY_LEVEL) {
+        return res.status(400).json({ message: `You must be at least level ${BUY_LEVEL} to buy items` });
       }
 
-      if (listing.sellerId.toString() === buyerId.toString()) {
-        return res.status(400).json({ message: "You can't buy your own listing" });
-      }
-
-      // atomically claim the listing so two buyers can't both purchase it
-      const claimed = await Marketplace.findOneAndDelete({ _id: listing._id });
-      if (!claimed) {
-        return res.status(404).json({ message: "Item no longer available" });
-      }
-
-      const inventoryItem = {
-        _id: claimed.item,
-        name: claimed.itemName,
-        image: claimed.itemImage,
-        rarity: claimed.rarity,
-        case: claimed.case,
-        createdAt: new Date(), // acquired now, so it sorts as newest
-        uniqueId: claimed.uniqueId,
-      };
-
-      // atomically debit the buyer and grant the item only if the balance covers it
-      const updatedBuyer = await User.findOneAndUpdate(
-        { _id: buyerId, walletBalance: { $gte: claimed.price } },
-        { $inc: { walletBalance: -claimed.price }, $push: { inventory: inventoryItem } },
-        { new: true }
-      );
-
-      if (!updatedBuyer) {
-        // payment failed: put the listing back on the market
-        await Marketplace.create({
-          sellerId: claimed.sellerId,
-          item: claimed.item,
-          case: claimed.case,
-          uniqueId: claimed.uniqueId,
-          price: claimed.price,
-          itemName: claimed.itemName,
-          itemImage: claimed.itemImage,
-          rarity: claimed.rarity,
-        });
-        return res.status(400).json({ message: "Insufficient balance" });
-      }
-
-      await recordTransaction({
-        userId: buyerId,
-        type: TX.MARKET_BUY,
-        direction: "debit",
-        amount: claimed.price,
-        balanceAfter: updatedBuyer.walletBalance,
-        meta: { itemName: claimed.itemName, sellerId: claimed.sellerId, listingId: claimed.uniqueId },
+      const result = await market.purchaseListing({
+        listingId: req.params.id,
+        buyerId: req.user._id,
+        io,
       });
-
-      // pay the seller through the ledger chokepoint (records the sale proceeds)
-      const seller = await creditUser(claimed.sellerId, claimed.price, 0, {
-        type: TX.MARKET_SALE,
-        meta: { itemName: claimed.itemName, buyerId, listingId: claimed.uniqueId },
-      });
-
-      // seller account is gone: reverse the buyer so their KP can't disappear
-      if (!seller) {
-        const reversed = await User.findOneAndUpdate(
-          { _id: buyerId },
-          { $inc: { walletBalance: claimed.price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } },
-          { new: true }
-        );
-        await recordTransaction({
-          userId: buyerId,
-          type: TX.MARKET_BUY,
-          direction: "credit",
-          amount: claimed.price,
-          balanceAfter: reversed ? reversed.walletBalance : undefined,
-          meta: { itemName: claimed.itemName, reversal: true, reason: "seller no longer exists" },
-        });
-        if (reversed) {
-          io.to(buyerId.toString()).emit("userDataUpdated", {
-            walletBalance: reversed.walletBalance,
-            xp: reversed.xp,
-            level: reversed.level,
-          });
-        }
-        return res.status(410).json({ message: "Seller no longer available; purchase reversed" });
+      if (!result.ok) {
+        return res.status(result.code).json({ message: result.message });
       }
-
-      res.json({ message: "Item purchased" });
-
-      // the buyer's balance is authoritative here; the client must not guess it
-      io.to(buyerId.toString()).emit("userDataUpdated", {
-        walletBalance: updatedBuyer.walletBalance,
-        xp: updatedBuyer.xp,
-        level: updatedBuyer.level,
-      });
-
-      // notify the seller after responding; failures here must not re-send headers
-      try {
-        if (seller) {
-          const newNotification = new Notification({
-            senderId: buyerId,
-            receiverId: seller._id,
-            type: 'message',
-            title: 'Item Sold',
-            content: `Your ${claimed.itemName} has been sold for K₽${claimed.price}`,
-          });
-          await newNotification.save();
-
-          io.to(seller._id.toString()).emit("newNotification", {
-            message: `Your ${claimed.itemName} has been sold for K₽${claimed.price}`
-          });
-
-          io.to(seller._id.toString()).emit('userDataUpdated', {
-            walletBalance: seller.walletBalance,
-            xp: seller.xp,
-            level: seller.level,
-          });
-        }
-      } catch (notifyErr) {
-        console.error(notifyErr);
-      }
+      res.json({ message: "Item purchased", price: result.price, walletBalance: result.buyer.walletBalance });
     } catch (err) {
       console.error(err);
       res.status(500).json({ message: "Internal server error" });

--- a/backend/scripts/backfillMarketSales.js
+++ b/backend/scripts/backfillMarketSales.js
@@ -1,0 +1,98 @@
+// Rebuild price history from the transaction ledger.
+//
+// Listings are hard-deleted on purchase, so before the MarketSale collection existed
+// the only trace of a completed sale was the market_sale ledger row. Those rows carry
+// the price (as `amount`) and the item NAME, but no itemId, so we match by name.
+// Historical sales predate the market fee, so fee = 0 and sellerNet = price.
+//
+// Usage:
+//   node scripts/backfillMarketSales.js          (dry run: reports what it would do)
+//   node scripts/backfillMarketSales.js --apply  (writes)
+//
+// Idempotent: skips any sale already recorded for the same listingId + soldAt.
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Transaction = require("../models/Transaction");
+const Item = require("../models/Item");
+const MarketSale = require("../models/MarketSale");
+const { TX } = require("../utils/economy");
+
+const APPLY = process.argv.includes("--apply");
+
+(async () => {
+  await mongoose.connect(process.env.MONGO_URI);
+
+  const rows = await Transaction.find({ type: TX.MARKET_SALE }).sort({ createdAt: 1 }).lean();
+  console.log(`found ${rows.length} market_sale ledger rows`);
+
+  // name -> item. ambiguous names (same name on two items) are skipped: we cannot
+  // know which one traded, and guessing would poison the price history.
+  const items = await Item.find({}, { name: 1, rarity: 1 }).lean();
+  const byName = new Map();
+  for (const it of items) {
+    const key = String(it.name);
+    if (byName.has(key)) byName.set(key, null); // duplicate name -> unusable
+    else byName.set(key, it);
+  }
+
+  let created = 0;
+  let skippedExisting = 0;
+  let unmatched = 0;
+  let ambiguous = 0;
+
+  for (const tx of rows) {
+    const meta = tx.meta || {};
+    const name = meta.itemName;
+    // newer rows already carry itemId; prefer it when present
+    let item = meta.itemId ? items.find((i) => String(i._id) === String(meta.itemId)) : null;
+    if (!item && name) {
+      const hit = byName.get(String(name));
+      if (hit === null) {
+        ambiguous += 1;
+        continue;
+      }
+      item = hit;
+    }
+    if (!item) {
+      unmatched += 1;
+      continue;
+    }
+
+    const exists = await MarketSale.findOne({
+      listingId: meta.listingId || null,
+      soldAt: tx.createdAt,
+      item: item._id,
+    });
+    if (exists) {
+      skippedExisting += 1;
+      continue;
+    }
+
+    // the seller was credited the full price back then (no fee existed)
+    const price = meta.price || tx.amount;
+    if (APPLY) {
+      await MarketSale.create({
+        item: item._id,
+        itemName: item.name,
+        rarity: item.rarity,
+        price,
+        fee: meta.fee || 0,
+        sellerNet: tx.amount,
+        sellerId: tx.userId,
+        buyerId: meta.buyerId || null,
+        listingId: meta.listingId || null,
+        soldAt: tx.createdAt,
+      });
+    }
+    created += 1;
+  }
+
+  console.log(
+    `${APPLY ? "created" : "would create"} ${created} | already recorded ${skippedExisting} | unmatched name ${unmatched} | ambiguous name ${ambiguous}`
+  );
+  if (!APPLY) console.log("dry run, pass --apply to write");
+  await mongoose.disconnect();
+})().catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -19,6 +19,8 @@ const TX = {
   BATTLE_REFUND: "battle_refund",
   MARKET_BUY: "market_buy",
   MARKET_SALE: "market_sale",
+  MARKET_ORDER: "market_order", // KP escrowed when a buy order is placed
+  MARKET_ORDER_REFUND: "market_order_refund", // escrow returned on cancel
   ITEM_SELL: "item_sell",
   ADMIN_ADJUST: "admin_adjust",
   MISSION_REWARD: "mission_reward",

--- a/backend/utils/itemValue.js
+++ b/backend/utils/itemValue.js
@@ -4,6 +4,7 @@ const { Rarities } = require("./caseOpening");
 const RARITY_MULTIPLIER = { "1": 1, "2": 4, "3": 12, "4": 40, "5": 100 };
 const RTP = 0.9; // expected item value per open = case price * RTP (10% open edge)
 const SELL_RATE = 0.75; // instant sell-to-house = base value * SELL_RATE
+const MARKET_FEE_RATE = 0.05; // house cut on a marketplace sale, paid by the seller
 
 const chanceFor = (rarityId) => {
   const r = Rarities.find((x) => x.id === String(rarityId));
@@ -39,6 +40,12 @@ function baseValuesForCase(caseDoc) {
 }
 
 const sellValue = (baseValue) => Math.floor((baseValue || 0) * SELL_RATE);
+
+// the buyer always pays the listed price; the seller keeps it minus the house fee,
+// which is burned (a KP sink). both derive from the same price so they can never
+// disagree about who got what.
+const marketFee = (price) => Math.floor(Math.max(0, price || 0) * MARKET_FEE_RATE);
+const sellerNet = (price) => Math.max(0, (price || 0) - marketFee(price));
 
 // recompute and persist baseValue for every item in a case, and (re)materialize the
 // provably-fair range table, bumping the case's config version + archiving it when
@@ -80,7 +87,10 @@ module.exports = {
   RARITY_MULTIPLIER,
   RTP,
   SELL_RATE,
+  MARKET_FEE_RATE,
   baseValuesForCase,
   sellValue,
+  marketFee,
+  sellerNet,
   recomputeCaseValues,
 };

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -19,9 +19,12 @@ function inventoryEntryFrom(listing) {
   };
 }
 
-// put a claimed listing back on the market (same uniqueId, new _id)
+// put a claimed listing back on the market. the _id is preserved: clients hold it
+// and buy by it, so minting a new one would 404 every honest buyer and let a broke
+// account re-key a listing at will just by failing to pay for it.
 function restoreListing(claimed) {
   return Marketplace.create({
+    _id: claimed._id,
     sellerId: claimed.sellerId,
     item: claimed.item,
     case: claimed.case,
@@ -176,17 +179,18 @@ async function purchaseListing({ listingId, buyerId, io }) {
   return { ok: true, price: claimed.price, buyer: updatedBuyer, listing: claimed };
 }
 
-// fill a fresh listing against a resting buy order. the bid is the resting side, so
-// the trade clears at the ORDER's price (price improvement goes to the seller), and
-// the buyer's KP is already escrowed. every step is reversible if the next one fails.
-async function fillListingWithOrder({ listing, order, io }) {
-  const claimed = await Marketplace.findOneAndDelete({ _id: listing._id });
-  if (!claimed) return { ok: false, reason: "listing gone" };
-
+// cross an item the seller still holds straight into a resting buy order, WITHOUT
+// ever publishing a listing (publishing first would let a third party front-run the
+// bid at the lower ask, and would hand out an _id that the restore path invalidates).
+// the bid is the resting side, so the trade clears at the ORDER's price: the price
+// improvement goes to the seller. the buyer's KP is already escrowed, so no wallet
+// moves here and no ledger row is written for the buyer: the escrow debit recorded at
+// placement is the spend. writing one here would double-count it against the wallet.
+async function fillOrderWithItem({ pending, order, io }) {
   const price = order.price;
 
   // claim exactly one unit of escrow; the filter is the guard, so two concurrent
-  // listings can never overfill the same order
+  // sellers can never overfill the same order
   const claimedOrder = await BuyOrder.findOneAndUpdate(
     {
       _id: order._id,
@@ -197,31 +201,25 @@ async function fillListingWithOrder({ listing, order, io }) {
     { $inc: { filled: 1, escrow: -price } },
     { new: true }
   );
-  if (!claimedOrder) {
-    await restoreListing(claimed);
-    return { ok: false, reason: "order gone" };
-  }
+  if (!claimedOrder) return { ok: false, reason: "order gone" };
 
-  // hand the item to the order's owner
   const grant = await User.updateOne(
     { _id: claimedOrder.userId },
-    { $push: { inventory: inventoryEntryFrom(claimed) } }
+    { $push: { inventory: inventoryEntryFrom(pending) } }
   );
   if (!grant.matchedCount) {
-    // buyer vanished: undo the escrow claim and put the listing back
     await BuyOrder.updateOne({ _id: order._id }, { $inc: { filled: -1, escrow: price } });
-    await restoreListing(claimed);
     return { ok: false, reason: "buyer gone" };
   }
 
   const net = sellerNet(price);
-  const seller = await creditUser(claimed.sellerId, net, 0, {
+  const seller = await creditUser(pending.sellerId, net, 0, {
     type: TX.MARKET_SALE,
     meta: {
-      itemId: claimed.item,
-      itemName: claimed.itemName,
+      itemId: pending.item,
+      itemName: pending.itemName,
       buyerId: claimedOrder.userId,
-      listingId: claimed.uniqueId,
+      listingId: pending.uniqueId,
       price,
       fee: marketFee(price),
       viaOrder: true,
@@ -232,48 +230,33 @@ async function fillListingWithOrder({ listing, order, io }) {
     // seller gone: give the escrowed KP back to the buyer and take the item back
     await User.updateOne(
       { _id: claimedOrder.userId },
-      { $inc: { walletBalance: price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } }
+      { $inc: { walletBalance: price }, $pull: { inventory: { uniqueId: pending.uniqueId } } }
     );
     await recordTransaction({
       userId: claimedOrder.userId,
       type: TX.MARKET_ORDER_REFUND,
       direction: "credit",
       amount: price,
-      meta: { itemName: claimed.itemName, reversal: true, reason: "seller no longer exists" },
+      meta: { itemName: pending.itemName, reversal: true, reason: "seller no longer exists" },
     });
     return { ok: false, reason: "seller gone" };
   }
-
-  // the buyer's escrow paid for this unit: ledger it as the purchase
-  await recordTransaction({
-    userId: claimedOrder.userId,
-    type: TX.MARKET_BUY,
-    direction: "debit",
-    amount: price,
-    meta: {
-      itemId: claimed.item,
-      itemName: claimed.itemName,
-      sellerId: claimed.sellerId,
-      listingId: claimed.uniqueId,
-      fromEscrow: true,
-    },
-  });
 
   if (claimedOrder.filled >= claimedOrder.quantity) {
     await BuyOrder.updateOne({ _id: order._id, status: "open" }, { $set: { status: "filled" } });
   }
 
-  await logSale({ listing: claimed, buyerId: claimedOrder.userId, price, viaOrder: true });
+  await logSale({ listing: pending, buyerId: claimedOrder.userId, price, viaOrder: true });
 
   if (io) {
     io.to(claimedOrder.userId.toString()).emit("newNotification", {
-      message: `Your buy order filled: ${claimed.itemName} for K₽${price}`,
+      message: `Your buy order filled: ${pending.itemName} for K₽${price}`,
     });
   }
   await notifySeller({
     seller,
     buyerId: claimedOrder.userId,
-    itemName: claimed.itemName,
+    itemName: pending.itemName,
     price,
     net,
     io,
@@ -298,6 +281,6 @@ module.exports = {
   restoreListing,
   logSale,
   purchaseListing,
-  fillListingWithOrder,
+  fillOrderWithItem,
   findMatchingOrder,
 };

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -1,0 +1,303 @@
+const User = require("../models/User");
+const Marketplace = require("../models/Marketplace");
+const MarketSale = require("../models/MarketSale");
+const BuyOrder = require("../models/BuyOrder");
+const Notification = require("../models/Notification");
+const { creditUser, recordTransaction, TX } = require("./economy");
+const { marketFee, sellerNet } = require("./itemValue");
+
+// rebuild the inventory entry a listing represents. acquired now, so it sorts newest.
+function inventoryEntryFrom(listing) {
+  return {
+    _id: listing.item,
+    name: listing.itemName,
+    image: listing.itemImage,
+    rarity: listing.rarity,
+    case: listing.case,
+    createdAt: new Date(),
+    uniqueId: listing.uniqueId,
+  };
+}
+
+// put a claimed listing back on the market (same uniqueId, new _id)
+function restoreListing(claimed) {
+  return Marketplace.create({
+    sellerId: claimed.sellerId,
+    item: claimed.item,
+    case: claimed.case,
+    uniqueId: claimed.uniqueId,
+    price: claimed.price,
+    itemName: claimed.itemName,
+    itemImage: claimed.itemImage,
+    rarity: claimed.rarity,
+  });
+}
+
+// the durable price-history record. best-effort: a failed write must never break a
+// settled trade, mirroring recordTransaction.
+async function logSale({ listing, buyerId, price, viaOrder = false }) {
+  try {
+    return await MarketSale.create({
+      item: listing.item,
+      itemName: listing.itemName,
+      rarity: listing.rarity,
+      price,
+      fee: marketFee(price),
+      sellerNet: sellerNet(price),
+      sellerId: listing.sellerId,
+      buyerId,
+      listingId: listing.uniqueId,
+      viaOrder,
+      soldAt: new Date(),
+    });
+  } catch (err) {
+    console.error("logSale failed:", err);
+    return null;
+  }
+}
+
+// tell the seller their item sold. never throws into the trade.
+async function notifySeller({ seller, buyerId, itemName, price, net, io }) {
+  try {
+    if (!seller) return;
+    const message = `Your ${itemName} sold for K₽${price} (you received K₽${net})`;
+    await Notification.create({
+      senderId: buyerId,
+      receiverId: seller._id,
+      type: "message",
+      title: "Item Sold",
+      content: message,
+    });
+    if (io) {
+      io.to(seller._id.toString()).emit("newNotification", { message });
+      io.to(seller._id.toString()).emit("userDataUpdated", {
+        walletBalance: seller.walletBalance,
+        xp: seller.xp,
+        level: seller.level,
+      });
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+// buy a listing straight from the wallet. shared by POST /buy/:id and by a new buy
+// order crossing resting listings. the atomic claim (findOneAndDelete) is the lock:
+// exactly one caller can win a given listing.
+async function purchaseListing({ listingId, buyerId, io }) {
+  const claimed = await Marketplace.findOneAndDelete({ _id: listingId });
+  if (!claimed) return { ok: false, code: 404, message: "Item no longer available" };
+
+  if (String(claimed.sellerId) === String(buyerId)) {
+    await restoreListing(claimed);
+    return { ok: false, code: 400, message: "You can't buy your own listing" };
+  }
+
+  // debit the buyer and grant the item together, only if the balance covers it
+  const updatedBuyer = await User.findOneAndUpdate(
+    { _id: buyerId, walletBalance: { $gte: claimed.price } },
+    { $inc: { walletBalance: -claimed.price }, $push: { inventory: inventoryEntryFrom(claimed) } },
+    { new: true }
+  );
+  if (!updatedBuyer) {
+    await restoreListing(claimed);
+    return { ok: false, code: 400, message: "Insufficient balance" };
+  }
+
+  await recordTransaction({
+    userId: buyerId,
+    type: TX.MARKET_BUY,
+    direction: "debit",
+    amount: claimed.price,
+    balanceAfter: updatedBuyer.walletBalance,
+    meta: {
+      itemId: claimed.item,
+      itemName: claimed.itemName,
+      sellerId: claimed.sellerId,
+      listingId: claimed.uniqueId,
+    },
+  });
+
+  const net = sellerNet(claimed.price);
+  const seller = await creditUser(claimed.sellerId, net, 0, {
+    type: TX.MARKET_SALE,
+    meta: {
+      itemId: claimed.item,
+      itemName: claimed.itemName,
+      buyerId,
+      listingId: claimed.uniqueId,
+      price: claimed.price,
+      fee: marketFee(claimed.price),
+    },
+  });
+
+  // seller account is gone: reverse the buyer so their KP can't disappear
+  if (!seller) {
+    const reversed = await User.findOneAndUpdate(
+      { _id: buyerId },
+      { $inc: { walletBalance: claimed.price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } },
+      { new: true }
+    );
+    await recordTransaction({
+      userId: buyerId,
+      type: TX.MARKET_BUY,
+      direction: "credit",
+      amount: claimed.price,
+      balanceAfter: reversed ? reversed.walletBalance : undefined,
+      meta: { itemName: claimed.itemName, reversal: true, reason: "seller no longer exists" },
+    });
+    if (reversed && io) {
+      io.to(buyerId.toString()).emit("userDataUpdated", {
+        walletBalance: reversed.walletBalance,
+        xp: reversed.xp,
+        level: reversed.level,
+      });
+    }
+    return { ok: false, code: 410, message: "Seller no longer available; purchase reversed" };
+  }
+
+  await logSale({ listing: claimed, buyerId, price: claimed.price });
+  if (io) {
+    io.to(buyerId.toString()).emit("userDataUpdated", {
+      walletBalance: updatedBuyer.walletBalance,
+      xp: updatedBuyer.xp,
+      level: updatedBuyer.level,
+    });
+  }
+  await notifySeller({
+    seller,
+    buyerId,
+    itemName: claimed.itemName,
+    price: claimed.price,
+    net,
+    io,
+  });
+
+  return { ok: true, price: claimed.price, buyer: updatedBuyer, listing: claimed };
+}
+
+// fill a fresh listing against a resting buy order. the bid is the resting side, so
+// the trade clears at the ORDER's price (price improvement goes to the seller), and
+// the buyer's KP is already escrowed. every step is reversible if the next one fails.
+async function fillListingWithOrder({ listing, order, io }) {
+  const claimed = await Marketplace.findOneAndDelete({ _id: listing._id });
+  if (!claimed) return { ok: false, reason: "listing gone" };
+
+  const price = order.price;
+
+  // claim exactly one unit of escrow; the filter is the guard, so two concurrent
+  // listings can never overfill the same order
+  const claimedOrder = await BuyOrder.findOneAndUpdate(
+    {
+      _id: order._id,
+      status: "open",
+      escrow: { $gte: price },
+      $expr: { $lt: ["$filled", "$quantity"] },
+    },
+    { $inc: { filled: 1, escrow: -price } },
+    { new: true }
+  );
+  if (!claimedOrder) {
+    await restoreListing(claimed);
+    return { ok: false, reason: "order gone" };
+  }
+
+  // hand the item to the order's owner
+  const grant = await User.updateOne(
+    { _id: claimedOrder.userId },
+    { $push: { inventory: inventoryEntryFrom(claimed) } }
+  );
+  if (!grant.matchedCount) {
+    // buyer vanished: undo the escrow claim and put the listing back
+    await BuyOrder.updateOne({ _id: order._id }, { $inc: { filled: -1, escrow: price } });
+    await restoreListing(claimed);
+    return { ok: false, reason: "buyer gone" };
+  }
+
+  const net = sellerNet(price);
+  const seller = await creditUser(claimed.sellerId, net, 0, {
+    type: TX.MARKET_SALE,
+    meta: {
+      itemId: claimed.item,
+      itemName: claimed.itemName,
+      buyerId: claimedOrder.userId,
+      listingId: claimed.uniqueId,
+      price,
+      fee: marketFee(price),
+      viaOrder: true,
+    },
+  });
+
+  if (!seller) {
+    // seller gone: give the escrowed KP back to the buyer and take the item back
+    await User.updateOne(
+      { _id: claimedOrder.userId },
+      { $inc: { walletBalance: price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } }
+    );
+    await recordTransaction({
+      userId: claimedOrder.userId,
+      type: TX.MARKET_ORDER_REFUND,
+      direction: "credit",
+      amount: price,
+      meta: { itemName: claimed.itemName, reversal: true, reason: "seller no longer exists" },
+    });
+    return { ok: false, reason: "seller gone" };
+  }
+
+  // the buyer's escrow paid for this unit: ledger it as the purchase
+  await recordTransaction({
+    userId: claimedOrder.userId,
+    type: TX.MARKET_BUY,
+    direction: "debit",
+    amount: price,
+    meta: {
+      itemId: claimed.item,
+      itemName: claimed.itemName,
+      sellerId: claimed.sellerId,
+      listingId: claimed.uniqueId,
+      fromEscrow: true,
+    },
+  });
+
+  if (claimedOrder.filled >= claimedOrder.quantity) {
+    await BuyOrder.updateOne({ _id: order._id, status: "open" }, { $set: { status: "filled" } });
+  }
+
+  await logSale({ listing: claimed, buyerId: claimedOrder.userId, price, viaOrder: true });
+
+  if (io) {
+    io.to(claimedOrder.userId.toString()).emit("newNotification", {
+      message: `Your buy order filled: ${claimed.itemName} for K₽${price}`,
+    });
+  }
+  await notifySeller({
+    seller,
+    buyerId: claimedOrder.userId,
+    itemName: claimed.itemName,
+    price,
+    net,
+    io,
+  });
+
+  return { ok: true, price, order: claimedOrder };
+}
+
+// the best resting bid that a listing at `price` would cross (highest, then oldest)
+function findMatchingOrder({ itemId, price, excludeUserId }) {
+  return BuyOrder.findOne({
+    item: itemId,
+    status: "open",
+    price: { $gte: price },
+    userId: { $ne: excludeUserId },
+    $expr: { $lt: ["$filled", "$quantity"] },
+  }).sort({ price: -1, createdAt: 1 });
+}
+
+module.exports = {
+  inventoryEntryFrom,
+  restoreListing,
+  logSale,
+  purchaseListing,
+  fillListingWithOrder,
+  findMatchingOrder,
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,6 @@ function App() {
   const [userData, setUserData] = useState<User | null>(null);
   const [recentCaseOpenings, setRecentCaseOpenings] = useState<any>([]);
   const [openUserFlow, setOpenUserFlow] = useState<boolean>(false);
-  const [joinedRoom, setJoinedRoom] = useState<boolean>(false);
   const [notification, setNotification] = useState<any>();
 
   const socket = SocketConnection.getInstance();
@@ -105,19 +104,23 @@ function App() {
     };
   }, [socket]);
 
+  // keyed on the account itself, not a "joined once" latch: logging out and into
+  // another account in the same tab never remounts App, so a latch would leave the
+  // socket in the old user's room and userIdRef pointing at them.
   useEffect(() => {
-    if (userData && userData.id && !joinedRoom) {
-      userIdRef.current = userData.id;
-      // reconnect so the handshake re-runs with the now-available token; the
-      // server authenticates it and joins this user's private room
-      socket.disconnect();
-      socket.connect();
-      setJoinedRoom(true);
+    const id = userData?.id ?? null;
+    if (userIdRef.current === id) return;
+    userIdRef.current = id;
+    // reconnect so the handshake re-runs with the current token; the server
+    // authenticates it and joins this user's private room, or none when logged out
+    socket.disconnect();
+    socket.connect();
+    if (id) {
       // full catch-up check on login: seeds silently the first time, then toasts
       // anything completed while away
       checkMissions(false);
     }
-  }, [joinedRoom, socket, userData]);
+  }, [socket, userData]);
 
   useEffect(() => {
     socket.on("newNotification", (notification) => {
@@ -142,7 +145,6 @@ function App() {
       clearTokens();
       setIsLogged(false);
       setUserData(null);
-      setJoinedRoom(false);
       setOpenUserFlow(true);
       toast.info("Your session expired. Please log in again.");
     };

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -1,0 +1,196 @@
+import { useMemo, useState } from "react";
+
+export interface PricePoint {
+  t: string;
+  median: number;
+  avg: number;
+  min: number;
+  max: number;
+  volume: number;
+}
+
+interface Props {
+  points: PricePoint[];
+  floor?: number | null; // the house always pays this: a hard price floor
+  height?: number;
+  loading?: boolean;
+}
+
+const W = 720; // viewBox units; the svg scales to its container
+const PAD = { top: 12, right: 8, bottom: 22, left: 46 };
+
+const fmtK = (n: number) => (n >= 1000 ? `${Math.round(n / 100) / 10}k` : String(Math.round(n)));
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+
+// a small hand-rolled chart: median price line + volume bars. no charting dep, so it
+// stays honest about what it draws and costs nothing in bundle size.
+const PriceChart: React.FC<Props> = ({ points, floor, height = 220, loading }) => {
+  const [hover, setHover] = useState<number | null>(null);
+  const H = height;
+
+  const geom = useMemo(() => {
+    if (!points.length) return null;
+    const prices = points.flatMap((p) => [p.median]);
+    const withFloor = floor && floor > 0 ? [...prices, floor] : prices;
+    let lo = Math.min(...withFloor);
+    let hi = Math.max(...withFloor);
+    if (hi === lo) {
+      // a flat series still deserves a readable band
+      hi = lo + Math.max(1, lo * 0.1);
+      lo = Math.max(0, lo - Math.max(1, lo * 0.1));
+    }
+    const pad = (hi - lo) * 0.1;
+    lo = Math.max(0, lo - pad);
+    hi = hi + pad;
+
+    const maxVol = Math.max(...points.map((p) => p.volume), 1);
+    const innerW = W - PAD.left - PAD.right;
+    const innerH = H - PAD.top - PAD.bottom;
+
+    const x = (i: number) =>
+      PAD.left + (points.length === 1 ? innerW / 2 : (i / (points.length - 1)) * innerW);
+    const y = (v: number) => PAD.top + innerH - ((v - lo) / (hi - lo)) * innerH;
+
+    return { lo, hi, maxVol, innerW, innerH, x, y };
+  }, [points, floor, H]);
+
+  if (loading) {
+    return (
+      <div
+        className="w-full rounded-lg bg-surface-nav border border-line animate-pulse"
+        style={{ height: H }}
+      />
+    );
+  }
+
+  if (!points.length || !geom) {
+    return (
+      <div
+        className="w-full rounded-lg bg-surface-nav border border-line flex items-center justify-center text-sm text-ink-muted"
+        style={{ height: H }}
+      >
+        No sales recorded in this period yet.
+      </div>
+    );
+  }
+
+  const { lo, hi, maxVol, innerW, innerH, x, y } = geom;
+  const line = points.map((p, i) => `${x(i)},${y(p.median)}`).join(" ");
+  const area = `${PAD.left},${PAD.top + innerH} ${line} ${x(points.length - 1)},${PAD.top + innerH}`;
+  const gridVals = [lo, lo + (hi - lo) / 2, hi];
+  const barW = Math.max(1, Math.min(14, innerW / points.length - 2));
+  const hp = hover !== null ? points[hover] : null;
+
+  return (
+    <div className="w-full rounded-lg bg-surface-nav border border-line p-2 relative">
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" style={{ height: H }} role="img" aria-label="price history">
+        <defs>
+          <linearGradient id="pcFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#4F46E5" stopOpacity="0.35" />
+            <stop offset="100%" stopColor="#4F46E5" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+
+        {gridVals.map((v, i) => (
+          <g key={i}>
+            <line x1={PAD.left} x2={W - PAD.right} y1={y(v)} y2={y(v)} stroke="#2A2840" strokeWidth="1" />
+            <text x={PAD.left - 6} y={y(v) + 3} textAnchor="end" fontSize="9" fill="#84819A">
+              {fmtK(v)}
+            </text>
+          </g>
+        ))}
+
+        {/* volume bars sit on the baseline, scaled to a third of the plot */}
+        {points.map((p, i) => {
+          const h = (p.volume / maxVol) * (innerH * 0.28);
+          return (
+            <rect
+              key={`v${i}`}
+              x={x(i) - barW / 2}
+              y={PAD.top + innerH - h}
+              width={barW}
+              height={h}
+              fill="#4F46E5"
+              opacity={hover === i ? 0.5 : 0.18}
+            />
+          );
+        })}
+
+        {floor && floor > 0 && floor >= lo && floor <= hi && (
+          <g>
+            <line
+              x1={PAD.left}
+              x2={W - PAD.right}
+              y1={y(floor)}
+              y2={y(floor)}
+              stroke="#FFCC00"
+              strokeWidth="1"
+              strokeDasharray="4 4"
+              opacity="0.7"
+            />
+            <text x={W - PAD.right} y={y(floor) - 4} textAnchor="end" fontSize="9" fill="#FFCC00">
+              house floor
+            </text>
+          </g>
+        )}
+
+        <polygon points={area} fill="url(#pcFill)" />
+        <polyline points={line} fill="none" stroke="#4F46E5" strokeWidth="2" strokeLinejoin="round" />
+
+        {points.map((p, i) => (
+          <circle
+            key={`p${i}`}
+            cx={x(i)}
+            cy={y(p.median)}
+            r={hover === i ? 3.5 : 0}
+            fill="#fff"
+            stroke="#4F46E5"
+            strokeWidth="2"
+          />
+        ))}
+
+        {/* x labels: first, middle, last only, so they never collide */}
+        {[0, Math.floor(points.length / 2), points.length - 1]
+          .filter((i, idx, a) => a.indexOf(i) === idx && points[i])
+          .map((i) => (
+            <text
+              key={`x${i}`}
+              x={x(i)}
+              y={H - 6}
+              textAnchor={i === 0 ? "start" : i === points.length - 1 ? "end" : "middle"}
+              fontSize="9"
+              fill="#84819A"
+            >
+              {fmtDate(points[i].t)}
+            </text>
+          ))}
+
+        {/* invisible hit areas drive the tooltip */}
+        {points.map((_, i) => (
+          <rect
+            key={`h${i}`}
+            x={x(i) - innerW / points.length / 2}
+            y={PAD.top}
+            width={innerW / points.length}
+            height={innerH}
+            fill="transparent"
+            onMouseEnter={() => setHover(i)}
+            onMouseLeave={() => setHover(null)}
+          />
+        ))}
+      </svg>
+
+      {hp && (
+        <div className="pointer-events-none absolute top-2 right-2 rounded-md bg-surface border border-line px-2 py-1 text-[11px] leading-tight">
+          <div className="text-ink font-semibold">K₽{hp.median.toLocaleString()}</div>
+          <div className="text-ink-muted">
+            {hp.volume} sale{hp.volume === 1 ? "" : "s"} · {fmtDate(hp.t)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PriceChart;

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -48,8 +48,14 @@ const PriceChart: React.FC<Props> = ({ points, floor, height = 220, loading }) =
     const innerW = W - PAD.left - PAD.right;
     const innerH = H - PAD.top - PAD.bottom;
 
+    // x is positioned by TIME, not by index: the backend emits only buckets that had
+    // sales, so index spacing would silently squash a month-long gap next to an hour.
+    const times = points.map((p) => new Date(p.t).getTime());
+    const t0 = Math.min(...times);
+    const t1 = Math.max(...times);
+    const span = t1 - t0;
     const x = (i: number) =>
-      PAD.left + (points.length === 1 ? innerW / 2 : (i / (points.length - 1)) * innerW);
+      PAD.left + (span <= 0 ? innerW / 2 : ((times[i] - t0) / span) * innerW);
     const y = (v: number) => PAD.top + innerH - ((v - lo) / (hi - lo)) * innerH;
 
     return { lo, hi, maxVol, innerW, innerH, x, y };
@@ -138,12 +144,13 @@ const PriceChart: React.FC<Props> = ({ points, floor, height = 220, loading }) =
         <polygon points={area} fill="url(#pcFill)" />
         <polyline points={line} fill="none" stroke="#4F46E5" strokeWidth="2" strokeLinejoin="round" />
 
+        {/* a lone bucket has no line to draw, so it must still show as a point */}
         {points.map((p, i) => (
           <circle
             key={`p${i}`}
             cx={x(i)}
             cy={y(p.median)}
-            r={hover === i ? 3.5 : 0}
+            r={hover === i ? 3.5 : points.length === 1 ? 3 : 0}
             fill="#fff"
             stroke="#4F46E5"
             strokeWidth="2"
@@ -166,19 +173,24 @@ const PriceChart: React.FC<Props> = ({ points, floor, height = 220, loading }) =
             </text>
           ))}
 
-        {/* invisible hit areas drive the tooltip */}
-        {points.map((_, i) => (
-          <rect
-            key={`h${i}`}
-            x={x(i) - innerW / points.length / 2}
-            y={PAD.top}
-            width={innerW / points.length}
-            height={innerH}
-            fill="transparent"
-            onMouseEnter={() => setHover(i)}
-            onMouseLeave={() => setHover(null)}
-          />
-        ))}
+        {/* invisible hit areas: each spans to the midpoint of its neighbours, so the
+            whole plot is hoverable even though points are unevenly spaced in time */}
+        {points.map((_, i) => {
+          const left = i === 0 ? PAD.left : (x(i - 1) + x(i)) / 2;
+          const right = i === points.length - 1 ? W - PAD.right : (x(i) + x(i + 1)) / 2;
+          return (
+            <rect
+              key={`h${i}`}
+              x={left}
+              y={PAD.top}
+              width={Math.max(1, right - left)}
+              height={innerH}
+              fill="transparent"
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+            />
+          );
+        })}
       </svg>
 
       {hp && (

--- a/src/pages/Collections/CollectionDetail/CollectionDetail.services.ts
+++ b/src/pages/Collections/CollectionDetail/CollectionDetail.services.ts
@@ -1,4 +1,6 @@
 import { useContext, useEffect, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { useSearchParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import UserContext from "../../../UserContext";
 import { sellItems } from "../../../services/users/UserServices";
@@ -33,8 +35,8 @@ export const useCollectionDetailServices = ({ userId, isOwner, caseId, onBack }:
   const [sortBy, setSortByState] = useState<AlbumSort>("mostRare");
   const [refresh, setRefresh] = useState<boolean>(false);
 
-  const [selectedItem, setSelectedItem] = useState<AlbumItem | null>(null);
-  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const itemParam = searchParams.get("item");
   const [selling, setSelling] = useState<boolean>(false);
 
   const [quicksellOpen, setQuicksellOpen] = useState<boolean>(false);
@@ -71,10 +73,55 @@ export const useCollectionDetailServices = ({ userId, isOwner, caseId, onBack }:
     setSortByState(s);
   };
 
+  // the open item lives in the url, so returning from the market reopens it. items and
+  // extras are disjoint by _id, so the first hit is unambiguous.
+  const selectedItem: AlbumItem | null =
+    (itemParam && detail
+      ? detail.items.find((i) => i._id === itemParam) ??
+        detail.extras.find((i) => i._id === itemParam)
+      : undefined) ?? null;
+  const modalOpen = selectedItem !== null;
+
+  const writeItem = (id: string | null) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (id) next.set("item", id);
+        else next.delete("item");
+        return next;
+      },
+      { replace: true }
+    );
+
+  // a refetch keeps the old rows on screen (the skeleton only covers the first load),
+  // so ignore clicks on rows that are about to be replaced: the item may not survive
+  // the new result set, and the modal would open and then vanish.
   const openItem = (item: AlbumItem) => {
-    setSelectedItem(item);
-    setModalOpen(true);
+    if (loading) return;
+    writeItem(item._id);
   };
+
+  // keeps the view/modal contract: Modal only ever calls setOpen(false).
+  const setModalOpen: Dispatch<SetStateAction<boolean>> = (value) => {
+    const next = typeof value === "function" ? value(modalOpen) : value;
+    if (!next && itemParam) writeItem(null);
+  };
+
+  // an ?item= we cannot resolve against the loaded album (it sits on another page, or
+  // it is gone) has to be dropped, or it pops the modal open unbidden the moment the
+  // user pages to the page that happens to hold it. loading covers the refetch window,
+  // and the album unmounts on a case change, so detail always belongs to this caseId.
+  useEffect(() => {
+    if (!itemParam || loading || !detail || selectedItem) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("item");
+        return next;
+      },
+      { replace: true }
+    );
+  }, [itemParam, loading, detail, selectedItem, setSearchParams]);
 
   const handleSellOne = async (uniqueId: string) => {
     if (selling) return;

--- a/src/pages/Collections/CollectionDetail/CollectionDetail.services.ts
+++ b/src/pages/Collections/CollectionDetail/CollectionDetail.services.ts
@@ -16,6 +16,20 @@ import {
 export type AlbumFilter = "all" | "owned" | "missing" | "duplicates";
 export type AlbumSort = "mostRare" | "mostCommon";
 
+const FILTERS: AlbumFilter[] = ["all", "owned", "missing", "duplicates"];
+const SORTS: AlbumSort[] = ["mostRare", "mostCommon"];
+
+// the album view lives in the url too, so returning from the market lands on the same
+// page and filter the item was found under. junk falls back to the default.
+export const resolveFilter = (v: string | null): AlbumFilter =>
+  FILTERS.includes(v as AlbumFilter) ? (v as AlbumFilter) : "all";
+export const resolveSort = (v: string | null): AlbumSort =>
+  SORTS.includes(v as AlbumSort) ? (v as AlbumSort) : "mostRare";
+export const resolvePage = (v: string | null): number => {
+  const n = Number(v);
+  return Number.isInteger(n) && n > 0 ? n : 1;
+};
+
 interface Args {
   userId: string;
   isOwner: boolean;
@@ -30,13 +44,13 @@ export const useCollectionDetailServices = ({ userId, isOwner, caseId, onBack }:
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
 
-  const [page, setPage] = useState<number>(1);
-  const [filter, setFilterState] = useState<AlbumFilter>("all");
-  const [sortBy, setSortByState] = useState<AlbumSort>("mostRare");
   const [refresh, setRefresh] = useState<boolean>(false);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const itemParam = searchParams.get("item");
+  const page = resolvePage(searchParams.get("page"));
+  const filter = resolveFilter(searchParams.get("filter"));
+  const sortBy = resolveSort(searchParams.get("sort"));
   const [selling, setSelling] = useState<boolean>(false);
 
   const [quicksellOpen, setQuicksellOpen] = useState<boolean>(false);
@@ -64,14 +78,61 @@ export const useCollectionDetailServices = ({ userId, isOwner, caseId, onBack }:
     };
   }, [caseId, userId, page, filter, sortBy, refresh]);
 
-  const setFilter = (f: AlbumFilter) => {
-    setPage(1);
-    setFilterState(f);
+  // the set can shrink under a page we are already on (selling the last card of a
+  // filter, or a hand-typed number), and the pager hides itself once there is one page
+  // left, so the album would strand empty with nothing to click. kept out of the fetch
+  // effect on purpose: its deps must not include setSearchParams, whose identity
+  // changes on every param write and would refetch the album on each one.
+  useEffect(() => {
+    if (loading || !detail || page <= detail.totalPages) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("page");
+        return next;
+      },
+      { replace: true }
+    );
+  }, [loading, detail, page, setSearchParams]);
+
+  // a param at its default is left out, so a plain album url stays clean
+  const writeView = (next: URLSearchParams, key: string, value: string | null) => {
+    if (value) next.set(key, value);
+    else next.delete(key);
   };
-  const setSortBy = (s: AlbumSort) => {
-    setPage(1);
-    setSortByState(s);
-  };
+
+  const setPage = (p: number) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        writeView(next, "page", p > 1 ? String(p) : null);
+        return next;
+      },
+      { replace: true }
+    );
+
+  // a new filter or sort reshuffles the album, so the old page number means nothing
+  const setFilter = (f: AlbumFilter) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        writeView(next, "filter", f !== "all" ? f : null);
+        next.delete("page");
+        return next;
+      },
+      { replace: true }
+    );
+
+  const setSortBy = (s: AlbumSort) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        writeView(next, "sort", s !== "mostRare" ? s : null);
+        next.delete("page");
+        return next;
+      },
+      { replace: true }
+    );
 
   // the open item lives in the url, so returning from the market reopens it. items and
   // extras are disjoint by _id, so the first hit is unambiguous.

--- a/src/pages/Collections/CollectionDetail/albumParams.test.ts
+++ b/src/pages/Collections/CollectionDetail/albumParams.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { resolveFilter, resolvePage, resolveSort } from "./CollectionDetail.services";
+
+// these read straight off the query string, so anything can arrive here
+describe("album view params", () => {
+  it("falls back to the defaults when absent", () => {
+    expect(resolveFilter(null)).toBe("all");
+    expect(resolveSort(null)).toBe("mostRare");
+    expect(resolvePage(null)).toBe(1);
+  });
+
+  it("keeps the real values", () => {
+    expect(resolveFilter("duplicates")).toBe("duplicates");
+    expect(resolveSort("mostCommon")).toBe("mostCommon");
+    expect(resolvePage("3")).toBe(3);
+  });
+
+  it("rejects junk", () => {
+    expect(resolveFilter("nonsense")).toBe("all");
+    expect(resolveSort("cheapest")).toBe("mostRare");
+    expect(resolvePage("nonsense")).toBe(1);
+  });
+
+  it("rejects pages that are not a whole number above zero", () => {
+    expect(resolvePage("0")).toBe(1);
+    expect(resolvePage("-5")).toBe(1);
+    expect(resolvePage("2.5")).toBe(1);
+    expect(resolvePage("")).toBe(1);
+    expect(resolvePage("1e9")).toBe(1000000000);
+  });
+});

--- a/src/pages/Collections/CollectionsPanel.tsx
+++ b/src/pages/Collections/CollectionsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import CollectionsView from "./Collections.view";
 import { useCollectionsServices } from "./Collections.services";
 import CollectionDetailView from "./CollectionDetail/CollectionDetail.view";
@@ -29,9 +29,35 @@ const CollectionAlbum: React.FC<{
 };
 
 // the collections tab: shows the album grid, and swaps to a single case's album on
-// click without leaving the profile page.
+// click without leaving the profile page. the open case lives in the url so leaving
+// for the market and coming back restores it.
 const CollectionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
-  const [selectedCaseId, setSelectedCaseId] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedCaseId = searchParams.get("case");
+
+  // copy before writing: the params object is memoized on location.search, so
+  // mutating it in place corrupts the memo for the rest of this location.
+  const openCase = (caseId: string) =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("case", caseId);
+        next.delete("item");
+        return next;
+      },
+      { replace: true }
+    );
+
+  const back = () =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("case");
+        next.delete("item");
+        return next;
+      },
+      { replace: true }
+    );
 
   if (selectedCaseId) {
     return (
@@ -39,11 +65,11 @@ const CollectionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
         userId={userId}
         isOwner={isOwner}
         caseId={selectedCaseId}
-        onBack={() => setSelectedCaseId(null)}
+        onBack={back}
       />
     );
   }
-  return <CollectionSummary userId={userId} isOwner={isOwner} onOpenCase={setSelectedCaseId} />;
+  return <CollectionSummary userId={userId} isOwner={isOwner} onOpenCase={openCase} />;
 };
 
 export default CollectionsPanel;

--- a/src/pages/Collections/CollectionsPanel.tsx
+++ b/src/pages/Collections/CollectionsPanel.tsx
@@ -35,6 +35,15 @@ const CollectionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedCaseId = searchParams.get("case");
 
+  // the open item and the album view belong to whichever case was open, so they go
+  // whenever the case does: a duplicates filter must not leak into the next album.
+  const clearAlbum = (params: URLSearchParams) => {
+    params.delete("item");
+    params.delete("page");
+    params.delete("filter");
+    params.delete("sort");
+  };
+
   // copy before writing: the params object is memoized on location.search, so
   // mutating it in place corrupts the memo for the rest of this location.
   const openCase = (caseId: string) =>
@@ -42,7 +51,7 @@ const CollectionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
       (prev) => {
         const next = new URLSearchParams(prev);
         next.set("case", caseId);
-        next.delete("item");
+        clearAlbum(next);
         return next;
       },
       { replace: true }
@@ -53,7 +62,7 @@ const CollectionsPanel: React.FC<Props> = ({ userId, isOwner }) => {
       (prev) => {
         const next = new URLSearchParams(prev);
         next.delete("case");
-        next.delete("item");
+        clearAlbum(next);
         return next;
       },
       { replace: true }

--- a/src/pages/Market/Filters.tsx
+++ b/src/pages/Market/Filters.tsx
@@ -1,78 +1,90 @@
-import React, { useState, useEffect } from 'react';
-import Rarities from '../../components/Rarities';
-import { FiFilter } from 'react-icons/fi';
+import React, { useState, useEffect } from "react";
+import Rarities from "../../components/Rarities";
+import { FiSearch } from "react-icons/fi";
 
-interface FiltersProps {
-  filters: {
-    name: string;
-    rarity: string;
-    sortBy: string;
-    order: string;
-  };
-  setFilters: React.Dispatch<React.SetStateAction<{
-    name: string;
-    rarity: string;
-    sortBy: string;
-    order: string;
-  }>>;
+export interface MarketFilters {
+  name: string;
+  rarity: string;
+  sortBy: string;
+  order: string;
+  listedOnly: boolean;
 }
 
+interface FiltersProps {
+  filters: MarketFilters;
+  setFilters: React.Dispatch<React.SetStateAction<MarketFilters>>;
+}
+
+const SORTS = [
+  { value: "recent", label: "Recently listed" },
+  { value: "price", label: "Price" },
+  { value: "rarity", label: "Rarity" },
+  { value: "listings", label: "Most listings" },
+  { value: "name", label: "Name" },
+];
+
+const select =
+  "bg-surface-nav border border-line rounded-md px-3 py-2 text-sm text-ink-soft focus:border-accent outline-none";
+
+// always-visible filter bar. sorting actually works now: the backend used to accept
+// sortBy/order and silently ignore them.
 const Filters: React.FC<FiltersProps> = ({ filters, setFilters }) => {
-  const [localFilters, setLocalFilters] = useState(filters);
-  const [openFilters, setOpenFilters] = useState<boolean>(false);
+  const [name, setName] = useState(filters.name);
 
-
+  // debounce only the text field; selects apply immediately
   useEffect(() => {
     const handler = setTimeout(() => {
-      setFilters(localFilters);
-    }, 1500);
+      setFilters((prev) => (prev.name === name ? prev : { ...prev, name }));
+    }, 500);
+    return () => clearTimeout(handler);
+  }, [name, setFilters]);
 
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [localFilters]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
-    setLocalFilters(prev => ({ ...prev, [name]: value }));
-  };
+  const set = (patch: Partial<MarketFilters>) => setFilters((prev) => ({ ...prev, ...patch }));
 
   return (
-    <div className='w-full max-w-[1200px] md:-mt-[72px] mb-4 '  >
-      <div className="flex flex-col items-center md:items-end gap-4 mt-4 justify-end w-full">
-               <div onClick={() => setOpenFilters(!openFilters)} className="border p-2 rounded-md cursor-pointer">
-              <FiFilter className="text-2xl " />
-            </div>
-      {
-        openFilters && (
-          <div className="flex flex-col md:flex-row gap-4">
+    <div className="w-full max-w-[1312px] flex flex-wrap items-center gap-2">
+      <div className="relative flex-1 min-w-[180px]">
+        <FiSearch className="absolute left-3 top-1/2 -translate-y-1/2 text-ink-muted" />
         <input
           type="text"
-          name="name"
-          placeholder="Search by name"
-          value={localFilters.name}
-          onChange={handleChange}
-          className="border rounded px-4 py-2"
+          placeholder="Search items"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full bg-surface-nav border border-line rounded-md pl-9 pr-3 py-2 text-sm text-ink focus:border-accent outline-none"
         />
-        <select name="rarity" value={localFilters.rarity} onChange={handleChange} className="border rounded px-4 py-2">
-          <option value="">Rarity</option>
-          {Rarities.map((rarity, index) => (
-            <option key={index} value={rarity.id}>{rarity.name}</option>
-          ))}
-        </select>
-        <select name="sortBy" value={localFilters.sortBy} onChange={handleChange} className="border rounded px-4 py-2">
-          <option value="">Sort By</option>
-          <option value="price">Price</option>
-          <option value="rarity">Rarity</option>
-        </select>
-        <select name="order" value={localFilters.order} onChange={handleChange} className="border rounded px-4 py-2">
-          <option value="asc">Ascending</option>
-          <option value="desc">Descending</option>
-        </select>
       </div>
-        )
-      }
-    </div>
+
+      <select value={filters.rarity} onChange={(e) => set({ rarity: e.target.value })} className={select}>
+        <option value="">All rarities</option>
+        {Rarities.map((r) => (
+          <option key={r.id} value={r.id}>
+            {r.name}
+          </option>
+        ))}
+      </select>
+
+      <select value={filters.sortBy} onChange={(e) => set({ sortBy: e.target.value })} className={select}>
+        {SORTS.map((s) => (
+          <option key={s.value} value={s.value}>
+            {s.label}
+          </option>
+        ))}
+      </select>
+
+      <select value={filters.order} onChange={(e) => set({ order: e.target.value })} className={select}>
+        <option value="asc">Ascending</option>
+        <option value="desc">Descending</option>
+      </select>
+
+      <label className="flex items-center gap-2 text-sm text-ink-soft cursor-pointer select-none px-2">
+        <input
+          type="checkbox"
+          checked={filters.listedOnly}
+          onChange={(e) => set({ listedOnly: e.target.checked })}
+          className="accent-indigo-600"
+        />
+        On sale only
+      </label>
     </div>
   );
 };

--- a/src/pages/Market/ItemPage.tsx
+++ b/src/pages/Market/ItemPage.tsx
@@ -202,7 +202,7 @@ const ItemPage: React.FC = () => {
         {/* item header */}
         <div className="flex items-center gap-4 rounded-xl border border-line bg-surface p-4">
           <div
-            className="w-20 h-20 shrink-0 rounded-lg bg-surface-nav flex items-center justify-center border-b-4"
+            className="w-20 h-20 shrink-0 rounded-t-lg bg-surface-nav flex items-center justify-center border-b-4"
             style={{ borderColor: color }}
           >
             {item ? (

--- a/src/pages/Market/ItemPage.tsx
+++ b/src/pages/Market/ItemPage.tsx
@@ -73,6 +73,7 @@ const ItemPage: React.FC = () => {
 
   const [history, setHistory] = useState<ItemHistory | null>(null);
   const [loadingHistory, setLoadingHistory] = useState<boolean>(true);
+  const [historyError, setHistoryError] = useState<boolean>(false);
   const [range, setRange] = useState<string>("week");
   const [book, setBook] = useState<{ price: number; quantity: number }[]>([]);
   const [myOrders, setMyOrders] = useState<BuyOrder[]>([]);
@@ -81,6 +82,11 @@ const ItemPage: React.FC = () => {
     setLoading(true);
     try {
       const data = await getItemListings(itemId as string, page);
+      // buying the last listing on a page would otherwise strand you on an empty one
+      if (page > 1 && data.items.length === 0 && data.totalPages >= 1) {
+        setPage(Math.min(page - 1, Math.max(1, data.totalPages)));
+        return;
+      }
       setItems(data);
     } catch (error) {
       console.log(error);
@@ -95,8 +101,10 @@ const ItemPage: React.FC = () => {
       const [h, o] = await Promise.all([getItemHistory(itemId, range), getItemOrders(itemId)]);
       setHistory(h);
       setBook(o.orders || []);
+      setHistoryError(false);
     } catch (error) {
       console.log(error);
+      setHistoryError(true);
     } finally {
       setLoadingHistory(false);
     }
@@ -177,6 +185,20 @@ const ItemPage: React.FC = () => {
       )}
 
       <div className="w-full max-w-[1312px] px-4 md:px-8 py-6 flex flex-col gap-6">
+        {historyError && (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-300 flex items-center justify-between gap-3">
+            <span>Could not load market data for this item.</span>
+            <button
+              onClick={() => {
+                setLoadingHistory(true);
+                fetchMarketData();
+              }}
+              className="px-3 py-1 rounded border border-red-400/50 text-xs hover:bg-red-500/20"
+            >
+              Retry
+            </button>
+          </div>
+        )}
         {/* item header */}
         <div className="flex items-center gap-4 rounded-xl border border-line bg-surface p-4">
           <div

--- a/src/pages/Market/ItemPage.tsx
+++ b/src/pages/Market/ItemPage.tsx
@@ -1,12 +1,26 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { getItemListings, removeListing } from "../../services/market/MarketService";
+import { toast } from "react-toastify";
+import {
+  getItemListings,
+  getItemHistory,
+  getItemOrders,
+  getMyOrders,
+  cancelBuyOrder,
+  removeListing,
+  ItemHistory,
+  BuyOrder,
+} from "../../services/market/MarketService";
 import Item from "./Item";
 import Pagination from "../../components/Pagination";
 import Skeleton from "react-loading-skeleton";
+import Monetary from "../../components/Monetary";
+import PriceChart from "../../components/PriceChart";
+import { rarityColor, rarityName } from "../../utils/rarity";
 import { IMarketItem } from "../../components/Types";
 import SellItemModal from "./SellItemModal";
 import ConfirmPurchaseModal from "./ConfirmPurchaseModal";
+import PlaceBuyOrderModal from "./PlaceBuyOrderModal";
 
 interface ItemData {
   totalPages: number;
@@ -16,22 +30,34 @@ interface ItemData {
 
 const defaultItem: IMarketItem = {
   _id: "",
-  sellerId: {
-    _id: "",
-    username: "",
-  },
-  item: {
-    _id: "",
-    name: "",
-    image: "",
-    uniqueId: "",
-  },
+  sellerId: { _id: "", username: "" },
+  item: { _id: "", name: "", image: "", uniqueId: "" },
   price: 0,
   itemName: "",
   itemImage: "",
   __v: 0,
   uniqueId: "",
 };
+
+const RANGES = [
+  { key: "week", label: "Week" },
+  { key: "month", label: "Month" },
+  { key: "year", label: "Year" },
+  { key: "lifetime", label: "Lifetime" },
+];
+
+const Stat: React.FC<{ label: string; value: React.ReactNode; hint?: string; accent?: string }> = ({
+  label,
+  value,
+  hint,
+  accent,
+}) => (
+  <div className="flex flex-col gap-0.5 rounded-lg border border-line bg-surface px-3 py-2 min-w-0">
+    <span className="text-[10px] uppercase tracking-wide text-ink-muted">{label}</span>
+    <span className={`text-base font-semibold truncate ${accent || "text-ink"}`}>{value}</span>
+    {hint && <span className="text-[10px] text-ink-faint truncate">{hint}</span>}
+  </div>
+);
 
 const ItemPage: React.FC = () => {
   const { itemId } = useParams<{ itemId: string }>();
@@ -41,111 +67,298 @@ const ItemPage: React.FC = () => {
   const [loadingRemoval, setLoadingRemoval] = useState<boolean>(false);
   const [openBuyModal, setOpenBuyModal] = useState<boolean>(false);
   const [openSellModal, setOpenSellModal] = useState<boolean>(false);
+  const [openOrderModal, setOpenOrderModal] = useState<boolean>(false);
   const [refresh, setRefresh] = useState<boolean>(false);
   const [selectedItem, setSelectedItem] = useState<IMarketItem>(defaultItem);
 
+  const [history, setHistory] = useState<ItemHistory | null>(null);
+  const [loadingHistory, setLoadingHistory] = useState<boolean>(true);
+  const [range, setRange] = useState<string>("week");
+  const [book, setBook] = useState<{ price: number; quantity: number }[]>([]);
+  const [myOrders, setMyOrders] = useState<BuyOrder[]>([]);
 
-  const fetchItemListings = async () => {
+  const fetchItemListings = useCallback(async () => {
     setLoading(true);
     try {
-      const items = await getItemListings(itemId as string, page);
-      setItems(items);
-      setLoading(false);
+      const data = await getItemListings(itemId as string, page);
+      setItems(data);
     } catch (error) {
       console.log(error);
     } finally {
       setLoading(false);
     }
-  };
+  }, [itemId, page]);
+
+  const fetchMarketData = useCallback(async () => {
+    if (!itemId) return;
+    try {
+      const [h, o] = await Promise.all([getItemHistory(itemId, range), getItemOrders(itemId)]);
+      setHistory(h);
+      setBook(o.orders || []);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setLoadingHistory(false);
+    }
+    // my orders only exist when logged in; a failure here is not an error state
+    try {
+      const mine = await getMyOrders();
+      setMyOrders((mine.orders || []).filter((o) => String(o.item) === String(itemId)));
+    } catch {
+      setMyOrders([]);
+    }
+  }, [itemId, range]);
 
   useEffect(() => {
     if (refresh) {
       fetchItemListings();
+      fetchMarketData();
       setRefresh(false);
     }
-  }, [refresh]);
-
-
-  useEffect(() => {
-    fetchItemListings();
-  }, [page]);
+  }, [refresh, fetchItemListings, fetchMarketData]);
 
   useEffect(() => {
     fetchItemListings();
-  }, [itemId]);
+  }, [fetchItemListings]);
 
-  
+  useEffect(() => {
+    setLoadingHistory(true);
+    fetchMarketData();
+  }, [fetchMarketData]);
+
   const buyItem = (item: IMarketItem) => {
     setSelectedItem(item);
     setOpenBuyModal(true);
-  }
+  };
 
   const removeItem = async (item: IMarketItem) => {
-    setLoadingRemoval(true)
+    setLoadingRemoval(true);
     try {
       await removeListing(item.uniqueId);
       setRefresh(true);
-    } catch(err) {
+    } catch (err) {
       console.log(err);
-    }finally{
-      setLoadingRemoval(false)
+    } finally {
+      setLoadingRemoval(false);
     }
-  }
+  };
 
+  const cancelOrder = async (id: string) => {
+    try {
+      const res = await cancelBuyOrder(id);
+      toast.success(`Order cancelled, K₽${res.refunded} refunded`);
+      setRefresh(true);
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || "Could not cancel the order");
+    }
+  };
+
+  const stats = history?.stats;
+  const item = history?.item;
+  const color = item ? rarityColor(item.rarity) : "#ffffff";
 
   return (
-    <div className="flex flex-col w-screen items-center justify-center">
-           <SellItemModal
-        isOpen={openSellModal}
-        onClose={() => setOpenSellModal(false)}
-        setRefresh={setRefresh}
-      />
+    <div className="flex flex-col w-full items-center">
+      <SellItemModal isOpen={openSellModal} onClose={() => setOpenSellModal(false)} setRefresh={setRefresh} />
       <ConfirmPurchaseModal
         isOpen={openBuyModal}
         onClose={() => setOpenBuyModal(false)}
         item={selectedItem}
         setRefresh={setRefresh}
       />
-      <h1 className="text-3xl font-bold mb-6">Item Listings</h1>
-      {
-        items?.totalPages && items?.totalPages > 1 && (
-          <Pagination totalPages={items.totalPages} currentPage={page} setPage={setPage} />
-        )
-      }
-      {loading ? (
-        <div className="flex flex-wrap items-center gap-4 justify-center px-8 ">
-          {Array(10)
-            .fill(0)
-            .map((_, i) => (
-              <div key={i} className="w-[226px] h-[334px]  ">
-                <Skeleton height={334} width={226} />
-              </div>
-            ))}
+      {item && (
+        <PlaceBuyOrderModal
+          isOpen={openOrderModal}
+          onClose={() => setOpenOrderModal(false)}
+          item={{ _id: item._id, name: item.name, image: item.image }}
+          stats={stats}
+          onPlaced={() => setRefresh(true)}
+        />
+      )}
+
+      <div className="w-full max-w-[1312px] px-4 md:px-8 py-6 flex flex-col gap-6">
+        {/* item header */}
+        <div className="flex items-center gap-4 rounded-xl border border-line bg-surface p-4">
+          <div
+            className="w-20 h-20 shrink-0 rounded-lg bg-surface-nav flex items-center justify-center border-b-4"
+            style={{ borderColor: color }}
+          >
+            {item ? (
+              <img src={item.image} alt={item.name} className="max-h-16 max-w-16 object-contain" />
+            ) : (
+              <Skeleton width={56} height={56} />
+            )}
+          </div>
+          <div className="flex flex-col min-w-0">
+            <h1 className="text-2xl font-bold truncate" style={{ color }}>
+              {item ? item.name : <Skeleton width={180} />}
+            </h1>
+            <span className="text-xs" style={{ color }}>
+              {item ? rarityName(item.rarity) : ""}
+            </span>
+          </div>
+          <div className="ml-auto flex gap-2">
+            <button
+              onClick={() => setOpenOrderModal(true)}
+              className="px-4 h-10 rounded-md border border-accent-gold/50 text-accent-gold text-sm font-semibold hover:bg-accent-gold/10"
+            >
+              Place buy order
+            </button>
+            <button
+              onClick={() => setOpenSellModal(true)}
+              className="px-4 h-10 rounded-md bg-accent hover:bg-accent-light text-sm font-semibold text-white"
+            >
+              Sell an item
+            </button>
+          </div>
         </div>
-      ) : (
-        <div className="flex flex-wrap items-center gap-4 justify-center px-8 max-w-[1600px]">
-          {items && items.items && items.items.length > 0 ? (items.items.map((item) => (
-            <Item
-              key={item._id}
-              item={item}
-              click={() => buyItem(item)}
-              remove={() => removeItem(item)}
-              loadingRemoval={loadingRemoval}
-            />
-          ))) : (
-            <div className="flex flex-col items-center justify-center w-full">
-              <h1 className="text-2xl font-bold text-center">
-                There are no listings for this item.
-              </h1>
+
+        {/* the numbers a trader actually needs */}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+          <Stat
+            label="Lowest listing"
+            value={stats?.lowestListing ? <Monetary value={stats.lowestListing} /> : "None"}
+            hint={stats ? `${stats.totalListings} on sale` : ""}
+            accent="text-accent"
+          />
+          <Stat
+            label="Median (7d)"
+            value={stats?.median7d ? <Monetary value={stats.median7d} /> : "No sales"}
+            hint={stats ? `${stats.volume7d} sold` : ""}
+          />
+          <Stat
+            label="Median (30d)"
+            value={stats?.median30d ? <Monetary value={stats.median30d} /> : "No sales"}
+            hint={stats ? `${stats.volume30d} sold` : ""}
+          />
+          <Stat
+            label="Best buy order"
+            value={stats?.bestBid ? <Monetary value={stats.bestBid} /> : "No bids"}
+            accent="text-accent-gold"
+          />
+          <Stat
+            label="House floor"
+            value={stats ? <Monetary value={stats.floor} /> : "-"}
+            hint="instant sell price"
+            accent="text-ink-muted"
+          />
+        </div>
+
+        {/* price history */}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <h2 className="text-lg font-semibold text-ink">Median sale prices</h2>
+            <div className="inline-flex rounded-lg border border-line overflow-hidden">
+              {RANGES.map((r) => (
+                <button
+                  key={r.key}
+                  onClick={() => setRange(r.key)}
+                  className={`px-3 py-1.5 text-xs font-semibold transition-colors ${
+                    range === r.key ? "bg-surface-raised text-ink" : "text-ink-muted hover:text-ink"
+                  }`}
+                >
+                  {r.label}
+                </button>
+              ))}
             </div>
+          </div>
+          <PriceChart points={history?.points || []} floor={stats?.floor} height={240} loading={loadingHistory} />
+          {stats?.lastSale && (
+            <span className="text-xs text-ink-muted">
+              Last sold for <Monetary value={stats.lastSale.price} /> on{" "}
+              {new Date(stats.lastSale.soldAt).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}
+            </span>
           )}
         </div>
-      )}
-      {
-        items?.totalPages && items?.totalPages > 1 && (
-          <Pagination totalPages={items.totalPages} currentPage={page} setPage={setPage} />
-        )
-      }
+
+        {/* buy orders */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="rounded-xl border border-line bg-surface p-4 flex flex-col gap-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-ink-muted">Buy orders</h3>
+            {book.length === 0 ? (
+              <span className="text-sm text-ink-muted py-2">Nobody is bidding on this item yet.</span>
+            ) : (
+              <div className="flex flex-col gap-1">
+                {book.slice(0, 6).map((b) => (
+                  <div key={b.price} className="flex items-center justify-between text-sm">
+                    <span className="text-accent-gold font-semibold">
+                      <Monetary value={b.price} />
+                    </span>
+                    <span className="text-ink-muted text-xs">
+                      {b.quantity} wanted
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-line bg-surface p-4 flex flex-col gap-2">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-ink-muted">Your orders</h3>
+            {myOrders.length === 0 ? (
+              <span className="text-sm text-ink-muted py-2">You have no buy orders for this item.</span>
+            ) : (
+              myOrders.map((o) => (
+                <div key={o._id} className="flex items-center justify-between gap-2 text-sm">
+                  <span className="text-ink">
+                    <Monetary value={o.price} /> x{o.quantity - o.filled}
+                    <span className="text-ink-faint text-xs"> · K₽{o.escrow} held</span>
+                  </span>
+                  <button
+                    onClick={() => cancelOrder(o._id)}
+                    className="px-2 py-1 rounded border border-line text-xs text-ink-muted hover:text-red-400 hover:border-red-400/50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* listings */}
+        <div className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold text-ink">
+            Listings {items?.items?.length ? `(${stats?.totalListings ?? items.items.length})` : ""}
+          </h2>
+          {loading ? (
+            <div className="flex flex-wrap items-center gap-4">
+              {Array(6)
+                .fill(0)
+                .map((_, i) => (
+                  <Skeleton key={i} height={334} width={226} />
+                ))}
+            </div>
+          ) : items && items.items && items.items.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-4">
+              {items.items.map((it) => (
+                <Item
+                  key={it._id}
+                  item={it}
+                  click={() => buyItem(it)}
+                  remove={() => removeItem(it)}
+                  loadingRemoval={loadingRemoval}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-line bg-surface p-8 text-center flex flex-col items-center gap-3">
+              <span className="text-ink-muted">Nobody is selling this item right now.</span>
+              <button
+                onClick={() => setOpenOrderModal(true)}
+                className="px-4 h-10 rounded-md border border-accent-gold/50 text-accent-gold text-sm font-semibold hover:bg-accent-gold/10"
+              >
+                Place a buy order instead
+              </button>
+            </div>
+          )}
+          {items?.totalPages && items.totalPages > 1 ? (
+            <div className="flex justify-center">
+              <Pagination totalPages={items.totalPages} currentPage={page} setPage={setPage} />
+            </div>
+          ) : null}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/pages/Market/MarketItem.tsx
+++ b/src/pages/Market/MarketItem.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
-import MainButton from "../../components/MainButton";
-import { Link } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
-import Rarities from "../../components/Rarities";
+import Monetary from "../../components/Monetary";
+import { rarityColor, rarityName } from "../../utils/rarity";
 
 interface Props {
   item: {
@@ -10,62 +9,70 @@ interface Props {
     name: string;
     rarity: number;
     _id: string;
-    uniqueId: string
-    cheapestPrice: number;
+    uniqueId: string;
+    cheapestPrice: number | null;
     totalListings: number;
-  }
+    sellValue?: number;
+  };
 }
 
+// one item on the market: rarity-framed art, what it starts at, and how deep the
+// book is. an item with no listings is still shown so it can be bid on.
 const MarketItem: React.FC<Props> = ({ item }) => {
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loaded, setLoaded] = useState<boolean>(false);
   const navigate = useNavigate();
-
-  const handleImageLoad = () => {
-    setLoading(false);
-  };
-
-  const color = Rarities.find((rarity) => rarity.id== item?.rarity)?.color || "white";
-
-
+  const color = rarityColor(item.rarity);
+  const listed = item.totalListings > 0;
 
   return (
-    <div className="border border-[#161448] rounded-lg p-4 bg-gradient-to-tr from-[#1D1730] to-[#141333] transition-all duration-500 ease-in-out w-[226px] h-[334px]">
-      <div className="flex items-center gap-2 relative">
-      <div className={`w-1 h-1 md:h-2 md:w-2 aspect-square rounded-full`} style={{
-          backgroundColor: color
-        }} />
-        <span className="text-lg font-semibold text-white truncate">
-      
-        {item.name}
-        </span>
-
-      </div>
-      {loading && (
-        <div className="w-full h-48 flex items-center justify-center">
-          <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-[#606BC7]"></div>
-        </div>
-      )}
-      <Link to={`/marketplace/item/${item._id}`}>
+    <button
+      type="button"
+      onClick={() => navigate(`/marketplace/item/${item._id}`)}
+      className="group w-[200px] rounded-xl border border-line bg-surface hover:border-line-strong hover:-translate-y-1 transition-all overflow-hidden text-left"
+    >
+      <div
+        className="relative h-40 flex items-center justify-center bg-surface-nav border-b-2"
+        style={{ borderColor: color }}
+      >
+        {!loaded && <div className="absolute inset-0 animate-pulse bg-surface-nav" />}
         <img
           src={item.image}
           alt={item.name}
-          className={`mb-2 w-full h-48 object-cover rounded ${loading ? "hidden" : ""
-            }`}
-          onLoad={handleImageLoad}
+          onLoad={() => setLoaded(true)}
+          className={`max-h-32 max-w-[80%] object-contain transition-all group-hover:scale-105 ${
+            loaded ? "" : "opacity-0"
+          }`}
+          style={{ filter: `drop-shadow(0 0 14px ${color}55)` }}
         />
-      </Link>
-      <p className="text-blue-500 text-center py-1 text-ellipsis truncate">
-            {item.totalListings} announced
-      </p>
-      <MainButton textSize="text-sm" text={`Starting at ${new Intl.NumberFormat("en-US", {
-          style: "currency",
-          currency: "DOL",
-          minimumFractionDigits: 0,
-        })
-          .format(item.cheapestPrice)
-          .replace("DOL", "K₽")}`} onClick={() => navigate(`/marketplace/item/${item._id}`)}  />
+        {listed && (
+          <span className="absolute top-2 right-2 rounded-full bg-surface/90 border border-line px-2 py-0.5 text-[10px] text-ink-muted">
+            {item.totalListings}
+          </span>
+        )}
+      </div>
 
-    </div>
+      <div className="p-3 flex flex-col gap-1">
+        <span className="text-sm font-semibold text-ink truncate">{item.name}</span>
+        <span className="text-[10px]" style={{ color }}>
+          {rarityName(item.rarity)}
+        </span>
+        <div className="mt-1 flex items-end justify-between gap-2">
+          {listed ? (
+            <div className="flex flex-col min-w-0">
+              <span className="text-[10px] text-ink-muted">Starting at</span>
+              <span className="text-sm font-bold text-accent truncate">
+                <Monetary value={item.cheapestPrice || 0} />
+              </span>
+            </div>
+          ) : (
+            <span className="text-xs text-ink-faint">No listings</span>
+          )}
+          <span className="text-[10px] text-ink-faint shrink-0 group-hover:text-ink-muted">
+            {listed ? "View" : "Place bid"}
+          </span>
+        </div>
+      </div>
+    </button>
   );
 };
 

--- a/src/pages/Market/Marketplace.tsx
+++ b/src/pages/Market/Marketplace.tsx
@@ -44,15 +44,19 @@ const Marketplace: React.FC = () => {
 
   const { isLogged } = useContext(UserContext);
 
+  // a filter change also resets the page, which would fire a second overlapping
+  // request; the sequence guard makes sure only the newest response is rendered
+  const reqSeq = React.useRef(0);
   const fetchItems = useCallback(async () => {
+    const seq = ++reqSeq.current;
     setLoading(true);
     try {
       const data = await getItems(page, filters);
-      setItems(data);
+      if (seq === reqSeq.current) setItems(data);
     } catch (error) {
       console.log(error);
     } finally {
-      setLoading(false);
+      if (seq === reqSeq.current) setLoading(false);
     }
   }, [page, filters]);
 

--- a/src/pages/Market/Marketplace.tsx
+++ b/src/pages/Market/Marketplace.tsx
@@ -1,32 +1,30 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import MarketItem from "./MarketItem";
-import { getItems } from "../../services/market/MarketService";
+import { getItems, getMyOrders, cancelBuyOrder, BuyOrder } from "../../services/market/MarketService";
 import SellItemModal from "./SellItemModal";
-import MainButton from "../../components/MainButton";
-import Title from "../../components/Title";
 import Skeleton from "react-loading-skeleton";
 import UserContext from "../../UserContext";
 import Pagination from "../../components/Pagination";
-import Filters from "./Filters";
+import Monetary from "../../components/Monetary";
+import Filters, { MarketFilters } from "./Filters";
+import { toast } from "react-toastify";
+import { Link } from "react-router-dom";
 
-
-interface Props {
-
-    image: string;
-    name: string;
-    rarity: number;
-    _id: string;
-    uniqueId: string
-    cheapestPrice: number;
-    totalListings: number;
-  
+interface MarketRow {
+  image: string;
+  name: string;
+  rarity: number;
+  _id: string;
+  uniqueId: string;
+  cheapestPrice: number | null;
+  totalListings: number;
+  sellValue?: number;
 }
-
 
 interface ItemData {
   totalPages: number;
   currentPage: number;
-  items: Props[];
+  items: MarketRow[];
 }
 
 const Marketplace: React.FC = () => {
@@ -35,105 +33,156 @@ const Marketplace: React.FC = () => {
   const [openSellModal, setOpenSellModal] = useState<boolean>(false);
   const [refresh, setRefresh] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
-  const [filters, setFilters] = useState({
-    name: '',
-    rarity: '',
-    sortBy: '',
-    order: 'asc'
+  const [orders, setOrders] = useState<BuyOrder[]>([]);
+  const [filters, setFilters] = useState<MarketFilters>({
+    name: "",
+    rarity: "",
+    sortBy: "recent",
+    order: "desc",
+    listedOnly: true,
   });
 
   const { isLogged } = useContext(UserContext);
 
-  const fetchItems = async () => {
+  const fetchItems = useCallback(async () => {
     setLoading(true);
     try {
-      const items = await getItems(page, filters);
-      setItems(items);
-      setLoading(false);
+      const data = await getItems(page, filters);
+      setItems(data);
     } catch (error) {
       console.log(error);
     } finally {
       setLoading(false);
     }
-  };
+  }, [page, filters]);
+
+  const fetchOrders = useCallback(async () => {
+    if (!isLogged) {
+      setOrders([]);
+      return;
+    }
+    try {
+      const mine = await getMyOrders();
+      setOrders(mine.orders || []);
+    } catch {
+      setOrders([]);
+    }
+  }, [isLogged]);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  useEffect(() => {
+    fetchOrders();
+  }, [fetchOrders]);
 
   useEffect(() => {
     if (refresh) {
       fetchItems();
+      fetchOrders();
       setRefresh(false);
     }
-  }, [refresh]);
+  }, [refresh, fetchItems, fetchOrders]);
 
+  // filters change the result set: go back to the first page
   useEffect(() => {
-    setRefresh(true);
-    scrollTo(0, 0);
-  }, [page]);
-
-  useEffect(() => {
-    fetchItems();
+    setPage(1);
   }, [filters]);
 
+  const cancel = async (id: string) => {
+    try {
+      const res = await cancelBuyOrder(id);
+      toast.success(`Order cancelled, K₽${res.refunded} refunded`);
+      setRefresh(true);
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || "Could not cancel the order");
+    }
+  };
+
   return (
-    <div className="flex flex-col w-screen items-center justify-center ">
-      <SellItemModal
-        isOpen={openSellModal}
-        onClose={() => setOpenSellModal(false)}
-        setRefresh={setRefresh}
-      />
-      <div className="flex items-center justify-center w-full max-w-[1600px] relative ">
-        <Title title="Marketplace" />
+    <div className="flex flex-col w-full items-center">
+      <SellItemModal isOpen={openSellModal} onClose={() => setOpenSellModal(false)} setRefresh={setRefresh} />
 
-        <div className="absolute md:right-24 -top-6 md:top-0">
+      <div className="w-full max-w-[1312px] px-4 md:px-8 py-6 flex flex-col gap-5">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div className="flex flex-col">
+            <h1 className="text-2xl font-bold text-ink">Marketplace</h1>
+            <span className="text-xs text-ink-muted">
+              Buy from other players, or place a buy order and let the market come to you.
+            </span>
+          </div>
           {isLogged && (
-            <div className="w-52">
-
-              <MainButton
-                onClick={() => setOpenSellModal(true)}
-                text="Sell an item"
-              />
-            </div>
+            <button
+              onClick={() => setOpenSellModal(true)}
+              className="px-4 h-10 rounded-md bg-accent hover:bg-accent-light text-sm font-semibold text-white"
+            >
+              Sell an item
+            </button>
           )}
         </div>
-      </div>
-      {
-        items?.totalPages && items?.totalPages > 1 && (
-          <Pagination totalPages={items.totalPages} currentPage={page} setPage={setPage} />
-        )
-      }
-            <Filters filters={filters} setFilters={setFilters} />
 
-      {loading ? (
-        <div className="flex flex-wrap items-center gap-4 justify-center px-8 ">
-          {Array(10)
-            .fill(0)
-            .map((_, i) => (
-              <div key={i} className="w-[226px] h-[334px]  ">
-                <Skeleton height={334} width={226} />
-              </div>
+        <Filters filters={filters} setFilters={setFilters} />
+
+        {/* your open buy orders, so escrowed KP is never invisible */}
+        {isLogged && orders.length > 0 && (
+          <div className="rounded-xl border border-accent-gold/30 bg-accent-gold/[0.04] p-3 flex flex-col gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wide text-accent-gold">
+              Your buy orders ({orders.length})
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {orders.map((o) => (
+                <div
+                  key={o._id}
+                  className="flex items-center gap-2 rounded-lg border border-line bg-surface px-2 py-1.5"
+                >
+                  <img src={o.itemImage} alt="" className="w-7 h-7 object-contain" />
+                  <div className="flex flex-col">
+                    <Link to={`/marketplace/item/${o.item}`} className="text-xs text-ink hover:underline truncate max-w-[140px]">
+                      {o.itemName}
+                    </Link>
+                    <span className="text-[10px] text-ink-muted">
+                      <Monetary value={o.price} /> x{o.quantity - o.filled} · <Monetary value={o.escrow} /> held
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => cancel(o._id)}
+                    className="ml-1 text-[10px] text-ink-faint hover:text-red-400"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex flex-wrap gap-4">
+            {Array(12)
+              .fill(0)
+              .map((_, i) => (
+                <Skeleton key={i} height={260} width={200} borderRadius={12} />
+              ))}
+          </div>
+        ) : items && items.items && items.items.length > 0 ? (
+          <div className="flex flex-wrap gap-4">
+            {items.items.map((item) => (
+              <MarketItem key={item._id} item={item} />
             ))}
-        </div>
-      ) : (
-        <div className="flex flex-wrap items-center gap-4 justify-center px-8  max-w-[1600px]">
-          {items && items.items && items.items.length > 0 ? (items.items.map((item) => (
-            <MarketItem
-              key={item._id}
-              item={item}
-        
-            />
-          ))) : (
-            <div className="flex flex-col items-center justify-center w-full">
-              <h1 className="text-2xl font-bold text-center">
-                There's no items for sale, try again later
-              </h1>
-            </div>
-          )}
-        </div>
-      )}
-      {
-        items?.totalPages && items?.totalPages > 1 && (
-          <Pagination totalPages={items.totalPages} currentPage={page} setPage={setPage} />
-        )
-      }
+          </div>
+        ) : (
+          <div className="rounded-xl border border-line bg-surface p-12 text-center text-ink-muted">
+            Nothing matches those filters.
+          </div>
+        )}
+
+        {items?.totalPages && items.totalPages > 1 ? (
+          <div className="flex justify-center">
+            <Pagination totalPages={items.totalPages} currentPage={page} setPage={setPage} />
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/src/pages/Market/PlaceBuyOrderModal.tsx
+++ b/src/pages/Market/PlaceBuyOrderModal.tsx
@@ -101,17 +101,19 @@ const PlaceBuyOrderModal: React.FC<Props> = ({ isOpen, onClose, item, stats, onP
 
         <div className="rounded border border-line bg-surface p-3 text-xs flex flex-col gap-1">
           <div className="flex justify-between">
-            <span className="text-ink-muted">Total held in escrow</span>
+            <span className="text-ink-muted">Charged now, up to</span>
             <span className="text-ink font-semibold">
               <Monetary value={total} />
             </span>
           </div>
-          <span className="text-ink-faint">
-            Charged now and refunded in full if you cancel. This guarantees your order can pay when it matches.
-          </span>
-          {fillsNow && (
+          {fillsNow ? (
             <span className="text-accent-gold">
-              At this price part of your order fills immediately from existing listings.
+              Anything already listed at or below your bid is bought immediately (spent, not refundable).
+              Only the unfilled rest is held as escrow and refunded if you cancel.
+            </span>
+          ) : (
+            <span className="text-ink-faint">
+              Held as escrow and refunded in full if you cancel. This guarantees your order can pay when it matches.
             </span>
           )}
         </div>

--- a/src/pages/Market/PlaceBuyOrderModal.tsx
+++ b/src/pages/Market/PlaceBuyOrderModal.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { toast } from "react-toastify";
+import Modal from "../../components/Modal";
+import MainButton from "../../components/MainButton";
+import Monetary from "../../components/Monetary";
+import { placeBuyOrder, MarketStats } from "../../services/market/MarketService";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  item: { _id: string; name: string; image: string };
+  stats?: MarketStats | null;
+  onPlaced?: () => void;
+}
+
+// place a standing offer to buy. funds are escrowed up front, so the order can always
+// pay when it matches; anything already listed at or below the bid fills immediately.
+const PlaceBuyOrderModal: React.FC<Props> = ({ isOpen, onClose, item, stats, onPlaced }) => {
+  const [price, setPrice] = useState<number>(0);
+  const [quantity, setQuantity] = useState<number>(1);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  if (!isOpen) return null;
+
+  const total = (price || 0) * (quantity || 1);
+  const fillsNow = !!(stats?.lowestListing && price >= stats.lowestListing);
+
+  const submit = async () => {
+    if (!price || price < 1 || price > 1000000) return toast.error("Price must be between 1 and 1.000.000");
+    if (!quantity || quantity < 1 || quantity > 20) return toast.error("Quantity must be between 1 and 20");
+    setLoading(true);
+    try {
+      const res = await placeBuyOrder(item._id, price, quantity);
+      if (res.filled > 0 && res.order) {
+        toast.success(`Bought ${res.filled} now, ${res.order.quantity} left as a buy order`);
+      } else if (res.filled > 0) {
+        toast.success(`Bought ${res.filled} instantly`);
+      } else {
+        toast.success("Buy order placed");
+      }
+      if (res.message) toast.info(res.message);
+      onPlaced && onPlaced();
+      onClose();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || "Could not place the order");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal open={isOpen} setOpen={onClose} width="min(460px, 95vw)">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-3">
+          <img src={item.image} alt={item.name} className="w-12 h-12 object-contain" />
+          <div className="flex flex-col">
+            <h3 className="font-semibold text-ink">Place a buy order</h3>
+            <span className="text-xs text-ink-muted">{item.name}</span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          <div className="rounded border border-line bg-surface p-2">
+            <div className="text-ink-muted">Lowest listing</div>
+            <div className="text-accent font-semibold">
+              {stats?.lowestListing ? <Monetary value={stats.lowestListing} /> : "None"}
+            </div>
+          </div>
+          <div className="rounded border border-line bg-surface p-2">
+            <div className="text-ink-muted">Median (7d)</div>
+            <div className="text-ink font-semibold">
+              {stats?.median7d ? <Monetary value={stats.median7d} /> : "No sales"}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <label className="flex flex-col gap-1 flex-1">
+            <span className="text-xs text-ink-muted">Price each</span>
+            <input
+              type="number"
+              min={1}
+              max={1000000}
+              value={price || ""}
+              onChange={(e) => setPrice(parseInt(e.target.value) || 0)}
+              className="bg-surface-nav border border-line focus:border-accent outline-none rounded px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="flex flex-col gap-1 w-24">
+            <span className="text-xs text-ink-muted">Quantity</span>
+            <input
+              type="number"
+              min={1}
+              max={20}
+              value={quantity}
+              onChange={(e) => setQuantity(parseInt(e.target.value) || 1)}
+              className="bg-surface-nav border border-line focus:border-accent outline-none rounded px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+
+        <div className="rounded border border-line bg-surface p-3 text-xs flex flex-col gap-1">
+          <div className="flex justify-between">
+            <span className="text-ink-muted">Total held in escrow</span>
+            <span className="text-ink font-semibold">
+              <Monetary value={total} />
+            </span>
+          </div>
+          <span className="text-ink-faint">
+            Charged now and refunded in full if you cancel. This guarantees your order can pay when it matches.
+          </span>
+          {fillsNow && (
+            <span className="text-accent-gold">
+              At this price part of your order fills immediately from existing listings.
+            </span>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <button onClick={onClose} className="px-4 py-2 rounded bg-surface-raised text-sm font-semibold">
+            Cancel
+          </button>
+          <div className="flex-1">
+            <MainButton
+              text="Place buy order"
+              onClick={submit}
+              loading={loading}
+              disabled={loading || !price}
+            />
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PlaceBuyOrderModal;

--- a/src/pages/Market/SellItemModal.tsx
+++ b/src/pages/Market/SellItemModal.tsx
@@ -164,9 +164,12 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
   const stats = history?.stats;
   const feeRate = stats?.feeRate ?? 0.05;
   const p = price || 0;
-  const fee = Math.floor(p * feeRate);
-  const receive = Math.max(0, p - fee);
   const crossesBid = !!(stats?.bestBid && p > 0 && p <= stats.bestBid);
+  // an ask that crosses a resting bid clears at the BID, not the ask: quote what the
+  // seller will actually be paid, not what they typed
+  const clearsAt = crossesBid ? (stats?.bestBid as number) : p;
+  const fee = Math.floor(clearsAt * feeRate);
+  const receive = Math.max(0, clearsAt - fee);
 
   return (
     <Modal open={isOpen} setOpen={onClose} width="min(980px, 95vw)">
@@ -294,7 +297,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
                     {p > 0 && (
                       <span className="text-xs text-ink-muted">
                         You receive <span className="text-accent-gold font-semibold"><Monetary value={receive} /></span>
-                        {" "}· buyer pays <Monetary value={p} /> ({Math.round(feeRate * 100)}% fee <Monetary value={fee} />)
+                        {" "}· buyer pays <Monetary value={clearsAt} /> ({Math.round(feeRate * 100)}% fee <Monetary value={fee} />)
                       </span>
                     )}
                   </div>

--- a/src/pages/Market/SellItemModal.tsx
+++ b/src/pages/Market/SellItemModal.tsx
@@ -1,9 +1,11 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { sellItem } from "../../services/market/MarketService";
+import { sellItem, getItemHistory, ItemHistory } from "../../services/market/MarketService";
 import { getInventory } from "../../services/users/UserServices";
 import UserContext from "../../UserContext";
 import Item from "../../components/Item";
 import MainButton from "../../components/MainButton";
+import Monetary from "../../components/Monetary";
+import PriceChart from "../../components/PriceChart";
 import { toast } from "react-toastify";
 import Skeleton from "react-loading-skeleton";
 import Pagination from "../../components/Pagination";
@@ -21,7 +23,7 @@ interface InventoryItem {
   name: string;
   image: string;
   rarity: string;
-  uniqueId: string
+  uniqueId: string;
 }
 
 interface Inventory {
@@ -30,6 +32,20 @@ interface Inventory {
   items: InventoryItem[];
 }
 
+// one price reference (what the house pays, what others ask, what it actually sells for)
+const Stat: React.FC<{ label: string; value: React.ReactNode; hint?: string; accent?: string }> = ({
+  label,
+  value,
+  hint,
+  accent,
+}) => (
+  <div className="flex flex-col gap-0.5 min-w-0">
+    <span className="text-[10px] uppercase tracking-wide text-ink-muted">{label}</span>
+    <span className={`text-sm font-semibold truncate ${accent || "text-ink"}`}>{value}</span>
+    {hint && <span className="text-[10px] text-ink-faint truncate">{hint}</span>}
+  </div>
+);
+
 const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
   const [selectedItem, setSelectedItem] = useState<any>();
   const [price, setPrice] = useState<number | undefined>();
@@ -37,13 +53,10 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
   const [invItems, setInvItems] = useState<InventoryItem[]>([]);
   const [loadingInventory, setLoadingInventory] = useState<boolean>(true);
   const [loadingButton, setLoadingButton] = useState<boolean>(false);
+  const [history, setHistory] = useState<ItemHistory | null>(null);
+  const [loadingHistory, setLoadingHistory] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
-  const [filters, setFilters] = useState({
-    name: '',
-    rarity: '',
-    sortBy: '',
-    order: 'asc'
-  });
+  const [filters, setFilters] = useState({ name: "", rarity: "", sortBy: "", order: "asc" });
   const delayDebounceFn = useRef<NodeJS.Timeout | null>(null);
 
   const { userData } = useContext(UserContext);
@@ -52,22 +65,53 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
     setSelectedItem(null);
     setPrice(0);
     setInvItems([]);
+    setHistory(null);
     setPage(1);
     onClose();
-  }
+  };
+
+  // whenever an item is picked, pull what it actually trades for
+  useEffect(() => {
+    if (!selectedItem?._id) {
+      setHistory(null);
+      return;
+    }
+    let active = true;
+    setLoadingHistory(true);
+    setHistory(null);
+    getItemHistory(selectedItem._id, "month")
+      .then((h) => {
+        if (!active) return;
+        setHistory(h);
+        // pre-fill with the most defensible ask we can suggest
+        const suggested = h.stats.median7d ?? h.stats.median30d ?? h.stats.lowestListing ?? h.stats.floor;
+        if (suggested) setPrice(suggested);
+      })
+      .catch(() => {
+        // guidance is a nice-to-have; listing still works without it
+      })
+      .finally(() => {
+        if (active) setLoadingHistory(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedItem?._id]);
 
   const handleSubmit = async () => {
     setLoadingButton(true);
-
     if (!price || price < 1 || price > 1000000) {
       setLoadingButton(false);
       return toast.error("Price must be between 1 and 1.000.000", {});
     }
-
     try {
-      await sellItem(selectedItem.uniqueId, price);
+      const res = await sellItem(selectedItem.uniqueId, price);
       setRefresh && setRefresh(true);
-      toast.success("Item listed for sale!", {});
+      if (res?.soldInstantly) {
+        toast.success(`Sold instantly to a buy order for K₽${res.soldFor}! You received K₽${res.received}`);
+      } else {
+        toast.success("Item listed for sale!", {});
+      }
       CloseModal();
     } catch (error: any) {
       toast.error(error?.response?.data?.message || "Could not list the item");
@@ -77,11 +121,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
 
   const getInventoryInfo = async (newPage?: number) => {
     try {
-      const response = await getInventory(
-        userData.id,
-        page,
-        filters
-      );
+      const response = await getInventory(userData.id, page, filters);
       setInventory(response);
       newPage
         ? setInvItems((prev) => [...prev, ...response.items])
@@ -94,11 +134,9 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
   };
 
   const handleEnterPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === "Enter") {
       e.preventDefault();
-      // Cancel the debounce
       clearTimeout(delayDebounceFn.current as NodeJS.Timeout);
-      // Fetch the inventory immediately
       getInventoryInfo();
     }
   };
@@ -109,9 +147,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
         getInventoryInfo();
       }, 1000);
       return () => {
-        if (delayDebounceFn.current) {
-          clearTimeout(delayDebounceFn.current);
-        }
+        if (delayDebounceFn.current) clearTimeout(delayDebounceFn.current);
       };
     }
   }, [filters]);
@@ -123,26 +159,31 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
     }
   }, [isOpen, page]);
 
-  if (!isOpen) {
-    return null;
-  }
+  if (!isOpen) return null;
+
+  const stats = history?.stats;
+  const feeRate = stats?.feeRate ?? 0.05;
+  const p = price || 0;
+  const fee = Math.floor(p * feeRate);
+  const receive = Math.max(0, p - fee);
+  const crossesBid = !!(stats?.bestBid && p > 0 && p <= stats.bestBid);
 
   return (
-    <Modal open={isOpen} setOpen={onClose} width="min(960px, 95vw)">
+    <Modal open={isOpen} setOpen={onClose} width="min(980px, 95vw)">
       <div className="flex flex-col gap-4">
         <h2 className="text-xl font-bold">Sell an item</h2>
 
         <Filters filters={filters} setFilters={setFilters} onKeyPress={handleEnterPress} />
 
-        <div className="max-h-[42vh] overflow-y-auto overflow-x-hidden -mx-1 px-1">
+        <div className="max-h-[28vh] overflow-y-auto overflow-x-hidden -mx-1 px-1">
           {loadingInventory ? (
             <div className="flex flex-wrap justify-center gap-3">
               {[1, 2, 3, 4, 5, 6].map((i) => (
-                <Skeleton key={i} width={128} height={150} baseColor="#1c1a31" highlightColor="#161427" />
+                <Skeleton key={i} width={128} height={150} />
               ))}
             </div>
           ) : invItems.length === 0 ? (
-            <div className="text-center text-[#84819a] py-12">No items to sell.</div>
+            <div className="text-center text-ink-muted py-12">No items to sell.</div>
           ) : (
             <div className="flex flex-wrap justify-center gap-3">
               {invItems.map((item, index) => {
@@ -152,7 +193,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
                     key={item._id + index}
                     onClick={() => setSelectedItem(item)}
                     className={`rounded-lg cursor-pointer transition-all p-1 border-2 ${
-                      isSelected ? "border-indigo-500 bg-indigo-500/10" : "border-transparent hover:bg-[#212031]"
+                      isSelected ? "border-accent bg-accent/10" : "border-transparent hover:bg-surface"
                     }`}
                   >
                     <Item item={item} size="small" />
@@ -172,53 +213,142 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
           )}
         </div>
 
-        <div className="sticky bottom-0 flex flex-col sm:flex-row sm:items-center gap-3 border-t border-gray-700 pt-4 bg-[#19172D]">
-          <div className="flex items-center gap-3 flex-1 min-w-0">
-            {selectedItem ? (
-              <>
-                <img src={selectedItem.image} alt={selectedItem.name} className="w-12 h-12 object-contain shrink-0" />
-                <span className="font-semibold truncate">{selectedItem.name}</span>
-              </>
-            ) : (
-              <span className="text-[#84819a] text-sm">Pick an item above to sell it.</span>
-            )}
-          </div>
+        {/* price guidance: the whole point is that you never have to guess */}
+        {selectedItem && (
+          <div className="rounded-lg border border-line bg-surface p-3 flex flex-col gap-3">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <Stat
+                label="Median (7d)"
+                value={stats?.median7d ? <Monetary value={stats.median7d} /> : "No sales"}
+                hint={stats?.volume7d ? `${stats.volume7d} sold this week` : "nothing sold recently"}
+                accent="text-ink"
+              />
+              <Stat
+                label="Lowest listing"
+                value={stats?.lowestListing ? <Monetary value={stats.lowestListing} /> : "None listed"}
+                hint={stats?.totalListings ? `${stats.totalListings} on sale` : "you'd be the only one"}
+                accent="text-accent"
+              />
+              <Stat
+                label="Best buy order"
+                value={stats?.bestBid ? <Monetary value={stats.bestBid} /> : "No bids"}
+                hint={stats?.bestBid ? "sells instantly at or below" : undefined}
+                accent="text-accent-gold"
+              />
+              <Stat
+                label="House floor"
+                value={stats ? <Monetary value={stats.floor} /> : "-"}
+                hint="instant sell, no wait"
+                accent="text-ink-muted"
+              />
+            </div>
 
-          <div className="flex items-center gap-2">
-            <div className="relative flex-1 sm:flex-none">
-              <span className="absolute inset-y-0 left-3 flex items-center text-[#84819a] text-sm pointer-events-none">
-                K₽
-              </span>
-              <input
-                type="number"
-                min={0}
-                max={1000000}
-                placeholder="Price"
-                value={price ?? ""}
-                onKeyDown={(event) => {
-                  if (!/[0-9]/.test(event.key) && !["Backspace", "Tab", "ArrowLeft", "ArrowRight", "Delete"].includes(event.key)) {
-                    event.preventDefault();
-                  }
-                }}
-                onChange={(e) => setPrice(parseInt(e.target.value) || 0)}
-                className="w-full sm:w-36 bg-[#19172D] border border-gray-700 focus:border-indigo-500 outline-none rounded pl-9 pr-3 py-2 text-sm"
-              />
-            </div>
-            <button
-              onClick={CloseModal}
-              className="px-4 py-2 rounded bg-[#281D3F] hover:bg-red-700 text-sm font-semibold"
-            >
-              Close
-            </button>
-            <div className="w-32 shrink-0">
-              <MainButton
-                text="Sell item"
-                onClick={handleSubmit}
-                loading={loadingButton}
-                disabled={!selectedItem || !price || loadingButton}
-              />
+            <PriceChart points={history?.points || []} floor={stats?.floor} height={120} loading={loadingHistory} />
+
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-[11px] text-ink-muted mr-1">Quick price:</span>
+              {stats?.median7d ? (
+                <button
+                  onClick={() => setPrice(stats.median7d as number)}
+                  className="px-2 py-1 rounded border border-line text-xs hover:bg-surface-raised"
+                >
+                  Median
+                </button>
+              ) : null}
+              {stats?.lowestListing ? (
+                <>
+                  <button
+                    onClick={() => setPrice(stats.lowestListing as number)}
+                    className="px-2 py-1 rounded border border-line text-xs hover:bg-surface-raised"
+                  >
+                    Match lowest
+                  </button>
+                  <button
+                    onClick={() => setPrice(Math.max(1, (stats.lowestListing as number) - 1))}
+                    className="px-2 py-1 rounded border border-line text-xs hover:bg-surface-raised"
+                  >
+                    Undercut by 1
+                  </button>
+                </>
+              ) : null}
+              {stats?.bestBid ? (
+                <button
+                  onClick={() => setPrice(stats.bestBid as number)}
+                  className="px-2 py-1 rounded border border-accent-gold/50 text-accent-gold text-xs hover:bg-accent-gold/10"
+                >
+                  Sell to bid now
+                </button>
+              ) : null}
             </div>
           </div>
+        )}
+
+        <div className="sticky bottom-0 flex flex-col gap-3 border-t border-line pt-4 bg-surface-nav">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+            <div className="flex items-center gap-3 flex-1 min-w-0">
+              {selectedItem ? (
+                <>
+                  <img src={selectedItem.image} alt={selectedItem.name} className="w-12 h-12 object-contain shrink-0" />
+                  <div className="flex flex-col min-w-0">
+                    <span className="font-semibold truncate">{selectedItem.name}</span>
+                    {p > 0 && (
+                      <span className="text-xs text-ink-muted">
+                        You receive <span className="text-accent-gold font-semibold"><Monetary value={receive} /></span>
+                        {" "}· buyer pays <Monetary value={p} /> ({Math.round(feeRate * 100)}% fee <Monetary value={fee} />)
+                      </span>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <span className="text-ink-muted text-sm">Pick an item above to sell it.</span>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <div className="relative flex-1 sm:flex-none">
+                <span className="absolute inset-y-0 left-3 flex items-center text-ink-muted text-sm pointer-events-none">
+                  K₽
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  max={1000000}
+                  placeholder="Price"
+                  value={price ?? ""}
+                  onKeyDown={(event) => {
+                    if (
+                      !/[0-9]/.test(event.key) &&
+                      !["Backspace", "Tab", "ArrowLeft", "ArrowRight", "Delete"].includes(event.key)
+                    ) {
+                      event.preventDefault();
+                    }
+                  }}
+                  onChange={(e) => setPrice(parseInt(e.target.value) || 0)}
+                  className="w-full sm:w-36 bg-surface-nav border border-line focus:border-accent outline-none rounded pl-9 pr-3 py-2 text-sm"
+                />
+              </div>
+              <button
+                onClick={CloseModal}
+                className="px-4 py-2 rounded bg-surface-raised hover:bg-red-700 text-sm font-semibold"
+              >
+                Close
+              </button>
+              <div className="w-32 shrink-0">
+                <MainButton
+                  text={crossesBid ? "Sell now" : "List item"}
+                  onClick={handleSubmit}
+                  loading={loadingButton}
+                  disabled={!selectedItem || !price || loadingButton}
+                  type={crossesBid ? "success" : "button"}
+                />
+              </div>
+            </div>
+          </div>
+          {crossesBid && (
+            <span className="text-xs text-accent-gold">
+              A buy order is bidding <Monetary value={stats?.bestBid || 0} /> — this sells instantly at that price.
+            </span>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/pages/Profile/BalanceHistory.tsx
+++ b/src/pages/Profile/BalanceHistory.tsx
@@ -28,6 +28,8 @@ const TYPE_LABELS: Record<string, string> = {
   battle_refund: "Battle refund",
   market_buy: "Marketplace purchase",
   market_sale: "Marketplace sale",
+  market_order: "Buy order placed",
+  market_order_refund: "Buy order refunded",
   item_sell: "Sold to shop",
   admin_adjust: "Admin adjustment",
   mission_reward: "Mission reward",
@@ -48,6 +50,9 @@ const describe = (tx: Transaction): string => {
   }
   if (tx.type === "mission_reward" && m.missionTitle) {
     return `Mission reward: ${m.missionTitle}`;
+  }
+  if ((tx.type === "market_order" || tx.type === "market_order_refund") && m.itemName) {
+    return `${base}: ${m.itemName}`;
   }
   return base;
 };

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -12,6 +12,7 @@ import Pagination from "../../components/Pagination";
 import BalanceHistory from "./BalanceHistory";
 import CollectionsPanel from "../Collections/CollectionsPanel";
 import MissionsPanel from "../Missions/MissionsPanel";
+import { resolveTab, Tab } from "./tabs";
 import { User } from '../../components/Types'
 
 interface Inventory {
@@ -25,7 +26,7 @@ const NEW_TABS = ["collections", "missions"];
 
 const Profile = () => {
   const { id } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [user, setUser] = useState<User>();
   const [loading, setLoading] = useState<boolean>(true);
   const [loadingInventory, setLoadingInventory] = useState<boolean>(true);
@@ -36,7 +37,7 @@ const Profile = () => {
   const [refresh, setRefresh] = useState<boolean>(false);
   const [openFilters, setOpenFilters] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
-  const [activeTab, setActiveTab] = useState<"inventory" | "collections" | "history" | "missions">("inventory");
+  const activeTab = resolveTab(searchParams.get("tab"), isSameUser);
   const [seenTabs, setSeenTabs] = useState<string[]>([]);
   const [filters, setFilters] = useState({
     name: '',
@@ -45,8 +46,6 @@ const Profile = () => {
     order: 'asc',
   });
   const delayDebounceFn = useRef<NodeJS.Timeout | null>(null);
-  const deepLinkTabRef = useRef<string | null>(null);
-  const userPickedTabRef = useRef<boolean>(false);
 
   useEffect(() => {
     if (invItems?.length > 0) {
@@ -115,31 +114,8 @@ const Profile = () => {
   useEffect(() => {
     setInvItems([]);
     setPage(1);
-    setActiveTab("inventory");
     getUserInfo();
   }, [id]);
-
-  // deep-link support: /profile/:id?tab=missions opens that tab (e.g. from a toast).
-  // capture the requested tab; a slow /users/me can defer applying an own-only tab.
-  useEffect(() => {
-    deepLinkTabRef.current = searchParams.get("tab");
-    userPickedTabRef.current = false;
-  }, [id, searchParams]);
-
-  // apply the captured tab once ownership is known, unless the user already picked a
-  // tab manually in the meantime (so the deep-link can never clobber their choice).
-  useEffect(() => {
-    const tabParam = deepLinkTabRef.current;
-    if (!tabParam || userPickedTabRef.current) return;
-    const allowed =
-      tabParam === "inventory" ||
-      tabParam === "collections" ||
-      (isSameUser && (tabParam === "missions" || tabParam === "history"));
-    if (allowed) {
-      deepLinkTabRef.current = null;
-      setActiveTab(tabParam as "inventory" | "collections" | "history" | "missions");
-    }
-  }, [isSameUser, id, searchParams]);
 
   // load which "new" tabs this user has already opened (per user, per browser)
   useEffect(() => {
@@ -165,7 +141,7 @@ const Profile = () => {
   }, [page, id]);
 
 
-  const tabs: { key: "inventory" | "collections" | "history" | "missions"; label: string }[] = [
+  const tabs: { key: Tab; label: string }[] = [
     { key: "inventory", label: "Inventory" },
     { key: "collections", label: "Collections" },
     ...(isSameUser
@@ -216,8 +192,11 @@ const Profile = () => {
                     <button
                       key={t.key}
                       onClick={() => {
-                        userPickedTabRef.current = true;
-                        setActiveTab(t.key);
+                        // re-clicking the open tab must not throw away the case and item
+                        // params below it. a literal rebuilds from scratch, so switching
+                        // tabs drops them, which is what unmounting did before anyway.
+                        if (activeTab === t.key) return;
+                        setSearchParams({ tab: t.key }, { replace: true });
                       }}
                       className={`relative shrink-0 whitespace-nowrap pb-3 text-sm font-bold uppercase tracking-wider transition-colors ${
                         active ? "text-white" : "text-[#84819a] hover:text-white"

--- a/src/pages/Profile/tabs.test.ts
+++ b/src/pages/Profile/tabs.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { resolveTab } from "./tabs";
+
+describe("resolveTab", () => {
+  it("defaults to inventory when no tab is asked for", () => {
+    expect(resolveTab(null, true)).toBe("inventory");
+    expect(resolveTab(null, false)).toBe("inventory");
+  });
+
+  it("opens collections for anyone", () => {
+    expect(resolveTab("collections", false)).toBe("collections");
+    expect(resolveTab("collections", true)).toBe("collections");
+  });
+
+  it("gives the owner their own tabs", () => {
+    expect(resolveTab("missions", true)).toBe("missions");
+    expect(resolveTab("history", true)).toBe("history");
+  });
+
+  // isOwner is false both for a stranger and while /users/me is still in flight,
+  // so this one case covers the leak and the race at once
+  it("hides owner-only tabs from everyone else", () => {
+    expect(resolveTab("missions", false)).toBe("inventory");
+    expect(resolveTab("history", false)).toBe("inventory");
+  });
+
+  it("falls back to inventory on a junk tab", () => {
+    expect(resolveTab("nonsense", true)).toBe("inventory");
+  });
+});

--- a/src/pages/Profile/tabs.ts
+++ b/src/pages/Profile/tabs.ts
@@ -1,0 +1,11 @@
+export type Tab = "inventory" | "collections" | "history" | "missions";
+
+// the url is the source of truth for the tab. owner-only tabs collapse to inventory
+// whenever isOwner is false, which covers both "not the owner" and "ownership not
+// known yet", so a slow /users/me can never leak them.
+export const resolveTab = (param: string | null, isOwner: boolean): Tab =>
+  param === "collections"
+    ? "collections"
+    : (param === "missions" || param === "history") && isOwner
+    ? param
+    : "inventory";

--- a/src/services/market/MarketService.ts
+++ b/src/services/market/MarketService.ts
@@ -1,35 +1,67 @@
 import api from '../api';
+import { PricePoint } from '../../components/PriceChart';
+
+export interface MarketStats {
+    floor: number;              // instant sell-to-house price: a hard price floor
+    lowestListing: number | null;
+    totalListings: number;
+    bestBid: number | null;     // highest open buy order
+    lastSale: { price: number; soldAt: string } | null;
+    median7d: number | null;
+    median30d: number | null;
+    volume7d: number;
+    volume30d: number;
+    feeRate: number;
+}
+
+export interface ItemHistory {
+    item: { _id: string; name: string; image: string; rarity: string; baseValue: number };
+    range: string;
+    points: PricePoint[];
+    stats: MarketStats;
+}
+
+export interface BuyOrder {
+    _id: string;
+    item: string;
+    itemName: string;
+    itemImage: string;
+    rarity: string;
+    price: number;
+    quantity: number;
+    filled: number;
+    escrow: number;
+    status: string;
+    createdAt: string;
+}
 
 export async function getItems(page: number, filters: any) {
-    const { name, rarity, sortBy, order } = filters;
+    const { name, rarity, sortBy, order, listedOnly } = filters;
     const response = await api.get(`/marketplace`, {
-        params: {
-            page,
-            limit: 30,
-            name,
-            rarity,
-            sortBy,
-            order
-        }
+        params: { page, limit: 30, name, rarity, sortBy, order, listedOnly: listedOnly ? 1 : undefined }
     });
     return response.data;
 }
 
 export async function getItemListings(itemId: string, page: number) {
     const response = await api.get(`/marketplace/item/${itemId}`, {
-        params: {
-            page,
-            limit: 30
-        }
+        params: { page, limit: 30 }
     });
     return response.data;
 }
 
+export async function getItemHistory(itemId: string, range: string): Promise<ItemHistory> {
+    const response = await api.get(`/marketplace/item/${itemId}/history`, { params: { range } });
+    return response.data;
+}
+
+export async function getItemOrders(itemId: string): Promise<{ orders: { price: number; quantity: number }[] }> {
+    const response = await api.get(`/marketplace/item/${itemId}/orders`);
+    return response.data;
+}
+
 export async function sellItem(item: any, price: number) {
-    const response = await api.post(`/marketplace/`, {
-        item,
-        price
-    });
+    const response = await api.post(`/marketplace/`, { item, price });
     return response.data;
 }
 
@@ -40,5 +72,20 @@ export async function buyItem(id: string) {
 
 export async function removeListing(id: string) {
     const response = await api.delete(`/marketplace/${id}`);
+    return response.data;
+}
+
+export async function placeBuyOrder(itemId: string, price: number, quantity: number) {
+    const response = await api.post(`/marketplace/orders`, { itemId, price, quantity });
+    return response.data;
+}
+
+export async function getMyOrders(): Promise<{ orders: BuyOrder[] }> {
+    const response = await api.get(`/marketplace/orders/me`);
+    return response.data;
+}
+
+export async function cancelBuyOrder(id: string) {
+    const response = await api.delete(`/marketplace/orders/${id}`);
     return response.data;
 }


### PR DESCRIPTION
## Why

You could not tell what an item was worth. Listings were hard-deleted on sale with no record left behind, and the ledger only kept a name string, so "what is the going rate for this?" had no answer anywhere in the system. Selling was a guess.

Alongside that, the profile drill-down lived entirely in React state, so leaving for the market and pressing back dropped you on a bare profile with everything reset.

## Marketplace

- **Price history.** A new `MarketSale` record is written on every sale, so history comes from real trades rather than `Item.baseValue` (which gets recomputed from case price and would rewrite the past). Served bucketed by `GET /marketplace/item/:id/history`, drawn with a hand-rolled SVG chart, no charting dependency.
- **Sell guidance.** The sell modal now shows the median, the lowest listing, the best bid and the house floor, so a price is an informed choice. An ask that crosses a resting bid clears at the *bid*, and the modal says so rather than quoting the ask.
- **Buy orders.** Standing bids with funds escrowed up front, so a match can never fail for insufficient balance. Placing one sweeps existing listings first and only escrows the remainder; cancelling refunds from the order's own pre-image, so the exact held amount comes back.
- **5% house fee** on sales, paid by the seller.
- Sorting on the market never worked (`sortBy`/`order` were read but unused). Now whitelisted comparators.

Selling crosses resting bids *before* publishing a listing, which closes the front-run window rather than creating a listing and racing to fill it.

## Profile / collections

The tab, open collection, open item, and album page/filter/sort now live in the query string, so one back press restores where you were. They are **derived** from `searchParams` rather than synced into state, which deleted the `deepLinkTabRef`/`userPickedTabRef` dance outright: `isSameUser` is already false both for a stranger and while `/users/me` is in flight, so owner-only tabs collapse to inventory with no race to lose.

## Also fixed

The socket room was latched on a "joined once" flag that only the session-expiry path ever cleared. Since the router lives inside `App`, logging out and into another account in the same tab kept the previous user's room, their balance pushes and their mission links. It is now keyed on the account id, which also drops the room on logout.

## Verification

177 backend tests, 19 frontend unit tests, 3 e2e, build and lint all pass. Money paths were reviewed adversarially; two holes found and fixed before this branch was pushed:

- A fill wrote a second buyer debit for KP the escrow had already taken, drifting the ledger against the wallet.
- A failed purchase restored a listing under a *new* `_id`, so a zero-balance account could re-key any listing and make it permanently unbuyable. The id is now preserved.

Both have regression tests.