### PR TITLE
Refunds: stop an interrupted give-back keeping what it still owes

### DIFF
--- a/backend/__tests__/integration/refundResume.test.js
+++ b/backend/__tests__/integration/refundResume.test.js
@@ -1,0 +1,140 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+// creditUser is destructured at module load inside rounds.js/battleEngine.js, so it has
+// to be replaced at require time; a later spy would not be seen by them
+jest.mock("../../utils/economy", () => {
+  const actual = jest.requireActual("../../utils/economy");
+  return { ...actual, creditUser: jest.fn((...args) => actual.creditUser(...args)) };
+});
+
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Round = require("../../models/Round");
+const Battle = require("../../models/Battle");
+const Transaction = require("../../models/Transaction");
+const { creditUser, TX } = require("../../utils/economy");
+const { recoverStuckRounds } = require("../../utils/rounds");
+const engine = require("../../games/battleEngine");
+const { winPayout } = require("../../games/coinFlip");
+
+beforeAll(setupDb);
+afterEach(async () => {
+  creditUser.mockClear();
+  await clearDb();
+});
+afterAll(teardownDb);
+
+const makeUser = (walletBalance) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+};
+
+const balanceOf = async (u) => (await User.findById(u._id)).walletBalance;
+
+const stakeRow = (user, roundId, amount, type) =>
+  Transaction.create({
+    userId: user._id, type, direction: "debit", amount, balanceAfter: 0,
+    meta: { roundId: String(roundId) },
+  });
+
+// the process dying inside the refund loop, on the nth credit
+const dieOnCredit = (n) => {
+  const actual = jest.requireActual("../../utils/economy");
+  let seen = 0;
+  creditUser.mockImplementation(async (...args) => {
+    seen += 1;
+    if (seen === n) throw new Error("the process died mid-refund");
+    return actual.creditUser(...args);
+  });
+};
+
+const creditWorksAgain = () => {
+  const actual = jest.requireActual("../../utils/economy");
+  creditUser.mockImplementation((...args) => actual.creditUser(...args));
+};
+
+const recover = () => recoverStuckRounds(undefined, winPayout);
+
+// a dead process leaves its lease behind. the next sweep only takes it over once the
+// lease has gone stale, so that is what a later boot actually sees.
+const expireLease = (Model, id) =>
+  Model.updateOne({ _id: id }, { $set: { settlementStartedAt: new Date(Date.now() - 300000) } });
+
+test("a restart inside the refund loop does not strand the stakers it had not reached", async () => {
+  const a = await makeUser(900);
+  const b = await makeUser(900);
+  const c = await makeUser(900);
+  const round = await Round.create({
+    game: "crash", status: "betting",
+    bets: [a, b, c].map((u) => ({ userId: u._id, amount: 100 })),
+  });
+  for (const u of [a, b, c]) await stakeRow(u, round._id, 100, TX.CRASH_BET);
+
+  // the void gets one refund out and then the process dies
+  dieOnCredit(2);
+  await recover().catch(() => {});
+
+  // a second boot must finish the job. the round is already marked voided, so this
+  // only works if recovery revisits a void whose refunds never completed.
+  creditWorksAgain();
+  await expireLease(Round, round._id);
+  await recover();
+
+  expect(await balanceOf(a)).toBe(1000);
+  expect(await balanceOf(b)).toBe(1000);
+  expect(await balanceOf(c)).toBe(1000);
+});
+
+test("finishing an interrupted void does not refund the ones it already paid", async () => {
+  const a = await makeUser(900);
+  const b = await makeUser(900);
+  const round = await Round.create({
+    game: "crash", status: "betting",
+    bets: [a, b].map((u) => ({ userId: u._id, amount: 100 })),
+  });
+  for (const u of [a, b]) await stakeRow(u, round._id, 100, TX.CRASH_BET);
+
+  dieOnCredit(2);
+  await recover().catch(() => {});
+  creditWorksAgain();
+  await expireLease(Round, round._id);
+  await recover();
+  await expireLease(Round, round._id);
+  await recover(); // and again, for good measure
+
+  expect(await balanceOf(a)).toBe(1000); // not 1100
+  expect(await balanceOf(b)).toBe(1000);
+  expect(await Transaction.countDocuments({ type: TX.CRASH_REFUND })).toBe(2);
+});
+
+test("a battle void interrupted mid-refund is finished on the next boot", async () => {
+  const a = await makeUser(900);
+  const b = await makeUser(900);
+  const battle = await Battle.create({
+    status: "in_progress",
+    mode: "1v1",
+    cases: [new mongoose.Types.ObjectId()],
+    entryCost: 100,
+    createdBy: a._id,
+    players: [a, b].map((u, i) => ({ userId: u._id, username: u.username, team: i, slot: i })),
+    rolls: [],
+    currentRound: 0,
+  });
+  for (const u of [a, b]) {
+    await Transaction.create({
+      userId: u._id, type: TX.BATTLE_ENTRY, direction: "debit", amount: 100,
+      balanceAfter: 0, meta: { battleId: battle._id },
+    });
+  }
+
+  dieOnCredit(2);
+  await engine.completeStuckBattles().catch(() => {});
+  creditWorksAgain();
+  await expireLease(Battle, battle._id);
+  await engine.completeStuckBattles();
+
+  expect(await balanceOf(a)).toBe(1000);
+  expect(await balanceOf(b)).toBe(1000);
+});

