### PR TITLE
Crash: stop broadcasting where the round crashes

### DIFF
--- a/backend/__tests__/unit/crashSecrecy.test.js
+++ b/backend/__tests__/unit/crashSecrecy.test.js
@@ -34,12 +34,15 @@ jest.mock("../../utils/economy", () => ({
 }));
 
 const crashGame = require("../../games/crash");
-const { crashPointFromRandom } = require("../../utils/crashMath");
+const { creditUser } = require("../../utils/economy");
+const { crashPointFromRandom, GROWTH } = require("../../utils/crashMath");
 
 // picked so the round crashes at 4.00x: high enough that a cashout five seconds in
 // (1.35x) is still comfortably inside the round
-const H = 3229298719;
-const REAL_CRASH_POINT = crashPointFromRandom(H);
+const REAL_CRASH_POINT = crashPointFromRandom(3229298719);
+const BETTING_WINDOW = 12000;
+// exp(t * GROWTH) reaches 4.00x at ~23.1s, so this always outlives the round
+const WHOLE_ROUND = 24000;
 
 // records everything the server puts on the wire. the clone matters: gameState is one
 // object mutated in place, and socket.io serializes at emit time, so holding the
@@ -64,12 +67,18 @@ const makeSocket = (userId) => {
   return { userId, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: () => {} };
 };
 
