### PR TITLE
Fix the home page jumping when the cases arrive

### DIFF
--- a/src/pages/Home/CaseListing.tsx
+++ b/src/pages/Home/CaseListing.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import Skeleton from "react-loading-skeleton";
 import Case from "../../components/Case";
 import Title from "../../components/Title";
 
@@ -6,34 +7,49 @@ interface CaseListingProps {
   name: string;
   description?: string;
   cases: any;
+  loading?: boolean;
 }
 
-const CaseListing: React.FC<CaseListingProps> = ({
-  name,
-  description,
-  cases,
-}) => {
+// the placeholder mirrors a real card: same w-64, same h-32/md:h-64 art box, same text
+// block underneath. it lives in here rather than in the page so the two states cannot
+// drift apart, which is what shifted the whole page when the cases arrived.
+const CaseSkeleton = () => (
+  <div className="w-64 flex flex-col items-center">
+    <Skeleton containerClassName="block w-full h-32 md:h-64" height="100%" borderRadius={8} />
+    {/* 92px is what the real card's title and price block measures at both breakpoints
+        (p-4, a text-lg line, gap-2, a base line). pinning it means the placeholder and the
+        card are the same height whatever the skeleton library does with line-height */}
+    <div className="h-[92px] flex flex-col gap-2 items-center justify-center">
+      <Skeleton width={132} height={20} />
+      <Skeleton width={72} height={16} />
+    </div>
+  </div>
+);
+
+const CaseListing: React.FC<CaseListingProps> = ({ name, description, cases, loading }) => {
   return (
     <div className="w-full flex flex-col gap-4 py-10 items-center" key={name}>
       <div className="flex flex-col items-center justify-center max-w-[1600px]">
         <Title title={name} />
         {description && <div className="text">{description}</div>}
-        {
-          <div className="flex flex-col md:flex-row items-center justify-center w-full gap-8 md:flex-wrap">
-            {cases.map((item: any, index: number) => (
-              <Link to={`/case/${item._id}`} key={item._id}>
-                <Case
-                  key={item._id}
-                  id={item._id}
-                  title={item.title}
-                  image={item.image}
-                  price={item.price}
-                  priority={index < 4}
-                />
-              </Link>
-            ))}
-          </div>
-        }
+        <div className="flex flex-col md:flex-row items-center justify-center w-full gap-8 md:flex-wrap">
+          {loading
+            ? Array(6)
+                .fill(0)
+                .map((_, index) => <CaseSkeleton key={index} />)
+            : cases.map((item: any, index: number) => (
+                <Link to={`/case/${item._id}`} key={item._id}>
+                  <Case
+                    key={item._id}
+                    id={item._id}
+                    title={item.title}
+                    image={item.image}
+                    price={item.price}
+                    priority={index < 4}
+                  />
+                </Link>
+              ))}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -4,7 +4,6 @@ import CaseListing from "./CaseListing";
 import GameListing from "./GamesListing";
 import Leaderboard from "./Leaderboard";
 import { getCases } from "../../services/cases/CaseServices";
-import Skeleton from "react-loading-skeleton";
 import { toast } from "react-toastify";
 import { BannerProps } from "./Types";
 import { Carousel } from "react-responsive-carousel";
@@ -87,30 +86,11 @@ const Home = () => {
             <Banner key={index} left={_item.left} right={_item.right} />
           ))}
         </Carousel>
-        {loading ? (
-          <div className="flex items-center justify-center w-full mt-[164px]">
-            <div className="flex justiy-center gap-8 max-w-[1600px] flex-col md:flex-row">
-              {Array(4)
-                .fill(0)
-                .map((e, index) => (
-                  <div key={index}>
-                    <Skeleton
-                      width={256}
-                      height={348}
-                      highlightColor="#161427"
-                      baseColor="#1c1a31"
-                      key={e + index}
-                    />
-                  </div>
-                ))}
-            </div>
-          </div>
-        ) : (
-          <CaseListing
-            name="NEW CASES"
-            cases={cases.length > 6 ? cases.slice(0, 6) : cases}
-          />
-        )}
+        <CaseListing
+          name="NEW CASES"
+          loading={loading}
+          cases={loading ? [] : cases.length > 6 ? cases.slice(0, 6) : cases}
+        />
 
         {discordURL && (
           <div className="flex items-center justify-center w-full">


### PR DESCRIPTION
## The bug

Lighthouse put **0.336 of a 0.336 CLS** on one element:

```
score=0.33612  <div class="flex items-center justify-center w-full mt-[164px]">
```

That is the home page's loading block. It drew four skeletons at a fixed `height={348}` inside its own wrapper with a `mt-[164px]`, then handed over to six real cards in a completely different shell. The block changed height and everything below it moved.

The `348` was tuned for a desktop card. On mobile a real card is 220px, so the placeholder was over 100px too tall per card, stacked six deep.

It only appears when the API answers slower than React renders, which is why the score swung between 0 and 0.34 on identical runs.

## The fix

The placeholder now lives inside `CaseListing` and mirrors a real card: same `w-64`, same `h-32 md:h-64` art box, and a text block pinned to the 92px the real title and price occupy. Both states go through the same shell, so they cannot drift.

Measured at both breakpoints with the API deliberately delayed so the skeleton is guaranteed to render:

| | skeleton | real card | delta |
| --- | --- | --- | --- |
| Moto G4 | 220px | 220px | **0** |
| Desktop | 348px | 348px | **0** |

Pinning the text block to a measured 92px rather than sizing the skeletons individually is deliberate: `react-loading-skeleton` adds its own line-height, so per-row pixel values fight the library and drift the moment the card changes.

## Note

The 92px is the one number that has to track the card. If the title or price typography changes, the placeholder needs the same edit. The alternative, letting the rows inherit the card's typography classes, measured 18px short because the skeleton spans do not fill their line box.