### PR TITLE
House account: give the edge somewhere to go, and derive the KP supply

### DIFF
--- a/backend/__tests__/integration/houseAccount.test.js
+++ b/backend/__tests__/integration/houseAccount.test.js
@@ -1,0 +1,130 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const {
+  chargeUser, creditUser, recordTransaction, accountBalance, ledgerSupply, TX,
+} = require("../../utils/economy");
+const { HOUSE, MINT, ESCROW, GENESIS, isSystemAccount } = require("../../utils/accounts");
+const { purchaseListing } = require("../../utils/market");
+const { reconcile } = require("../../scripts/reconcile");
+const Marketplace = require("../../models/Marketplace");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeUser = (walletBalance = 0) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+};
+
+// sum every account that appears in the ledger; a closed set of movements nets to zero
+async function totalOfAllAccounts() {
+  const ids = await Transaction.distinct("userId");
+  const cps = await Transaction.distinct("counterparty");
+  const all = new Set([...ids, ...cps].filter(Boolean).map(String));
+  let total = 0;
+  for (const id of all) total += await accountBalance(id);
+  return total;
+}
+
+test("a mint, a bet and a win keep the house and mint balances correct", async () => {
+  const u = await makeUser(0);
+
+  // mint 1000 to the player (like a bonus): mint goes negative, player positive
+  await creditUser(u._id, 1000, 0, { type: TX.BONUS });
+  expect(await accountBalance(u._id)).toBe(1000);
+  expect(await accountBalance(MINT)).toBe(-1000);
+  expect(await ledgerSupply()).toBe(1000);
+
+  // player bets 100 on crash and loses it: house keeps the 100
+  await chargeUser(u._id, 100, { awardXp: false, type: TX.CRASH_BET });
+  expect(await accountBalance(u._id)).toBe(900);
+  expect(await accountBalance(HOUSE)).toBe(100);
+
+  // player bets 100 and cashes out 150: house is now down 50 on the game
+  await chargeUser(u._id, 100, { awardXp: false, type: TX.CRASH_BET });
+  await creditUser(u._id, 150, 50, { type: TX.CRASH_CASHOUT });
+  expect(await accountBalance(HOUSE)).toBe(100 + 100 - 150);
+  expect(await accountBalance(u._id)).toBe(950);
+});
+
+test("the books balance to zero across every account after a closed set of moves", async () => {
+  const a = await makeUser(0);
+  const b = await makeUser(0);
+
+  await creditUser(a._id, 500, 0, { type: TX.SIGNUP });
+  await creditUser(b._id, 500, 0, { type: TX.BONUS });
+  await chargeUser(a._id, 200, { awardXp: false, type: TX.SLOT_BET });
+  await creditUser(a._id, 90, 0, { type: TX.SLOT_WIN });
+  await creditUser(b._id, 40, 0, { type: TX.ITEM_SELL });
+
+  expect(await totalOfAllAccounts()).toBe(0);
+});
+
+test("a marketplace sale splits into buyer, seller and house legs that net to zero", async () => {
+  const seller = await makeUser(0);
+  const buyer = await makeUser(1000);
+  const caseId = new mongoose.Types.ObjectId();
+  const listing = await Marketplace.create({
+    sellerId: seller._id, item: new mongoose.Types.ObjectId(), case: caseId,
+    uniqueId: `uq-${uniqueSuffix()}`, price: 100,
+    itemName: "thing", itemImage: "x", rarity: "3",
+  });
+
+  const res = await purchaseListing({ listingId: listing._id, buyerId: buyer._id });
+  expect(res.ok).toBe(true);
+
+  // fee is floor(100 * 0.05) = 5, seller net 95, buyer paid 100
+  expect(await accountBalance(buyer._id)).toBe(-100);
+  expect(await accountBalance(seller._id)).toBe(95);
+  expect(await accountBalance(HOUSE)).toBe(5);
+  expect(await totalOfAllAccounts()).toBe(0);
+});
+
+test("escrow place then refund leaves escrow flat", async () => {
+  const u = await makeUser(1000);
+  await chargeUser(u._id, 300, { awardXp: false, type: TX.MARKET_ORDER });
+  expect(await accountBalance(ESCROW)).toBe(300);
+  await creditUser(u._id, 300, 0, { type: TX.MARKET_ORDER_REFUND });
+  expect(await accountBalance(ESCROW)).toBe(0);
+});
+
+test("system accounts are never real user documents", async () => {
+  for (const id of [HOUSE, MINT, ESCROW, GENESIS]) {
+    expect(isSystemAccount(id)).toBe(true);
+    expect(await User.findById(id)).toBeNull();
+  }
+});
+
+test("reconcile flags a legacy drift and reports the system balances", async () => {
+  await makeUser(700); // legacy: wallet 700, no ledger
+  const clean = await makeUser(400);
+  await creditUser(clean._id, 500, 0, { type: TX.BONUS }); // ledger now explains 500 of it
+
+  const r = await reconcile();
+  expect(r.players.total).toBe(2);
+  // the legacy 700 has no opening row, and the clean player's wallet leads its ledger by 400
+  expect(r.players.drifting).toBe(2);
+  expect(r.players.totalDrift).toBe(700 + 400);
+  expect(r.system.mint).toBe(-500);
+  expect(r.system.supply).toBe(500);
+});
+
+test("a genesis opening row makes a legacy balance reconcile", async () => {
+  // a player who existed before the ledger: wallet 700, no history
+  const u = await makeUser(700);
+  expect(await accountBalance(u._id)).toBe(0); // ledger cannot explain the 700 yet
+
+  // book the opening position from genesis, the plug the backfill will write
+  await recordTransaction({
+    userId: u._id, type: "opening_balance", direction: "credit",
+    amount: 700, counterparty: GENESIS,
+  });
+  expect(await accountBalance(u._id)).toBe(700);
+  expect(await accountBalance(GENESIS)).toBe(-700);
+});