-describe("crash round secrecy", () => {
+const lastState = (io) => {
+  const states = io.broadcasts.filter((b) => b.event === "crash:gameState");
+  return states[states.length - 1].payload;
+};
+
+describe("crash rounds", () => {
   let io;
 
   beforeEach(() => {
     jest.useFakeTimers();
     jest.spyOn(Math, "random").mockReturnValue(0.99); // above INSTANT_CRASH_CHANCE
+    creditUser.mockClear();
     io = makeIo();
     crashGame(io);
   });
@@ -90,7 +99,7 @@ describe("crash round secrecy", () => {
     await bob.handlers["crash:bet"](100, () => {});
 
     // start the round: from here the server knows where it crashes
-    await jest.advanceTimersByTimeAsync(12000);
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
     // climb to ~1.35x, far short of 4.00x
     await jest.advanceTimersByTimeAsync(5000);
 
@@ -99,10 +108,94 @@ describe("crash round secrecy", () => {
 
     // sanity: the round really was still live when she cashed out
     expect(REAL_CRASH_POINT).toBe(4);
+    expect(lastState(io).gamePlayers.bob.payout).toBeNull();
 
     const leaks = io.broadcasts.filter(
       (b) => b.payload && b.payload.crashPoint === REAL_CRASH_POINT
     );
     expect(leaks).toEqual([]);
+  });
+
+  test("a bet is still visible to everyone, and pays stake * multiplier on cashout", async () => {
+    const alice = makeSocket("alice");
+    io.connection(alice);
+
+    await alice.handlers["crash:bet"](100, () => {});
+
+    const betting = lastState(io);
+    expect(betting.gameBets.alice).toBe(100);
+    expect(betting.gamePlayers.alice.username).toBe("player");
+    expect(betting.gamePlayers.alice.payout).toBeNull();
+    expect(betting).not.toHaveProperty("crashPoint");
+
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
+    await jest.advanceTimersByTimeAsync(5000);
+    await alice.handlers["crash:cashout"](() => {});
+
+    const expectedMultiplier = Math.exp(5 * GROWTH); // ~1.3499x
+    expect(creditUser).toHaveBeenCalledTimes(1);
+    const [userId, payout, winnings] = creditUser.mock.calls[0];
+    expect(userId).toBe("alice");
+    expect(payout).toBeCloseTo(100 * expectedMultiplier, 5);
+    expect(winnings).toBeCloseTo(100 * expectedMultiplier - 100, 5);
+
+    // her locked-in payout is public; the crash point still is not
+    const cashedOut = lastState(io);
+    expect(cashedOut.gamePlayers.alice.payout).toBeCloseTo(expectedMultiplier, 5);
+    expect(cashedOut).not.toHaveProperty("crashPoint");
+  });
+
+  test("clients still get a climbing multiplier during the round", async () => {
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
+    await jest.advanceTimersByTimeAsync(5000);
+
+    const ticks = io.broadcasts.filter((b) => b.event === "crash:multiplier").map((b) => b.payload);
+    expect(ticks.length).toBeGreaterThan(50);
+    expect(ticks[0]).toBeGreaterThanOrEqual(1);
+    expect(ticks[ticks.length - 1]).toBeGreaterThan(ticks[0]);
+    expect(ticks[ticks.length - 1]).toBeLessThan(REAL_CRASH_POINT);
+  });
+
+  test("the crash point is revealed once the round is over, and betting reopens", async () => {
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
+    await jest.advanceTimersByTimeAsync(WHOLE_ROUND);
+
+    const results = io.broadcasts.filter((b) => b.event === "crash:result");
+    expect(results).toHaveLength(1);
+    expect(results[0].payload).toBe(REAL_CRASH_POINT);
+
+    // the state that follows the reveal is the empty one for the next round
+    expect(lastState(io)).toEqual({ gameBets: {}, gamePlayers: {}, gameStartTime: null });
+
+    const bob = makeSocket("bob");
+    io.connection(bob);
+    let reply;
+    await bob.handlers["crash:bet"](50, (r) => { reply = r; });
+    expect(reply).toEqual({ ok: true });
+  });
+
+  test("riding past the bust pays nothing", async () => {
+    const bob = makeSocket("bob");
+    io.connection(bob);
+    await bob.handlers["crash:bet"](100, () => {});
+
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
+    await jest.advanceTimersByTimeAsync(WHOLE_ROUND);
+
+    // too late: the round is gone
+    await bob.handlers["crash:cashout"](() => {});
+    expect(creditUser).not.toHaveBeenCalled();
+  });
+
+  test("betting is refused once the round is under way", async () => {
+    const bob = makeSocket("bob");
+    io.connection(bob);
+
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
+    await jest.advanceTimersByTimeAsync(2000);
+
+    let reply;
+    await bob.handlers["crash:bet"](100, (r) => { reply = r; });
+    expect(reply).toEqual({ error: "Betting is closed for this round" });
   });
 });

--- a/backend/__tests__/unit/crashSecrecy.test.js
+++ b/backend/__tests__/unit/crashSecrecy.test.js
@@ -1,0 +1,108 @@
+// pins the round to a known crash point. getRandomValues is a non-configurable
+// property on the real module, so it has to be replaced at require time.
+jest.mock("crypto", () => {
+  const actual = jest.requireActual("crypto");
+  return {
+    ...actual,
+    getRandomValues: (arr) => {
+      arr[0] = 3229298719;
+      return arr;
+    },
+  };
+});
+
+// what the wallet does is irrelevant to what the server broadcasts, so stubbing it
+// keeps this test free of a database and lets the round run on fake timers
+jest.mock("../../utils/economy", () => ({
+  chargeUser: jest.fn(async (userId) => ({
+    _id: userId,
+    username: "player",
+    profilePicture: "",
+    level: 1,
+    fixedItem: null,
+    walletBalance: 500,
+    xp: 0,
+  })),
+  creditUser: jest.fn(async (userId) => ({
+    _id: userId,
+    username: "player",
+    walletBalance: 900,
+    xp: 0,
+    level: 1,
+  })),
+  TX: { CRASH_BET: "crash_bet", CRASH_CASHOUT: "crash_cashout" },
+}));
+
+const crashGame = require("../../games/crash");
+const { crashPointFromRandom } = require("../../utils/crashMath");
+
+// picked so the round crashes at 4.00x: high enough that a cashout five seconds in
+// (1.35x) is still comfortably inside the round
+const H = 3229298719;
+const REAL_CRASH_POINT = crashPointFromRandom(H);
+
+// records everything the server puts on the wire. the clone matters: gameState is one
+// object mutated in place, and socket.io serializes at emit time, so holding the
+// reference would rewrite history.
+const makeIo = () => {
+  const broadcasts = [];
+  const io = {
+    connection: null,
+    on: (event, fn) => {
+      if (event === "connection") io.connection = fn;
+    },
+    emit: (event, payload) =>
+      broadcasts.push({ event, payload: JSON.parse(JSON.stringify(payload ?? null)) }),
+    to: () => ({ emit: () => {} }),
+    broadcasts,
+  };
+  return io;
+};
+
+const makeSocket = (userId) => {
+  const handlers = {};
+  return { userId, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: () => {} };
+};
+
+describe("crash round secrecy", () => {
+  let io;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, "random").mockReturnValue(0.99); // above INSTANT_CRASH_CHANCE
+    io = makeIo();
+    crashGame(io);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test("the crash point is never broadcast while the round is still running", async () => {
+    const alice = makeSocket("alice");
+    const bob = makeSocket("bob");
+    io.connection(alice);
+    io.connection(bob);
+
+    await alice.handlers["crash:bet"](100, () => {});
+    await bob.handlers["crash:bet"](100, () => {});
+
+    // start the round: from here the server knows where it crashes
+    await jest.advanceTimersByTimeAsync(12000);
+    // climb to ~1.35x, far short of 4.00x
+    await jest.advanceTimersByTimeAsync(5000);
+
+    // alice takes her money out. bob is still in the round and must learn nothing.
+    await alice.handlers["crash:cashout"](() => {});
+
+    // sanity: the round really was still live when she cashed out
+    expect(REAL_CRASH_POINT).toBe(4);
+
+    const leaks = io.broadcasts.filter(
+      (b) => b.payload && b.payload.crashPoint === REAL_CRASH_POINT
+    );
+    expect(leaks).toEqual([]);
+  });
+});

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -9,6 +9,16 @@ const freshState = () => ({
   gameStartTime: null,
 });
 
+// the crash point is the one secret a round holds, so it never goes on the wire until
+// the round is over and `crash:result` reveals it. broadcasting the whole state used to
+// hand it to every connected client the moment anyone cashed out: everyone still in the
+// round could then bail one tick before the bust, every time.
+const publicState = (state) => ({
+  gameBets: state.gameBets,
+  gamePlayers: state.gamePlayers,
+  gameStartTime: state.gameStartTime,
+});
+
 const crashGame = (io) => {
   let gameState = freshState();
   // bets are only accepted in the window between rounds
@@ -71,7 +81,7 @@ const crashGame = (io) => {
           level: updatedUser.level,
         });
 
-        io.emit("crash:gameState", gameState);
+        io.emit("crash:gameState", publicState(gameState));
         reply({ ok: true });
       } catch (err) {
         console.log(err);
@@ -124,7 +134,7 @@ const crashGame = (io) => {
             level: updatedUser.level,
           });
 
-          io.emit("crash:gameState", gameState);
+          io.emit("crash:gameState", publicState(gameState));
 
           socket.emit("crash:cashoutSuccess", { userId, payout, multiplier });
         }
@@ -161,7 +171,7 @@ const crashGame = (io) => {
         // reset and reopen betting for the next round
         gameState = freshState();
         bettingOpen = true;
-        io.emit("crash:gameState", gameState);
+        io.emit("crash:gameState", publicState(gameState));
 
         setTimeout(runRound, 12000); // betting window before the next round
       } else {


### PR DESCRIPTION
## The bug

`crash:gameState` broadcasts the whole round object, and that object carries `crashPoint`.

During the betting window it is still the `1.0` placeholder, so it looks harmless. But the cashout handler re-broadcasts the same object mid-round, after `runRound` has put the real value in it. So the first player to cash out handed every connected client the exact bust multiplier, and anyone still in the round could then sit until a tick before it and take the maximum.

It does not even need a second player to cooperate: one person with two accounts can cash out the first at 1.01x, read the value off the socket, and ride the second to the top. Every round.

## The fix

The client never read the field, it only received it. `publicState()` keeps it server side and broadcasts only what the UI actually uses (`gameBets`, `gamePlayers`, `gameStartTime`). `crash:result` still reveals the crash point when the round is over, exactly as before, so nothing on screen changes and no frontend change was needed.

## Tests

`backend/__tests__/unit/crashSecrecy.test.js` drives a round through a recording stand-in for socket.io with the crash point pinned to 4.00x. The first test fails on the old code with the crash point sitting in a broadcast while another player is still in the round.

The rest pin the lifecycle down, since the payload changed shape:

- a bet is still visible to everyone
- a cashout still pays stake times the live multiplier and publishes the payout
- the multiplier still ticks up during the round
- `crash:result` still reveals the crash point at the end and betting reopens
- riding past the bust pays nothing
- a bet placed after the round starts is refused

183/183 backend tests pass. Frontend build passes, and `src/` is untouched.