### PR TITLE
Upgrade: price a trade off what it stakes, not off its colors

### DIFF
--- a/backend/__tests__/unit/upgrade.test.js
+++ b/backend/__tests__/unit/upgrade.test.js
@@ -1,42 +1,98 @@
-const { calculateSuccessRate } = require("../../games/upgrade");
+const { calculateSuccessRate, MAX_UPGRADE_CHANCE } = require("../../games/upgrade");
+const { RARITY_MULTIPLIER, UPGRADE_RTP } = require("../../utils/itemValue");
 
-const items = (...rarities) => rarities.map((rarity) => ({ rarity }));
+// within a case an item's value is A * RARITY_MULTIPLIER[rarity], so a rarity is worth
+// its multiplier. A cancels out of every edge below, so it can be 1.
+const value = (rarity) => RARITY_MULTIPLIER[String(rarity)];
+const staked = (...rarities) => rarities.reduce((s, r) => s + value(r), 0);
+
+// what the player gets back per unit staked
+const edgeOf = (rarities, target) => {
+  const inValue = staked(...rarities);
+  const outValue = value(target);
+  return 1 - (calculateSuccessRate(inValue, outValue) * outValue) / inValue;
+};
+
+const RARITIES = [1, 2, 3, 4, 5];
 
 describe("upgrade success rate", () => {
-  test("a single item targeting its own rarity is below the cap", () => {
-    expect(calculateSuccessRate(items("3"), "3")).toBeGreaterThan(0);
-    expect(calculateSuccessRate(items("3"), "3")).toBeLessThanOrEqual(0.6);
+  test("the edge is exactly 1 - UPGRADE_RTP for every rarity pair", () => {
+    for (const from of RARITIES) {
+      for (const to of RARITIES) {
+        // skip the ones a big stake pushes into the cap; covered separately below
+        if (calculateSuccessRate(value(from), value(to)) >= MAX_UPGRADE_CHANCE) continue;
+        expect(edgeOf([from], to)).toBeCloseTo(1 - UPGRADE_RTP, 10);
+      }
+    }
   });
 
-  test("adding an item never lowers the rate (monotonic)", () => {
-    for (const target of ["2", "3", "4", "5"]) {
+  test("no combination of rarities is ever player-positive", () => {
+    // the old table paid the player +40% on 1x rarity-1 -> rarity-4, and stayed
+    // player-positive on that trade for stacks of up to six
+    for (const target of RARITIES) {
+      for (const from of RARITIES) {
+        for (let n = 1; n <= 30; n++) {
+          const edge = edgeOf(Array(n).fill(from), target);
+          expect(edge).toBeGreaterThanOrEqual(-1e-12);
+        }
+      }
+    }
+  });
+
+  test("mixing colors does not move the edge", () => {
+    const mixes = [
+      [1, 4], [4, 1], [1, 1, 5], [3, 3, 1], [2, 3, 4], [1, 2, 3, 4, 5], [5, 1, 1, 1],
+    ];
+    for (const mix of mixes) {
+      for (const target of RARITIES) {
+        if (calculateSuccessRate(staked(...mix), value(target)) >= MAX_UPGRADE_CHANCE) continue;
+        expect(edgeOf(mix, target)).toBeCloseTo(1 - UPGRADE_RTP, 10);
+      }
+    }
+  });
+
+  test("an extra item buys exactly the chance it pays for", () => {
+    // adding a 1 KP rarity-1 to a 24 KP pair of rarity-3s used to buy 8.6% more chance
+    // for 4% more value. the chance must now move in step with the stake.
+    const before = calculateSuccessRate(staked(3, 3), value(4));
+    const after = calculateSuccessRate(staked(3, 3, 1), value(4));
+    expect(after / before).toBeCloseTo(staked(3, 3, 1) / staked(3, 3), 10);
+  });
+
+  test("order of items does not change the result", () => {
+    expect(calculateSuccessRate(staked(1, 3, 2), value(4)))
+      .toBe(calculateSuccessRate(staked(3, 2, 1), value(4)));
+  });
+
+  test("adding an item never lowers the rate", () => {
+    for (const target of RARITIES) {
       let prev = 0;
-      const pool = ["1", "2", "3", "1", "2", "1"];
+      const pool = [1, 2, 3, 1, 2, 1];
       for (let n = 1; n <= pool.length; n++) {
-        const rate = calculateSuccessRate(items(...pool.slice(0, n)), target);
-        expect(rate + 1e-9).toBeGreaterThanOrEqual(prev);
+        const rate = calculateSuccessRate(staked(...pool.slice(0, n)), value(target));
+        expect(rate + 1e-12).toBeGreaterThanOrEqual(prev);
         prev = rate;
       }
     }
   });
 
-  test("the regression case no longer shrinks (target 4: r3 vs r3+r1)", () => {
-    const one = calculateSuccessRate(items("3"), "4");
-    const two = calculateSuccessRate(items("3", "1"), "4");
-    expect(two).toBeGreaterThanOrEqual(one);
+  test("an oversized stake is capped rather than promised", () => {
+    // 100x rarity-5 against a rarity-1 target would ask for a chance of 9000
+    const rate = calculateSuccessRate(staked(...Array(100).fill(5)), value(1));
+    expect(rate).toBe(MAX_UPGRADE_CHANCE);
+    expect(rate).toBeLessThan(1);
   });
 
-  test("order of items does not change the result", () => {
-    const a = calculateSuccessRate(items("1", "3", "2"), "4");
-    const b = calculateSuccessRate(items("3", "2", "1"), "4");
-    expect(a).toBeCloseTo(b, 10);
+  test("a capped trade is still house-positive", () => {
+    // overpaying is the player's own bad trade; it must never turn into a player edge
+    expect(edgeOf(Array(100).fill(5), 1)).toBeGreaterThan(0);
+    expect(edgeOf([4, 4], 4)).toBeGreaterThan(0);
   });
 
-  test("caps are enforced per target rarity", () => {
-    const many = items("4", "4", "4", "4", "4", "4", "4", "4");
-    expect(calculateSuccessRate(many, "5")).toBeLessThanOrEqual(0.2);
-    expect(calculateSuccessRate(many, "4")).toBeLessThanOrEqual(0.45);
-    expect(calculateSuccessRate(many, "3")).toBeLessThanOrEqual(0.6);
-    expect(calculateSuccessRate(many, "2")).toBeLessThanOrEqual(0.7);
+  test("worthless or missing values never produce a chance", () => {
+    expect(calculateSuccessRate(0, 100)).toBe(0);
+    expect(calculateSuccessRate(100, 0)).toBe(0);
+    expect(calculateSuccessRate(undefined, 100)).toBe(0);
+    expect(calculateSuccessRate(-5, 100)).toBe(0);
   });
 });

--- a/backend/games/upgrade.js
+++ b/backend/games/upgrade.js
@@ -3,43 +3,26 @@ const Item = require("../models/Item");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const { UPGRADE_RTP } = require("../utils/itemValue");
 
-const UPGRADE_ALGO_VERSION = 1; // bump if calculateSuccessRate ever changes
+const UPGRADE_ALGO_VERSION = 2; // bump if calculateSuccessRate ever changes
 
-const baseChances = {
-  "1": { "1": 0.5, "2": 0.2, "3": 0.1, "4": 0.05, "5": 0.002 },
-  "2": { "1": 0.2, "2": 0.5, "3": 0.2, "4": 0.1, "5": 0.01 },
-  "3": { "1": 0.1, "2": 0.2, "3": 0.5, "4": 0.2, "5": 0.05 },
-  "4": { "1": 0.05, "2": 0.1, "3": 0.2, "4": 0.5, "5": 0.1 },
-  "5": { "1": 0.002, "2": 0.01, "3": 0.05, "4": 0.1, "5": 0.5 }
-};
+// nothing is ever a certainty: staking more than the target is worth still leaves a
+// sliver of risk, and this is what stops an oversized stake asking for a chance above 1
+const MAX_UPGRADE_CHANCE = 0.95;
 
-const rarityFactors = { "4": 0.7, "5": 0.5 };
-const rarityCaps = { "1": 0.8, "2": 0.7, "3": 0.6, "4": 0.45, "5": 0.2 };
-const diminishingRate = 0.9; // 90% effectiveness for each subsequent item
-
-// success rate uses 1 - product(1 - chance), so each item can only help. the
-// per-item contributions are sorted strongest-first before the diminishing
-// factor is applied, which makes the result independent of selection order and
-// keeps it monotonic (adding an item never lowers the rate).
-const calculateSuccessRate = (selectedItems, targetRarity) => {
-  const rarityFactor = rarityFactors[targetRarity] || 1;
-
-  const contributions = selectedItems
-    .map((item) => {
-      const baseChance = (baseChances[item.rarity] || {})[targetRarity] || 0;
-      return baseChance * rarityFactor;
-    })
-    .sort((a, b) => b - a);
-
-  let failChance = 1;
-  contributions.forEach((chance, index) => {
-    failChance *= 1 - chance * Math.pow(diminishingRate, index);
-  });
-
-  const successRate = 1 - failChance;
-  const cap = rarityCaps[targetRarity] !== undefined ? rarityCaps[targetRarity] : 0.8;
-  return Math.min(successRate, cap);
+// the chance is the stake measured against the prize: p = RTP * staked / target. the
+// player's return is p * target / staked, so it is UPGRADE_RTP for every trade, and the
+// edge is a flat 1 - UPGRADE_RTP whatever mix of rarities goes in.
+//
+// it used to be read off a rarity-to-rarity table that had nothing to do with the
+// rarity multipliers item values are built from. the two were never reconciled, so the
+// edge swung from -40% (the player profiting, on 1x rarity-1 -> rarity-4) to +90%
+// depending purely on which colors were fed in, and adding a 1 KP item to a 24 KP stake
+// bought more chance than it paid for.
+const calculateSuccessRate = (stakedValue, targetValue) => {
+  if (!(stakedValue > 0) || !(targetValue > 0)) return 0;
+  return Math.min((UPGRADE_RTP * stakedValue) / targetValue, MAX_UPGRADE_CHANCE);
 };
 
 // Helper function to validate if all items belong to the same case
@@ -81,10 +64,18 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
       return { status: 400, message: "No items selected" };
     }
 
+    // the catalog is the authority on what an item is worth: an inventory entry carries
+    // no value at all, and some older ones lost their case too
+    const catalog = await Item.find(
+      { _id: { $in: [...new Set(selectedItems.map((invItem) => String(invItem._id)))] } },
+      { baseValue: 1, case: 1 }
+    );
+    const sourceById = new Map(catalog.map((item) => [String(item._id), item]));
+
     // backfill case for items that lost it (e.g. bought before case was preserved)
     for (const item of selectedItems) {
       if (!item.case) {
-        const sourceItem = await Item.findById(item._id);
+        const sourceItem = sourceById.get(String(item._id));
         if (sourceItem) item.case = sourceItem.case;
       }
     }
@@ -95,6 +86,15 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
 
     if (!verifyLesserRarity(selectedItems, targetItem)) {
       return { status: 400, message: "You can't upgrade to a lesser rarity" };
+    }
+
+    const stakedValue = selectedItems.reduce((sum, invItem) => {
+      const sourceItem = sourceById.get(String(invItem._id));
+      return sum + ((sourceItem && sourceItem.baseValue) || 0);
+    }, 0);
+    const targetValue = targetItem.baseValue || 0;
+    if (!(stakedValue > 0) || !(targetValue > 0)) {
+      return { status: 400, message: "These items have no value yet" };
     }
 
     // reserve the provably-fair nonce up front (atomic, never rolled back)
@@ -118,7 +118,7 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
     }
 
     // success is the provably-fair roll: succeed when the [0,1) draw is below the rate
-    const successRate = calculateSuccessRate(selectedItems, targetItem.rarity);
+    const successRate = calculateSuccessRate(stakedValue, targetValue);
     const rollFloatValue = rollFloat(reserved.serverSeed, reserved.clientSeed, nonce);
     const isSuccess = rollFloatValue < successRate;
 
@@ -157,6 +157,10 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
       outcome: {
         success: isSuccess,
         successRate,
+        // the two numbers the rate is derived from, so a past roll stays checkable
+        // even after the catalog revalues the items
+        stakedValue,
+        targetValue,
         targetItemId: String(targetItem._id),
         targetRarity: targetItem.rarity,
         algoVersion: UPGRADE_ALGO_VERSION,
@@ -178,4 +182,4 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
 module.exports = upgradeItems;
 // exposed for unit testing
 module.exports.calculateSuccessRate = calculateSuccessRate;
-module.exports.baseChances = baseChances;
+module.exports.MAX_UPGRADE_CHANCE = MAX_UPGRADE_CHANCE;

--- a/backend/utils/itemValue.js
+++ b/backend/utils/itemValue.js
@@ -3,6 +3,7 @@ const { Rarities } = require("./caseOpening");
 // tunable economy knobs
 const RARITY_MULTIPLIER = { "1": 1, "2": 4, "3": 12, "4": 40, "5": 100 };
 const RTP = 0.9; // expected item value per open = case price * RTP (10% open edge)
+const UPGRADE_RTP = 0.9; // expected item value out per value staked (10% upgrade edge)
 const SELL_RATE = 0.75; // instant sell-to-house = base value * SELL_RATE
 const MARKET_FEE_RATE = 0.05; // house cut on a marketplace sale, paid by the seller
 
@@ -86,6 +87,7 @@ async function recomputeCaseValues(caseId) {
 module.exports = {
   RARITY_MULTIPLIER,
   RTP,
+  UPGRADE_RTP,
   SELL_RATE,
   MARKET_FEE_RATE,
   baseValuesForCase,

--- a/src/pages/Upgrade/Items.tsx
+++ b/src/pages/Upgrade/Items.tsx
@@ -20,44 +20,26 @@ const Items: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedT
     const { userData } = useContext(UserContext);
 
 
-    const baseChances: any = {
-        "1": { "1": 0.5, "2": 0.2, "3": 0.1, "4": 0.05, "5": 0.002 },
-        "2": { "1": 0.2, "2": 0.5, "3": 0.2, "4": 0.1, "5": 0.01 },
-        "3": { "1": 0.1, "2": 0.2, "3": 0.5, "4": 0.2, "5": 0.05 },
-        "4": { "1": 0.05, "2": 0.1, "3": 0.2, "4": 0.5, "5": 0.1 },
-        "5": { "1": 0.002, "2": 0.01, "3": 0.05, "4": 0.1, "5": 0.5 }
-    };
+    // mirrors backend/games/upgrade.js exactly, so the rate on screen is the rate the
+    // server rolls. the chance is the stake measured against the prize, which holds the
+    // edge at 1 - UPGRADE_RTP however the rarities are mixed.
+    const UPGRADE_RTP = 0.9;
+    const MAX_UPGRADE_CHANCE = 0.95;
 
-    // mirrors the server formula exactly (sorted strongest-first, order-independent)
-    // so the displayed rate matches the rate the server actually rolls
-    const rarityFactors: any = { "4": 0.7, "5": 0.5 };
-    const rarityCaps: any = { "1": 0.8, "2": 0.7, "3": 0.6, "4": 0.45, "5": 0.2 };
-    const diminishingRate = 0.9;
-
-    const calculateSuccessRate = (selectedItems: any, targetRarity: string) => {
-        const rarityFactor = rarityFactors[targetRarity] || 1;
-
-        const contributions = selectedItems
-            .map((item: any) => {
-                const baseChance = (baseChances[item.item.rarity] || {})[targetRarity] || 0;
-                return baseChance * rarityFactor;
-            })
-            .sort((a: number, b: number) => b - a);
-
-        let failChance = 1;
-        contributions.forEach((chance: number, index: number) => {
-            failChance *= 1 - chance * Math.pow(diminishingRate, index);
-        });
-
-        const successRate = 1 - failChance;
-        const cap = rarityCaps[targetRarity] !== undefined ? rarityCaps[targetRarity] : 0.8;
-        return Math.min(successRate, cap);
+    const calculateSuccessRate = (items: any, target: any) => {
+        const stakedValue = items.reduce(
+            (sum: number, selected: any) => sum + (selected.item?.baseValue || 0),
+            0
+        );
+        const targetValue = target?.baseValue || 0;
+        if (stakedValue <= 0 || targetValue <= 0) return 0;
+        return Math.min((UPGRADE_RTP * stakedValue) / targetValue, MAX_UPGRADE_CHANCE);
     };
 
     useEffect(() => {
         if (selectedTarget && selectedItems.length > 0) {
             setFinished(false)
-            const rate = calculateSuccessRate(selectedItems, selectedTarget.rarity);
+            const rate = calculateSuccessRate(selectedItems, selectedTarget);
             setSuccessRate(rate);
 
         } else {


### PR DESCRIPTION
## The bug

Item value is `round(A * RARITY_MULTIPLIER[rarity])` (itemValue.js:4,37), so within a case **value is a pure function of rarity**. But `calculateSuccessRate` read the odds off a completely separate `baseChances` rarity-to-rarity table (upgrade.js:9-19) that had no relationship to those multipliers. The two were never reconciled, and the house edge was whatever fell out of the gap between them.

Computed from the real constants:

| trade | p | value x | EV | edge |
|---|---|---|---|---|
| 1x r1 -> r4 | 0.0350 | 40.00 | **1.4000** | **-40.00%** |
| 1x r1 -> r3 | 0.1000 | 12.00 | **1.2000** | **-20.00%** |
| 1x r1 -> r5 | 0.0010 | 100.00 | 0.1000 | +90.00% |
| 1x r4 -> r5 | 0.0500 | 2.50 | 0.1250 | +87.50% |
| 1x r4 -> r4 | 0.3500 | 1.00 | 0.3500 | +65.00% |

A negative edge means **the player profits**. `1x rarity-1 -> rarity-4` returned 1.4x in expectation in any case holding both rarities, and stacks stayed player-positive up to six items. That was farmable.

Mixing rarities made it incoherent, because the rate came from a diminishing-returns product over rarities and never looked at value at all:

- `2x r3 + 1x r1 -> r4`: adding a **1 KP** item to a 24 KP stake raised the chance from 0.2484 to 0.2697. 4% more value bought 8.6% more chance.
- `6x r1 + 1x r4 -> r4`: staked **46 KP** on a 0.44 shot at a **40 KP** item.

## The fix

The chance is now the stake measured against the prize:

```
p = min(UPGRADE_RTP * stakedValue / targetValue, MAX_UPGRADE_CHANCE)
```

The player's return is `p * target / staked = UPGRADE_RTP`, so the edge is a flat **10%** for every trade, whatever mix of rarities goes in. `UPGRADE_RTP` sits with the other economy knobs in `itemValue.js`.

Values are resolved from the **catalog**, not the inventory snapshot, which carries no value at all. `MAX_UPGRADE_CHANCE = 0.95` keeps an oversized stake from asking for a chance above 1; a capped trade is the player's own bad trade and stays house-positive.

The roll record now pins `stakedValue` and `targetValue` alongside `successRate`, so a past upgrade stays checkable after the catalog revalues its items. `UPGRADE_ALGO_VERSION` is bumped to 2.

The frontend duplicated the whole formula (`Items.tsx:23-54`), so it mirrors the new one and the wheel still shows the rate the server actually rolls.

## This changes the game

Some trades move a long way. `r4 -> r5` goes from a 5% chance to **36%**, and same-rarity rerolls from 35% to 90%, because those were charging 65-87% edge. `r1 -> r4` goes from 3.5% to **2.25%**, because it was paying the player.

## Tests

The old tests only ever checked monotonicity, ordering and caps - never the edge, which is why this survived. The new suite checks the edge directly:

- the edge is exactly `1 - UPGRADE_RTP` for every rarity pair
- **no combination of rarities is ever player-positive** (every rarity, stacks 1-30)
- mixing colors does not move the edge
- an extra item buys exactly the chance it pays for
- an oversized stake is capped rather than promised, and a capped trade is still house-positive
- worthless or missing values never produce a chance

Verified end-to-end against a real 1000 KP case through `baseValuesForCase`: every trade lands on exactly 10% with the real rounded values.

181/181 backend tests pass. Frontend lint clean (0 errors) and build passes.