### PR TITLE
Coin flip: give it a house edge

### DIFF
--- a/backend/__tests__/unit/coinFlip.test.js
+++ b/backend/__tests__/unit/coinFlip.test.js
@@ -1,0 +1,38 @@
+const { winPayout, COINFLIP_RTP } = require("../../games/coinFlip");
+
+// the coin itself is fair, so the edge lives entirely in the payout
+const edgeAt = (bet) => 1 - (0.5 * winPayout(bet)) / bet;
+
+describe("coin flip payout", () => {
+  test("a win pays 1.94x the stake", () => {
+    expect(winPayout(100)).toBe(194);
+    expect(winPayout(1000)).toBe(1940);
+    expect(winPayout(50000)).toBe(97000);
+  });
+
+  test("the edge is 1 - COINFLIP_RTP on any bet the rounding does not dominate", () => {
+    for (const bet of [50, 100, 250, 1000, 12345, 1000000]) {
+      expect(edgeAt(bet)).toBeCloseTo(1 - COINFLIP_RTP, 3);
+    }
+  });
+
+  test("no bet size rounds into a player edge", () => {
+    // this is the whole point: paying 2x on a fair coin was an edge of exactly zero
+    for (let bet = 1; bet <= 5000; bet++) {
+      expect(edgeAt(bet)).toBeGreaterThan(0);
+    }
+  });
+
+  test("the payout is always whole KP", () => {
+    for (const bet of [1, 3, 7, 99, 12345]) {
+      expect(Number.isInteger(winPayout(bet))).toBe(true);
+    }
+  });
+
+  test("a win still returns more than the stake", () => {
+    // floor must never make winning worse than not playing
+    for (let bet = 1; bet <= 200; bet++) {
+      expect(winPayout(bet)).toBeGreaterThanOrEqual(bet);
+    }
+  });
+});

--- a/backend/games/coinFlip.js
+++ b/backend/games/coinFlip.js
@@ -1,5 +1,19 @@
 const { chargeUser, creditUser, TX } = require("../utils/economy");
 
