### PR TITLE
Upgrade: stop a lost race destroying the items it kept

### DIFF
--- a/backend/__tests__/integration/upgradeRace.test.js
+++ b/backend/__tests__/integration/upgradeRace.test.js
@@ -1,0 +1,69 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const upgradeItems = require("../../games/upgrade");
+
+beforeAll(setupDb);
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await clearDb();
+});
+afterAll(teardownDb);
+
+async function scenario() {
+  const caseId = new mongoose.Types.ObjectId();
+  const target = await Item.create({
+    name: `t-${uniqueSuffix()}`, image: "x", rarity: "3", case: caseId, baseValue: 100,
+  });
+  const low = await Item.create({
+    name: `l-${uniqueSuffix()}`, image: "x", rarity: "1", case: caseId, baseValue: 10,
+  });
+  const inventory = ["a", "b", "c"].map((uniqueId) => ({
+    _id: low._id, name: low.name, image: low.image, rarity: "1", case: caseId, uniqueId,
+  }));
+  const user = await User.create({
+    username: `u-${uniqueSuffix()}`,
+    email: `u-${uniqueSuffix()}@e.com`,
+    password: "x",
+    inventory,
+  });
+  return { user, target };
+}
+
+const inventoryOf = async (id) =>
+  (await User.findById(id)).inventory.map((i) => i.uniqueId).sort();
+
+test("an item sold mid-upgrade does not take the other items with it", async () => {
+  const { user, target } = await scenario();
+
+  // the race, forced: the upgrade reads three items, and "c" is sold from under it
+  // before it consumes anything
+  const realFindById = User.findById.bind(User);
+  jest.spyOn(User, "findById").mockImplementationOnce(async (id) => {
+    const doc = await realFindById(id);
+    await User.updateOne({ _id: user._id }, { $pull: { inventory: { uniqueId: "c" } } });
+    return doc;
+  });
+
+  const res = await upgradeItems(user._id.toString(), ["a", "b", "c"], target._id.toString());
+
+  expect(res.status).toBe(400);
+  // a and b were never spent, so they must survive the refusal
+  expect(await inventoryOf(user._id)).toEqual(["a", "b"]);
+});
+
+test("an upgrade with all items present still consumes them", async () => {
+  const { user, target } = await scenario();
+
+  const res = await upgradeItems(user._id.toString(), ["a", "b"], target._id.toString());
+
+  expect(res.status).toBe(200);
+  const left = await inventoryOf(user._id);
+  expect(left).not.toContain("a");
+  expect(left).not.toContain("b");
+  expect(left).toContain("c");
+});

--- a/backend/games/upgrade.js
+++ b/backend/games/upgrade.js
@@ -101,19 +101,16 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
     const reserved = await seeds.reserveNonces(userId, 1);
     const nonce = reserved.startNonce;
 
-    // atomically consume the selected items; the pre-update doc tells us how many
-    // were actually present, so a concurrent request can't spend them twice
+    // consume the selected items in one atomic step. the filter demands every one of
+    // them is still there, so a request that loses the race to a sale or another
+    // upgrade removes nothing at all. it used to $pull first and count afterwards,
+    // which meant losing that race destroyed whichever items it did still find.
+    const consumeIds = selectedItems.map((invItem) => invItem.uniqueId);
     const before = await User.findOneAndUpdate(
-      { _id: userId },
-      { $pull: { inventory: { uniqueId: { $in: selectedItemIds } } } }
+      { _id: userId, "inventory.uniqueId": { $all: consumeIds } },
+      { $pull: { inventory: { uniqueId: { $in: consumeIds } } } }
     );
     if (!before) {
-      return { status: 404, message: "User not found" };
-    }
-    const removedCount = before.inventory.filter((invItem) =>
-      selectedItemIds.includes(invItem.uniqueId)
-    ).length;
-    if (removedCount !== selectedItems.length) {
       return { status: 400, message: "Items no longer available" };
     }
 


### PR DESCRIPTION
## The bug

The consume step pulled every selected item out of the inventory, and only then counted how many had actually been there:

```js
const before = await User.findOneAndUpdate(
  { _id: userId },                                    // no precondition
  { $pull: { inventory: { uniqueId: { $in: selectedItemIds } } } }
);
const removedCount = /* how many were really there */;
if (removedCount !== selectedItems.length) {
  return { status: 400, message: "Items no longer available" };   // too late
}
```

By the time it decides to bail, the pull has committed. Nothing puts the items back.

So selecting three items for an upgrade and selling one of them from another tab in the same moment took the other two with it: pulled out of the inventory, not upgraded, not refunded, not recorded anywhere. The more items in the upgrade, the more there was to lose. The double-submit case was safe (the second request finds nothing and removes nothing), so this only ever bit on a partial overlap, which is why it went unnoticed.

## The fix

The filter now demands that every selected item is still present, so the pull is all or nothing. A request that loses the race matches no document and removes nothing, and the player keeps their items.

Nonce reservation is left where it is, before the consume. A failed upgrade burning a nonce is the safe direction: rolling it back is what would let a player peek at an outcome.

## Tests

`backend/__tests__/integration/upgradeRace.test.js` forces the race by having the inventory read return three items while one is pulled from the database underneath it. On the old code the first test fails with the inventory emptied (`[]` instead of `["a", "b"]`) - both survivors destroyed. The second test pins the happy path so the new precondition cannot quietly refuse a legitimate upgrade.

185/185 backend tests pass.