--- a/backend/games/battleEngine.js
+++ b/backend/games/battleEngine.js
@@ -17,6 +17,9 @@ const { getOrCreateActiveSeed } = require("../utils/seeds");
 
 const noopIo = { to: () => ({ emit: () => {} }), emit: () => {} };
 
+// how long a refund loop's claim is trusted before another boot may take it over
+const SETTLEMENT_LEASE_MS = 60000;
+
 const emitUserData = (io, userId, user) => {
   io.to(userId.toString()).emit("userDataUpdated", {
     walletBalance: user.walletBalance,
@@ -240,10 +243,20 @@ async function finishBattle(battle, io = noopIo) {
 // nothing was ever rolled. finishing one invents a winner out of an empty pool (every
 // total is 0, so the tie-break picks at random) and quietly keeps the entry fees.
 async function voidBattle(battle, io = noopIo) {
-  // compare-and-set on status: only one runner voids this battle
+  // the claim doubles as a lease. "cancelled" is in the filter so a refund loop that
+  // died partway can be picked up again, and the lease stops two boots both running it
+  // and refunding the same player twice. a lease older than this is assumed dead.
   const claimed = await Battle.findOneAndUpdate(
-    { _id: battle._id, status: "in_progress" },
-    { $set: { status: "cancelled", finishedAt: new Date() } },
+    {
+      _id: battle._id,
+      status: { $in: ["in_progress", "cancelled"] },
+      settlementDone: { $ne: true },
+      $or: [
+        { settlementStartedAt: { $exists: false } },
+        { settlementStartedAt: { $lte: new Date(Date.now() - SETTLEMENT_LEASE_MS) } },
+      ],
+    },
+    { $set: { status: "cancelled", finishedAt: new Date(), settlementStartedAt: new Date() } },
     { new: true }
   );
   if (!claimed) return Battle.findById(battle._id);
@@ -267,13 +280,27 @@ async function voidBattle(battle, io = noopIo) {
     if (user) emitUserData(io, entry.userId, user);
   }
 
+  // only now is the battle finished with: until this lands, recovery will come back
+  await Battle.updateOne({ _id: claimed._id }, { $set: { settlementDone: true } });
   return claimed;
 }
 
 // on boot, settle any battle a restart interrupted so none are left stuck. one that
-// never committed a preroll has nothing to reveal, so it is voided rather than finished
+// never committed a preroll has nothing to reveal, so it is voided rather than finished.
+// the second arm picks up a void whose own refund loop died partway: it keys on
+// settlementStartedAt, which only exists once that loop has claimed the battle, so
+// battles cancelled before this existed are left alone.
 async function completeStuckBattles(io = noopIo) {
-  const stuck = await Battle.find({ status: "in_progress" });
+  const stuck = await Battle.find({
+    $or: [
+      { status: "in_progress" },
+      {
+        status: "cancelled",
+        settlementStartedAt: { $exists: true },
+        settlementDone: { $ne: true },
+      },
+    ],
+  });
   for (const b of stuck) {
     try {
       if (b.pfServerSeed && b.rolls && b.rolls.length) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -71,6 +71,7 @@ const coinFlip = require("./games/coinFlip");
 const crash = require("./games/crash");
 const caseBattle = require("./games/caseBattle");
 const { recoverStuckRounds } = require("./utils/rounds");
+const { completeStuckBattles } = require("./games/battleEngine");
 const userRoutes = require("./routes/userRoutes");
 const caseRoutes = require("./routes/caseRoutes");
 const itemRoutes = require("./routes/itemRoutes");
@@ -113,8 +114,15 @@ app.use("/collections", collectionsRoutes);
 app.use("/missions", missionsRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
-// crash or coin flip round holds real stakes, and until this runs they are unaccounted
-recoverStuckRounds(io, coinFlip.winPayout).catch((e) => console.log(e));
+// crash or coin flip round holds real stakes, and until this runs they are unaccounted.
+// it repeats because a give-back loop that dies holds its lease until that goes stale,
+// and a boot-only sweep would leave the money it still owes until the next restart.
+const sweepRounds = () => {
+  recoverStuckRounds(io, coinFlip.winPayout).catch((e) => console.log(e));
+  completeStuckBattles(io).catch((e) => console.log(e));
+};
+sweepRounds();
+setInterval(sweepRounds, 5 * 60 * 1000);
 
 // Start the games
 coinFlip(io);

--- a/backend/models/Battle.js
+++ b/backend/models/Battle.js
@@ -51,6 +51,10 @@ const BattleSchema = new mongoose.Schema(
     pfServerSeedHash: String, // committed at start
     startedAt: Date,
     finishedAt: Date,
+    // a refund loop marks the battle when it claims it and again when it finishes, so
+    // one that dies partway can be picked up rather than keeping the entries it owes
+    settlementStartedAt: Date,
+    settlementDone: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/backend/models/Round.js
+++ b/backend/models/Round.js
@@ -37,6 +37,10 @@ const RoundSchema = new mongoose.Schema(
     bets: { type: [roundBetSchema], default: [] },
     startedAt: Date,
     settledAt: Date,
+    // a give-back loop marks the round when it claims it and again when it finishes, so
+    // one that dies partway can be picked up rather than keeping what it still owes
+    settlementStartedAt: Date,
+    settlementDone: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/backend/utils/rounds.js
+++ b/backend/utils/rounds.js
@@ -4,6 +4,21 @@ const { creditUser, TX } = require("./economy");
 
 const noopIo = { to: () => ({ emit: () => {} }), emit: () => {} };
 
+// a give-back loop that dies partway through used to be unreachable forever: the round
+// was already marked terminal, and the boot sweep only looked at live ones, so whoever
+// the loop had not reached yet kept nothing. recovery now re-enters a round whose
+// settlement never finished, and the claim doubles as a lease so two boots cannot both
+// run the loop and pay the same staker twice. a lease older than this is assumed dead.
+const SETTLEMENT_LEASE_MS = 60000;
+
+const leaseFilter = () => ({
+  settlementDone: { $ne: true },
+  $or: [
+    { settlementStartedAt: { $exists: false } },
+    { settlementStartedAt: { $lte: new Date(Date.now() - SETTLEMENT_LEASE_MS) } },
+  ],
+});
+
 const TYPES = {
   crash: { bet: TX.CRASH_BET, refund: TX.CRASH_REFUND, paid: TX.CRASH_CASHOUT },
   coinflip: { bet: TX.COINFLIP_BET, refund: TX.COINFLIP_REFUND, paid: TX.COINFLIP_WIN },
@@ -34,12 +49,17 @@ async function settledUserIds(roundId, types) {
 // made whole, because a round that did not finish cannot be said to have lost.
 async function voidRound(round, io = noopIo) {
   const types = TYPES[round.game];
+  // "voided" is in the filter so an interrupted void can be picked up again
   const claimed = await Round.findOneAndUpdate(
-    { _id: round._id, status: { $in: ["betting", "running"] } },
-    { $set: { status: "voided", settledAt: new Date() } },
+    {
+      _id: round._id,
+      status: { $in: ["betting", "running", "voided"] },
+      ...leaseFilter(),
+    },
+    { $set: { status: "voided", settledAt: new Date(), settlementStartedAt: new Date() } },
     { new: true }
   );
-  if (!claimed) return null; // another runner got there first
+  if (!claimed) return null; // already given back, or another runner holds the lease
 
   const settled = await settledUserIds(claimed._id, types);
   const staked = await Transaction.find({
@@ -57,6 +77,9 @@ async function voidRound(round, io = noopIo) {
     });
     emitUserData(io, userId, user);
   }
+
+  // only now is the round finished with: until this lands, recovery will come back
+  await Round.updateOne({ _id: claimed._id }, { $set: { settlementDone: true } });
   return claimed;
 }
 
@@ -65,9 +88,10 @@ async function voidRound(round, io = noopIo) {
 // interruption beat to the credit are paid.
 async function settleInterruptedCoinFlip(round, io = noopIo, payoutFor) {
   const types = TYPES.coinflip;
+  // "settled" is in the filter so a payout loop that died partway is picked up again
   const claimed = await Round.findOneAndUpdate(
-    { _id: round._id, status: "running" },
-    { $set: { status: "settled", settledAt: new Date() } },
+    { _id: round._id, status: { $in: ["running", "settled"] }, ...leaseFilter() },
+    { $set: { status: "settled", settledAt: new Date(), settlementStartedAt: new Date() } },
     { new: true }
   );
   if (!claimed) return null;
@@ -87,19 +111,39 @@ async function settleInterruptedCoinFlip(round, io = noopIo, payoutFor) {
     });
     emitUserData(io, userId, user);
   }
+
+  await Round.updateOne({ _id: claimed._id }, { $set: { settlementDone: true } });
   return claimed;
 }
 
 // on boot, settle whatever a restart left in flight. a round with no outcome never
 // happened and its stakes go back; a coin flip that already landed is finished properly.
+// a round whose own give-back loop was interrupted is picked up again: it is terminal
+// but not done with, and the money it still owes is the whole reason this runs.
 async function recoverStuckRounds(io = noopIo, payoutFor) {
-  const stuck = await Round.find({ status: { $in: ["betting", "running"] } });
+  // the second arm keys on settlementStartedAt, which only exists once a give-back loop
+  // has actually claimed the round. every round that finished normally, and every round
+  // that predates this, has no such marker and is left alone: without that, the first
+  // boot would sweep every settled round ever and refund the losers.
+  const stuck = await Round.find({
+    $or: [
+      { status: { $in: ["betting", "running"] } },
+      {
+        status: { $in: ["voided", "settled"] },
+        settlementStartedAt: { $exists: true },
+        settlementDone: { $ne: true },
+      },
+    ],
+  });
   let voided = 0;
   let settled = 0;
 
   for (const round of stuck) {
     try {
-      const landed = round.game === "coinflip" && round.status === "running" && round.outcome;
+      // an outcome is what decides it, not the status: a resumed coin flip is already
+      // marked settled, and voiding it would hand the losers their stakes back
+      const landed =
+        round.game === "coinflip" && round.outcome && round.outcome.winningSide;
       if (landed && typeof payoutFor === "function") {
         if (await settleInterruptedCoinFlip(round, io, payoutFor)) settled += 1;
       } else if (await voidRound(round, io)) {


### PR DESCRIPTION
This is a bug in the recovery added by #130 and #133. It is live now.

## The bug

`voidRound` (utils/rounds.js:37-41) marks the round terminal, **then** loops over the refunds (:50-59). `recoverStuckRounds` (:96) only re-scanned `betting|running`.

So a process death anywhere inside that loop was permanent. The round was already `voided`, the boot sweep skipped it forever, and every staker the loop had not reached kept nothing. **A deploy landing in that window does exactly this.** The recovery written to stop restarts eating stakes ate stakes itself.

`voidBattle` (games/battleEngine.js:244-248 vs the `in_progress`-only scan at :276) has the identical shape.

`settleInterruptedCoinFlip` has it too, and it is worse there: it marks the round `settled` before paying the winners, so a death mid-loop strands people who **won**.

## The fix

The sweep now revisits a round or battle whose settlement never finished. The claim doubles as a **lease**, so two boots cannot both run the loop and pay the same staker twice. The loops were already idempotent against the ledger (`settledUserIds` reads refund/payout rows), which is what makes resuming safe: whoever already holds a refund row is skipped.

Two details that matter:

**The scan keys on `settlementStartedAt`, not on status.** That marker only exists once a give-back loop has claimed the round. Keying on `status: settled, settlementDone: false` instead would have sweep the **first boot after deploy refund the losers of every settled round ever written**, because historical rounds have no `settlementDone`. This way they are structurally invisible and no backfill is needed.

**The sweep repeats every 5 minutes**, not just at boot. A lease left by a dead process outlives the boot that would retry it, so a boot-only sweep would hold the money until the next restart.

## Dispatch fix

`recoverStuckRounds` chose the coin-flip path on `status === "running"`. A resumed coin flip is already marked `settled`, so it would have fallen through to `voidRound` and **handed the losers their stakes back**. It now dispatches on the presence of an outcome, which is what actually decides whether the coin landed.

## Tests

`backend/__tests__/integration/refundResume.test.js` kills `creditUser` on the 2nd of 3 refunds, exactly like a process death mid-loop. On the old code all three fail with the stranded stakers at 900:

- a restart inside the refund loop does not strand the stakers it had not reached
- finishing an interrupted void does not refund the ones it already paid (no double-pay, exactly one refund row each)
- a battle void interrupted mid-refund is finished on the next boot

The tests age the lease before the second sweep, because that is what a later sweep actually sees.

213/213 backend tests pass.

## Not in this PR

- **`missions.js` burns a reward** if the payout dies: the claim is marked at :222-225 before `creditUser` at :230. The obvious fix (fall through when no payout row exists) is **unsafe** - two concurrent claims where neither has paid yet would both credit, turning a burn into a double-pay. The mark is the mutex. This needs mark and credit to be atomic, so it belongs with the transaction work.
- **`crash.js:134` pays `betAmount * multiplier` unfloored**, minting fractional KP into an integer economy. Real, and it blocks a clean conservation invariant, but it is a player-visible nerf and should be a deliberate call.