--- a/backend/__tests__/integration/houseNoLeak.test.js
+++ b/backend/__tests__/integration/houseNoLeak.test.js
@@ -1,0 +1,47 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const { creditUser, TX } = require("../../utils/economy");
+const { HOUSE, MINT, SYSTEM_IDS } = require("../../utils/accounts");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeUser = (walletBalance = 100) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance, weeklyWinnings: 5 });
+};
+
+test("the house never appears in topPlayers or ranking", async () => {
+  const u = await makeUser(100);
+  // give the house a large derived balance and weekly-winnings-shaped activity
+  await creditUser(u._id, 100000, 999999, { type: TX.CRASH_BET });
+
+  const top = await request(app).get("/users/topPlayers").set({ Authorization: `Bearer ${tokenFor(u)}` });
+  const rank = await request(app).get("/users/ranking").set({ Authorization: `Bearer ${tokenFor(u)}` });
+
+  const rows = [...(top.body || []), ...((rank.body && rank.body.users) || [])];
+  const ids = rows.map((p) => String(p._id || p.id));
+  expect(ids).toContain(String(u._id)); // the real player is there
+  for (const sys of SYSTEM_IDS) expect(ids).not.toContain(sys);
+});
+
+test("a player's transaction history never shows a system account's rows", async () => {
+  const u = await makeUser(100);
+  await creditUser(u._id, 100, 0, { type: TX.BONUS }); // writes a MINT-facing row too
+
+  const res = await request(app)
+    .get("/users/transactions")
+    .set({ Authorization: `Bearer ${tokenFor(u)}` });
+
+  expect(res.status).toBe(200);
+  // every row belongs to the player; the mint/house legs are derived, not their history
+  for (const t of res.body.transactions) expect(String(t.userId)).toBe(String(u._id));
+  expect(String(HOUSE)).not.toBe(String(u._id));
+  expect(String(MINT)).not.toBe(String(u._id));
+});

