### PR TITLE
Battles: stop a restart inventing a winner for a battle that never ran

### DIFF
--- a/backend/__tests__/integration/battleRecovery.test.js
+++ b/backend/__tests__/integration/battleRecovery.test.js
@@ -1,0 +1,111 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Battle = require("../../models/Battle");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+const engine = require("../../games/battleEngine");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const ENTRY = 100;
+
+async function makePlayer(balance) {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance: balance });
+}
+
+// a battle the process abandoned after claiming it but before the preroll committed:
+// in_progress, no server seed, no rolls
+async function abandonedBattle(players) {
+  return Battle.create({
+    status: "in_progress",
+    mode: "1v1",
+    cases: [new mongoose.Types.ObjectId()],
+    entryCost: ENTRY,
+    createdBy: players[0]._id,
+    players: players.map((p, i) => ({
+      userId: p._id, username: p.username, team: i, slot: i, isBot: false,
+    })),
+    rolls: [],
+    currentRound: 0,
+    startedAt: new Date(),
+  });
+}
+
+// the row chargeUser would have written when the entry was actually taken
+const recordEntry = (userId, battleId) =>
+  Transaction.create({
+    userId, type: TX.BATTLE_ENTRY, direction: "debit", amount: ENTRY,
+    balanceAfter: 0, meta: { battleId },
+  });
+
+test("a battle abandoned before its preroll refunds the players who paid", async () => {
+  const a = await makePlayer(900);
+  const b = await makePlayer(900);
+  const battle = await abandonedBattle([a, b]);
+  await recordEntry(a._id, battle._id);
+  await recordEntry(b._id, battle._id);
+
+  await engine.completeStuckBattles();
+
+  const done = await Battle.findById(battle._id);
+  // it never happened, so it must not be dressed up as a finished battle
+  expect(done.status).toBe("cancelled");
+  expect(done.winningTeam).toBeNull();
+  expect(done.winnerUserIds).toEqual([]);
+
+  expect((await User.findById(a._id)).walletBalance).toBe(1000);
+  expect((await User.findById(b._id)).walletBalance).toBe(1000);
+});
+
+test("a player the crash beat to the charge is not refunded money they never paid", async () => {
+  const paid = await makePlayer(900);
+  const never = await makePlayer(1000);
+  const battle = await abandonedBattle([paid, never]);
+  await recordEntry(paid._id, battle._id); // only one of them was charged
+
+  await engine.completeStuckBattles();
+
+  expect((await User.findById(paid._id)).walletBalance).toBe(1000);
+  expect((await User.findById(never._id)).walletBalance).toBe(1000); // not 1100
+});
+
+test("voiding twice does not pay twice", async () => {
+  const a = await makePlayer(900);
+  const battle = await abandonedBattle([a]);
+  await recordEntry(a._id, battle._id);
+
+  await engine.completeStuckBattles();
+  await engine.completeStuckBattles();
+
+  expect((await User.findById(a._id)).walletBalance).toBe(1000);
+});
+
+test("a battle interrupted mid-reveal still finishes from its preroll", async () => {
+  const a = await makePlayer(900);
+  const b = await makePlayer(900);
+  const battle = await abandonedBattle([a, b]);
+  // this one got as far as committing its seed and preroll, so it has a real outcome
+  const item = {
+    _id: new mongoose.Types.ObjectId(), name: "won", image: "x", rarity: "3",
+    case: new mongoose.Types.ObjectId(), baseValue: 500, uniqueId: `w-${uniqueSuffix()}`,
+  };
+  battle.pfServerSeed = "a".repeat(64);
+  battle.pfServerSeedHash = "b".repeat(64);
+  battle.rolls = [[item, null]]; // slot 0 won something, slot 1 got nothing
+  await battle.save();
+
+  await engine.completeStuckBattles();
+
+  const done = await Battle.findById(battle._id);
+  expect(done.status).toBe("finished");
+  expect(done.winningTeam).toBe(0);
+  const winner = await User.findById(a._id);
+  expect(winner.inventory.map((i) => i.name)).toContain("won");
+});

--- a/backend/games/battleEngine.js
+++ b/backend/games/battleEngine.js
@@ -1,6 +1,7 @@
 const Battle = require("../models/Battle");
 const Case = require("../models/Case");
 const User = require("../models/User");
+const Transaction = require("../models/Transaction");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
 const { chargeUser, creditUser, awardXp, TX } = require("../utils/economy");
 const { modeConfig, evaluateWinner, splitItemsEvenly } = require("../utils/battle");