+// a fair coin paying 2x is a 0% house edge: the house cannot win, and the game is a
+// pure variance pump on the KP supply that no amount of play ever drains. paying
+// 1.94x puts it at 3%, in the same band as crash (3.97%) and slots (3.55%).
+// floor keeps the payout in whole KP and always rounds towards the house, so there is
+// no bet size that rounds its way into a player edge.
+const COINFLIP_RTP = 0.97;
+const winPayout = (bet) => Math.floor(bet * 2 * COINFLIP_RTP);
+
+// a table minimum, for the reason real tables have one: the payout is whole KP, and no
+// integer pays 3% on a 1 KP stake (1 is 50%, 2 is 0%), so below a floor the rounding is
+// the edge. at 10 the worst case is 5% and by 50 it is exactly 3%.
+const MIN_BET = 10;
+const MAX_BET = 1000000;
+
 const freshState = () => ({
   heads: { players: {}, bets: {} },
   tails: { players: {}, bets: {} },
@@ -25,8 +39,8 @@ const coinFlip = (io) => {
         if (!bettingOpen) return reply({ error: "Betting is closed for this round" });
 
         if (choice !== 0 && choice !== 1) return reply({ error: "Pick heads or tails" });
-        if (!Number.isInteger(bet) || bet < 1 || bet > 1000000) {
-          return reply({ error: "Invalid bet amount" });
+        if (!Number.isInteger(bet) || bet < MIN_BET || bet > MAX_BET) {
+          return reply({ error: `Bet between ${MIN_BET} and ${MAX_BET} KP` });
         }
 
         const side = choice === 0 ? "heads" : "tails";
@@ -86,9 +100,10 @@ const coinFlip = (io) => {
     for (const userId in gameState[winningSide].bets) {
       try {
         const betAmount = gameState[winningSide].bets[userId];
-        const updatedUser = await creditUser(userId, betAmount * 2, betAmount, {
+        const payout = winPayout(betAmount);
+        const updatedUser = await creditUser(userId, payout, payout - betAmount, {
           type: TX.COINFLIP_WIN,
-          meta: { betAmount, side: winningSide },
+          meta: { betAmount, payout, side: winningSide },
         });
         if (!updatedUser) continue; // account no longer exists
 
@@ -127,3 +142,7 @@ const coinFlip = (io) => {
 };
 
 module.exports = coinFlip;
+// exposed for unit testing
+module.exports.winPayout = winPayout;
+module.exports.COINFLIP_RTP = COINFLIP_RTP;
+module.exports.MIN_BET = MIN_BET;

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -8,6 +8,12 @@ import LiveBets from "./LiveBets";
 
 const socket = SocketConnection.getInstance();
 
+// mirrors backend/games/coinFlip.js: a win pays 1.94x, and the minimum exists because
+// the payout is whole KP, so below it the rounding would be the house edge
+const WIN_MULTIPLIER = 1.94;
+const MIN_BET = 10;
+const MAX_BET = 1000000;
+
 interface GameHistory {
   result: number;
 }
@@ -165,19 +171,27 @@ const CoinFlip = () => {
               }
             </div></div>
           <button onClick={handleBet} className=" p-2 border rounded bg-indigo-600 hover:bg-indigo-700 w-full mt-4" disabled={
-            choice === null || bet === 0 || userGambled || (userData !== null && userData.walletBalance < bet) || spinning || bet > 1000000
+            choice === null || bet < MIN_BET || userGambled || (userData !== null && userData.walletBalance < bet) || spinning || bet > MAX_BET
           }>
             {
 
               spinning ? "Spinning..."
                 : choice === null ? "Choose a side"
                   : bet === 0 ? "Place the bet value"
-                    : bet > 1000000 ? "Max bet is 1M"
-                      : userGambled ? "You're in!"
-                        : userData !== null && userData.walletBalance < bet ? "Not enough money"
-                          : "Enter the Game"
+                    : bet < MIN_BET ? `Min bet is ${MIN_BET}`
+                      : bet > MAX_BET ? "Max bet is 1M"
+                        : userGambled ? "You're in!"
+                          : userData !== null && userData.walletBalance < bet ? "Not enough money"
+                            : "Enter the Game"
             }
           </button>
+          {/* the payout is not 2x, so it says so rather than leaving it to be inferred */}
+          <div className="flex justify-between text-xs text-[#84819a] pt-2">
+            <span>Win pays {WIN_MULTIPLIER}x</span>
+            {bet >= MIN_BET && bet <= MAX_BET && (
+              <span>You'd win {Math.floor(bet * WIN_MULTIPLIER).toLocaleString()} K₽</span>
+            )}
+          </div>
         </div>
         <div className="flex flex-col">
           <div className="flex lg:w-[800px] border-b border-gray-700  p-4">


### PR DESCRIPTION
## The bug

Coin flip paid `betAmount * 2` (coinFlip.js:89) on a fair coin (`Math.floor(Math.random() * 2)`, coinFlip.js:110). That is a house edge of **exactly zero**, and there is no fee or rake anywhere in the file.

The house could not win. No volume of play drained a single KP, so the game was a pure variance pump on the KP supply while every other game slowly burned it. It was also the cheapest way to move KP between two accounts with no friction at all.

For comparison, computed from the real constants: crash is 3.97%, slots 3.5469%, case open 10%.

## The fix

A win pays **1.94x**, a 3% edge, in the same band as the other live games. `COINFLIP_RTP = 0.97` is a named constant next to the game, matching how crash keeps `INSTANT_CRASH_CHANCE` in `crashMath.js`.

The payout **floors**, so it is always whole KP and always rounds towards the house. No bet size can round its way into a player edge (there is a test over every bet from 1 to 5000).

## Why there is now a 10 KP minimum

That rounding is also the reason for a table minimum. The payout is an integer, and **no integer pays 3% on a 1 KP stake** - 1 is a 50% edge, 2 is 0%. So below a floor, the rounding *is* the edge:

| bet | payout | profit | edge |
|---|---|---|---|
| 1 | 1 | 0 | 50.00% |
| 5 | 9 | 4 | 10.00% |
| 10 | 19 | 9 | 5.00% |
| 50 | 97 | 47 | 3.00% |
| 1000 | 1940 | 940 | 3.00% |

Winning a 1 KP bet and getting exactly 1 KP back is not a game. A minimum of 10 caps the worst case at 5% and is exactly 3% from 50 up. Real tables have minimums for this reason. 10 KP is 5% of a single bonus claim.

## Also

- Weekly winnings recorded the **whole stake** as profit (`creditUser(id, bet * 2, bet)`). It now records `payout - stake`, the same as crash does.
- The UI states `Win pays 1.94x` and the exact payout. It never displayed a multiplier before, so nothing on screen promised 2x, but a coin flip implies double-or-nothing and players deserve to see that it is not.

## Tests

`backend/__tests__/unit/coinFlip.test.js`:

- a win pays 1.94x the stake
- the edge is `1 - COINFLIP_RTP` on any bet the rounding does not dominate
- **no bet size rounds into a player edge** (every bet from 1 to 5000)
- the payout is always whole KP, and a win always returns at least the stake

186/186 backend tests pass. Frontend lint clean (0 errors), build and e2e pass.