--- a/backend/models/Transaction.js
+++ b/backend/models/Transaction.js
@@ -26,6 +26,13 @@ const TransactionSchema = new mongoose.Schema({
   balanceAfter: {
     type: Number,
   },
+  // the account on the other side of the movement (a user or a system account), so a
+  // row is a complete double entry and every account's balance is derivable
+  counterparty: {
+    type: mongoose.Schema.Types.ObjectId,
+    index: true,
+    sparse: true,
+  },
   meta: {
     type: mongoose.Schema.Types.Mixed,
     default: {},

--- a/backend/scripts/reconcile.js
+++ b/backend/scripts/reconcile.js
@@ -1,0 +1,55 @@
+const mongoose = require("mongoose");
+require("dotenv").config();
+
+const User = require("../models/User");
+const { accountBalance, ledgerSupply } = require("../utils/economy");
+const { HOUSE, MINT, ESCROW, GENESIS } = require("../utils/accounts");
+
+// read-only audit: derive each account from the ledger and compare players against their
+// stored wallet. legacy accounts have no opening row, so drift is expected until genesis.
+async function reconcile() {
+  const users = await User.find({}, { walletBalance: 1 }).lean();
+  let drifting = 0;
+  let totalDrift = 0;
+  const worst = [];
+
+  for (const u of users) {
+    const derived = await accountBalance(u._id);
+    const drift = u.walletBalance - derived;
+    if (drift !== 0) {
+      drifting += 1;
+      totalDrift += drift;
+      worst.push({ userId: String(u._id), wallet: u.walletBalance, derived, drift });
+    }
+  }
+  worst.sort((a, b) => Math.abs(b.drift) - Math.abs(a.drift));
+
+  const [house, mint, escrow, genesis, supply] = await Promise.all([
+    accountBalance(HOUSE),
+    accountBalance(MINT),
+    accountBalance(ESCROW),
+    accountBalance(GENESIS),
+    ledgerSupply(),
+  ]);
+
+  return {
+    players: { total: users.length, drifting, totalDrift },
+    system: { house, mint, escrow, genesis, supply },
+    worst: worst.slice(0, 20),
+  };
+}
+
+async function main() {
+  if (!process.env.MONGO_URI) {
+    console.error("MONGO_URI is not set (run from backend/ with its .env)");
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.MONGO_URI);
+  const report = await reconcile();
+  console.log(JSON.stringify(report, null, 2));
+  await mongoose.disconnect();
+}
+
+if (require.main === module) main().catch((e) => { console.error(e); process.exit(1); });
+
+module.exports = { reconcile };

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -1,0 +1,44 @@
+const mongoose = require("mongoose");
+
+// system accounts are bare ObjectId constants, never User docs, so they cannot leak
+// into topPlayers / ranking / the leaderboard cron, which all query the User collection
+const HOUSE = new mongoose.Types.ObjectId("000000000000000000000000"); // edge revenue
+const MINT = new mongoose.Types.ObjectId("000000000000000000000001"); // issuance faucet
+const ESCROW = new mongoose.Types.ObjectId("000000000000000000000002"); // buy-order float
+const GENESIS = new mongoose.Types.ObjectId("000000000000000000000003"); // pre-ledger plug
+
+const SYSTEM_IDS = [HOUSE, MINT, ESCROW, GENESIS].map(String);
+const isSystemAccount = (id) => SYSTEM_IDS.includes(String(id));
+
+// the account a movement settles against, keyed by transaction type. market trades are
+// player to player and self-balance across their own legs, so they carry no counterparty.
+const COUNTERPARTY_FOR_TYPE = {
+  signup: MINT,
+  bonus: MINT,
+  mission_reward: MINT,
+  admin_adjust: MINT,
+  case_open: HOUSE,
+  slot_bet: HOUSE,
+  slot_win: HOUSE,
+  crash_bet: HOUSE,
+  crash_cashout: HOUSE,
+  crash_refund: HOUSE,
+  coinflip_bet: HOUSE,
+  coinflip_win: HOUSE,
+  coinflip_refund: HOUSE,
+  battle_entry: HOUSE,
+  battle_refund: HOUSE,
+  item_sell: HOUSE,
+  market_order: ESCROW,
+  market_order_refund: ESCROW,
+};
+
+module.exports = {
+  HOUSE,
+  MINT,
+  ESCROW,
+  GENESIS,
+  SYSTEM_IDS,
+  isSystemAccount,
+  COUNTERPARTY_FOR_TYPE,
+};

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -1,5 +1,7 @@
+const mongoose = require("mongoose");
 const User = require("../models/User");
 const Transaction = require("../models/Transaction");
+const { COUNTERPARTY_FOR_TYPE, MINT } = require("./accounts");
 
 const BASE_XP = 1000; // xp required for the first level
 const GROWTH_RATE = 1.25; // growth rate for each level
@@ -21,8 +23,10 @@ const TX = {
   BATTLE_REFUND: "battle_refund",
   MARKET_BUY: "market_buy",
   MARKET_SALE: "market_sale",
+  MARKET_FEE: "market_fee", // the house cut on a settled trade, credited to HOUSE
   MARKET_ORDER: "market_order", // KP escrowed when a buy order is placed
   MARKET_ORDER_REFUND: "market_order_refund", // escrow returned on cancel
+  MARKET_ORDER_FILL: "market_order_fill", // escrow paid out to a seller on a fill
   ITEM_SELL: "item_sell",
   ADMIN_ADJUST: "admin_adjust",
   MISSION_REWARD: "mission_reward",
@@ -43,8 +47,11 @@ function calculateLevelFromXp(xp) {
 
 // append a balance-history entry. best-effort audit: a failed write here must
 // never break the money path, so it logs and swallows rather than throwing.
-async function recordTransaction({ userId, type, direction, amount, balanceAfter, meta }) {
+async function recordTransaction({ userId, type, direction, amount, balanceAfter, meta, counterparty }) {
   if (!userId || !amount) return null;
+  // counterparty is the account on the other side; most types have a fixed one, and
+  // caller-supplied wins so market trades can name the actual player or system leg
+  const other = counterparty !== undefined ? counterparty : COUNTERPARTY_FOR_TYPE[type];
   try {
     return await Transaction.create({
       userId,
@@ -52,6 +59,7 @@ async function recordTransaction({ userId, type, direction, amount, balanceAfter
       direction,
       amount: Math.abs(amount),
       balanceAfter,
+      counterparty: other,
       meta: meta || {},
     });
   } catch (err) {
@@ -60,9 +68,38 @@ async function recordTransaction({ userId, type, direction, amount, balanceAfter
   }
 }
 
+// any account's balance derived from the ledger: each row is a transfer between userId
+// and counterparty, so the two sides read its signed amount oppositely
+async function accountBalance(accountId) {
+  const id = new mongoose.Types.ObjectId(String(accountId));
+  const [row] = await Transaction.aggregate([
+    { $match: { $or: [{ userId: id }, { counterparty: id }] } },
+    {
+      $group: {
+        _id: null,
+        bal: {
+          $sum: {
+            $cond: [
+              { $eq: ["$userId", id] },
+              { $cond: [{ $eq: ["$direction", "credit"] }, "$amount", { $multiply: ["$amount", -1] }] },
+              { $cond: [{ $eq: ["$direction", "credit"] }, { $multiply: ["$amount", -1] }, "$amount"] },
+            ],
+          },
+        },
+      },
+    },
+  ]);
+  return row ? row.bal : 0;
+}
+
+// total KP in circulation is everything the mint has issued and not taken back
+async function ledgerSupply() {
+  return -(await accountBalance(MINT));
+}
+
 // atomically debit `cost` only if the balance covers it, optionally granting xp.
 // returns the updated user, or null when funds are insufficient.
-async function chargeUser(userId, cost, { awardXp = true, type, meta } = {}) {
+async function chargeUser(userId, cost, { awardXp = true, type, meta, counterparty } = {}) {
   const inc = awardXp
     ? { walletBalance: -cost, xp: cost * 5 }
     : { walletBalance: -cost };
@@ -92,6 +129,7 @@ async function chargeUser(userId, cost, { awardXp = true, type, meta } = {}) {
     amount: cost,
     balanceAfter: user.walletBalance,
     meta,
+    counterparty,
   });
 
   return user;
@@ -99,7 +137,7 @@ async function chargeUser(userId, cost, { awardXp = true, type, meta } = {}) {
 
 // atomically credit winnings to the wallet (and weekly winnings).
 // returns the updated user, or null when the account no longer exists.
-async function creditUser(userId, amount, winnings = 0, { type, meta } = {}) {
+async function creditUser(userId, amount, winnings = 0, { type, meta, counterparty } = {}) {
   const user = await User.findByIdAndUpdate(
     userId,
     { $inc: { walletBalance: amount, weeklyWinnings: winnings } },
@@ -117,6 +155,7 @@ async function creditUser(userId, amount, winnings = 0, { type, meta } = {}) {
     amount,
     balanceAfter: user.walletBalance,
     meta,
+    counterparty,
   });
 
   return user;
@@ -149,5 +188,7 @@ module.exports = {
   chargeUser,
   creditUser,
   awardXp,
+  accountBalance,
+  ledgerSupply,
   TX,
 };

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -5,6 +5,22 @@ const BuyOrder = require("../models/BuyOrder");
 const Notification = require("../models/Notification");
 const { creditUser, recordTransaction, TX } = require("./economy");
 const { marketFee, sellerNet } = require("./itemValue");
+const { HOUSE, ESCROW } = require("./accounts");
+
+// the house cut on a settled trade, booked to HOUSE so the three trade legs (buyer,
+// seller, house) sum to zero. best-effort, like the rest of the ledger for now.
+async function recordMarketFee({ price, buyerId, meta }) {
+  const fee = marketFee(price);
+  if (!fee) return;
+  await recordTransaction({
+    userId: HOUSE,
+    type: TX.MARKET_FEE,
+    direction: "credit",
+    amount: fee,
+    counterparty: null,
+    meta: { ...meta, buyerId },
+  });
+}
 
 // rebuild the inventory entry a listing represents. acquired now, so it sorts newest.
 function inventoryEntryFrom(listing) {
@@ -107,12 +123,15 @@ async function purchaseListing({ listingId, buyerId, io }) {
     return { ok: false, code: 400, message: "Insufficient balance" };
   }
 
+  // the trade is player to player, so buyer and seller legs need no counterparty: they
+  // and the house fee row self-balance to zero
   await recordTransaction({
     userId: buyerId,
     type: TX.MARKET_BUY,
     direction: "debit",
     amount: claimed.price,
     balanceAfter: updatedBuyer.walletBalance,
+    counterparty: null,
     meta: {
       itemId: claimed.item,
       itemName: claimed.itemName,
@@ -124,6 +143,7 @@ async function purchaseListing({ listingId, buyerId, io }) {
   const net = sellerNet(claimed.price);
   const seller = await creditUser(claimed.sellerId, net, 0, {
     type: TX.MARKET_SALE,
+    counterparty: null,
     meta: {
       itemId: claimed.item,
       itemName: claimed.itemName,
@@ -158,6 +178,12 @@ async function purchaseListing({ listingId, buyerId, io }) {
     }
     return { ok: false, code: 410, message: "Seller no longer available; purchase reversed" };
   }
+
+  await recordMarketFee({
+    price: claimed.price,
+    buyerId,
+    meta: { itemName: claimed.itemName, listingId: claimed.uniqueId },
+  });
 
   await logSale({ listing: claimed, buyerId, price: claimed.price });
   if (io) {
@@ -215,6 +241,7 @@ async function fillOrderWithItem({ pending, order, io }) {
   const net = sellerNet(price);
   const seller = await creditUser(pending.sellerId, net, 0, {
     type: TX.MARKET_SALE,
+    counterparty: null,
     meta: {
       itemId: pending.item,
       itemName: pending.itemName,
@@ -241,6 +268,21 @@ async function fillOrderWithItem({ pending, order, io }) {
     });
     return { ok: false, reason: "seller gone" };
   }
+
+  // the buyer paid at placement, so the payout comes out of escrow, not their wallet
+  await recordTransaction({
+    userId: ESCROW,
+    type: TX.MARKET_ORDER_FILL,
+    direction: "debit",
+    amount: price,
+    counterparty: null,
+    meta: { orderId: String(order._id), sellerId: pending.sellerId, itemName: pending.itemName },
+  });
+  await recordMarketFee({
+    price,
+    buyerId: claimedOrder.userId,
+    meta: { itemName: pending.itemName, orderId: String(order._id), viaOrder: true },
+  });
 
   if (claimedOrder.filled >= claimedOrder.quantity) {
     await BuyOrder.updateOne({ _id: order._id, status: "open" }, { $set: { status: "filled" } });


### PR DESCRIPTION
First step of the "make the books balance" work, after #134 unblocked it. This is **accounting only - no player balance changes.**

## What was wrong

`chargeUser` destroyed KP and `creditUser` minted it, with nobody on the other side. Aggregate house profit was exactly **0**, every edge was a burn, and nothing in the backend could answer "how much KP exists".

## What this adds

**Four system accounts** as bare ObjectId constants (`backend/utils/accounts.js`), never User docs:

| Account | Holds |
|---|---|
| HOUSE | edge revenue (bets, case opens, item sell-backs, the market fee) |
| MINT | issuance (signup, 8-min bonus, mission rewards, admin credit) |
| ESCROW | the buy-order float |
| GENESIS | pre-ledger opening balances (booked in a later phase) |

Because they are not User docs, they **cannot leak** into `topPlayers`, `ranking`, or the leaderboard cron, which all query the User collection. A document that does not exist cannot appear in a listing (there is a test).

**A `counterparty` column on the Transaction row.** Each row is now a transfer of `amount` between `userId` and `counterparty`, signed by `direction`, so a row is a complete double entry and any account's balance is `accountBalance(id)`. Counterparty **defaults from the type**, so the ~25 money sites are almost untouched - the bonus/signup/missions settle against MINT, the games/case-opens/sell-backs against HOUSE, escrow place/refund against ESCROW.

**The bonus is funded by MINT, not HOUSE** (owner's call). HOUSE then reads as real edge revenue, and `-balance(MINT)` is the live KP supply - a number that did not exist before. In real-money mode the bonus becomes a daily free case but is still MINT issuance.

**The marketplace** splits into buyer, seller and an explicit HOUSE fee row that net to zero, so the 5% cut accrues to the house instead of vanishing. A buy-order fill pays the seller out of escrow with its own ESCROW leg.

**`reconcile.js`** (read-only) derives every account, compares each player's derived balance to their stored wallet, and reports the drift plus the system balances and supply. It is deliberately shipped *before* atomicity so drift has a measured baseline.

## What this does NOT do (by design, next phases)

- **Not atomic yet.** Writes are still best-effort; a swallowed row drops both legs together, so the books stay internally consistent but incomplete. The next phase (no money without history) closes that.
- **Legacy accounts still drift.** Balances that predate the ledger have no opening row, so `reconcile` is red for them. The genesis phase books one opening row each and drives it to zero. A test proves a genesis row makes a legacy balance reconcile.

## Tests

`houseAccount.test.js` (7): mint/bet/win keep HOUSE and MINT correct; **the books net to zero across every account** after a closed set of moves; a market sale splits buyer/seller/house to zero; escrow place+refund leaves escrow flat; system accounts are never User docs; reconcile flags legacy drift and reports supply; a genesis row makes a legacy balance reconcile.

`houseNoLeak.test.js` (2): the house never appears in topPlayers/ranking; a player's transaction history never shows a system leg.

222/222 backend tests pass. Frontend untouched (0 lint errors).