@@ -235,12 +236,51 @@ async function finishBattle(battle, io = noopIo) {
   return claimed;
 }
 
-// on boot, finish any battle a restart interrupted so none are stuck
+// a battle claimed but abandoned before its preroll committed has no outcome at all:
+// nothing was ever rolled. finishing one invents a winner out of an empty pool (every
+// total is 0, so the tie-break picks at random) and quietly keeps the entry fees.
+async function voidBattle(battle, io = noopIo) {
+  // compare-and-set on status: only one runner voids this battle
+  const claimed = await Battle.findOneAndUpdate(
+    { _id: battle._id, status: "in_progress" },
+    { $set: { status: "cancelled", finishedAt: new Date() } },
+    { new: true }
+  );
+  if (!claimed) return Battle.findById(battle._id);
+
+  // the ledger says who is owed, not the player list: the interruption can just as
+  // easily land between claiming the battle and charging for it, and refunding a slot
+  // that never paid would mint the entry out of nothing
+  const [paid, refunded] = await Promise.all([
+    Transaction.find({ type: TX.BATTLE_ENTRY, "meta.battleId": claimed._id }).select("userId"),
+    Transaction.find({ type: TX.BATTLE_REFUND, "meta.battleId": claimed._id }).select("userId"),
+  ]);
+  const settled = new Set(refunded.map((t) => String(t.userId)));
+
+  for (const entry of paid) {
+    if (settled.has(String(entry.userId))) continue;
+    settled.add(String(entry.userId));
+    const user = await creditUser(entry.userId, claimed.entryCost, 0, {
+      type: TX.BATTLE_REFUND,
+      meta: { battleId: claimed._id, reason: "interrupted before start" },
+    });
+    if (user) emitUserData(io, entry.userId, user);
+  }
+
+  return claimed;
+}
+
+// on boot, settle any battle a restart interrupted so none are left stuck. one that
+// never committed a preroll has nothing to reveal, so it is voided rather than finished
 async function completeStuckBattles(io = noopIo) {
   const stuck = await Battle.find({ status: "in_progress" });
   for (const b of stuck) {
     try {
-      await finishBattle(b, io);
+      if (b.pfServerSeed && b.rolls && b.rolls.length) {
+        await finishBattle(b, io);
+      } else {
+        await voidBattle(b, io);
+      }
     } catch (e) {
       console.log(e);
     }
@@ -248,4 +288,4 @@ async function completeStuckBattles(io = noopIo) {
   return stuck.length;
 }
 
-module.exports = { prerollBattle, chargeAndStart, applyRound, finishBattle, completeStuckBattles };
+module.exports = { prerollBattle, chargeAndStart, applyRound, finishBattle, voidBattle, completeStuckBattles };


### PR DESCRIPTION
## The bug

`chargeAndStart` claims a battle atomically (`waiting` -> `in_progress`) at battleEngine.js:72-74. Only after that does it charge the players (:120-131), and only after that does it commit the server seed and preroll (:137-150).

If the process dies inside that window, the next boot finds a battle in `in_progress` and `completeStuckBattles` hands it to `finishBattle`. That path assumes the preroll exists. It does not, so:

- `claimed.rolls` is empty, so every player is awarded zero items and every total stays 0
- every team is therefore tied, and `pfServerSeed` was never set, so `tieRng` is `undefined`
- `evaluateWinner` falls back to its own default parameter, `rng = Math.random` (utils/battle.js:25), and picks a winner
- the item pool is empty, so the "winner" is paid nothing
- the entry fees are never returned

A battle that never happened is recorded as finished, with a random winner, and everyone's entry is quietly kept.

## The fix

A battle with no committed preroll has no outcome to reveal, so it is now voided rather than finished.

The refund deliberately goes by the **ledger**, not the player list. The same interruption can just as easily land between claiming the battle and charging for it, so the roster is not the same set as the players who actually paid, and refunding a slot that never paid would mint the entry out of nothing. `Transaction` rows of type `battle_entry` for that battle say exactly who paid, and `battle_refund` rows say who has already been made whole, which also makes the void idempotent.

A battle that *did* commit its preroll still finishes from it, exactly as before. That path is unchanged.

## Tests

`backend/__tests__/integration/battleRecovery.test.js`. On the old code the first three fail:

- an abandoned battle refunds the players who paid (was: `finished`, random winner, no refund)
- a player the crash beat to the charge is not refunded money they never paid (guards against the obvious wrong fix)
- voiding twice does not pay twice
- a battle interrupted mid-reveal still finishes from its preroll - **passes on the old code too**, and pins the behaviour the fix must not break

181/181 backend tests pass.