### PR TITLE
Atomic ledger: no balance change without a history row

### DIFF
--- a/backend/__tests__/integration/adminWallet.test.js
+++ b/backend/__tests__/integration/adminWallet.test.js
@@ -1,0 +1,61 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeUser = (fields = {}) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance: 0, ...fields });
+};
+
+test("an admin balance set records the delta as a ledger row", async () => {
+  const admin = await makeUser({ isAdmin: true });
+  const target = await makeUser({ walletBalance: 100 });
+
+  const res = await request(app)
+    .put(`/admin/users/${target._id}/wallet`)
+    .set({ Authorization: `Bearer ${tokenFor(admin)}` })
+    .send({ walletBalance: 350 });
+
+  expect(res.status).toBe(200);
+  expect((await User.findById(target._id)).walletBalance).toBe(350);
+
+  const row = await Transaction.findOne({ userId: target._id, type: TX.ADMIN_ADJUST });
+  expect(row.direction).toBe("credit");
+  expect(row.amount).toBe(250);
+  expect(row.meta.previous).toBe(100);
+});
+
+test("setting the same balance records nothing", async () => {
+  const admin = await makeUser({ isAdmin: true });
+  const target = await makeUser({ walletBalance: 200 });
+
+  await request(app)
+    .put(`/admin/users/${target._id}/wallet`)
+    .set({ Authorization: `Bearer ${tokenFor(admin)}` })
+    .send({ walletBalance: 200 });
+
+  expect(await Transaction.countDocuments({ userId: target._id })).toBe(0);
+});
+
+test("a non-admin cannot set a balance", async () => {
+  const notAdmin = await makeUser({});
+  const target = await makeUser({ walletBalance: 100 });
+
+  const res = await request(app)
+    .put(`/admin/users/${target._id}/wallet`)
+    .set({ Authorization: `Bearer ${tokenFor(notAdmin)}` })
+    .send({ walletBalance: 999999 });
+
+  expect(res.status).toBeGreaterThanOrEqual(401);
+  expect((await User.findById(target._id)).walletBalance).toBe(100);
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -8,6 +8,7 @@ const gamesRoutes = require("../../routes/gamesRoutes");
 const fairRoutes = require("../../routes/fairRoutes");
 const collectionsRoutes = require("../../routes/collectionsRoutes");
 const missionsRoutes = require("../../routes/missionsRoutes");
+const adminRoutes = require("../../routes/adminRoutes");
 
 // no-op socket.io stand-in
 const io = { emit: () => {}, to: () => ({ emit: () => {} }) };
@@ -22,6 +23,7 @@ function makeApp() {
   app.use("/fair", fairRoutes);
   app.use("/collections", collectionsRoutes);
   app.use("/missions", missionsRoutes(io));
+  app.use("/admin", adminRoutes);
   return app;
 }
 

--- a/backend/__tests__/integration/ledgerAtomicity.test.js
+++ b/backend/__tests__/integration/ledgerAtomicity.test.js
@@ -1,0 +1,93 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+// this suite needs real transactions, so it runs its own replica set rather than the
+// shared standalone harness. it proves the guarantee prod relies on: money and its
+// history commit together or not at all.
+const { MongoMemoryReplSet } = require("mongodb-memory-server");
+const mongoose = require("mongoose");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const {
+  chargeUser, creditUser, probeTransactions, setTransactionsSupported, transactionsSupported, TX,
+} = require("../../utils/economy");
+
+let rs;
+
+beforeAll(async () => {
+  rs = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+  await mongoose.connect(rs.getUri());
+  setTransactionsSupported(await probeTransactions());
+});
+
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await User.deleteMany({});
+  await Transaction.deleteMany({});
+});
+
+afterAll(async () => {
+  setTransactionsSupported(false);
+  await mongoose.disconnect();
+  await rs.stop();
+});
+
+const makeUser = (walletBalance) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+};
+
+test("the replica set actually supports transactions", () => {
+  expect(transactionsSupported()).toBe(true);
+});
+
+test("a successful charge moves the balance and writes exactly one row", async () => {
+  const u = await makeUser(1000);
+  const res = await chargeUser(u._id, 100, { awardXp: false, type: TX.CRASH_BET });
+  expect(res).not.toBeNull();
+  expect((await User.findById(u._id)).walletBalance).toBe(900);
+  expect(await Transaction.countDocuments({ userId: u._id })).toBe(1);
+});
+
+test("a charge whose ledger row fails leaves the balance untouched", async () => {
+  const u = await makeUser(1000);
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+
+  const res = await chargeUser(u._id, 100, { awardXp: false, type: TX.CRASH_BET });
+
+  expect(res).toBeNull(); // the caller sees a failed charge
+  expect((await User.findById(u._id)).walletBalance).toBe(1000); // rolled back
+  expect(await Transaction.countDocuments({ userId: u._id })).toBe(0); // no history
+});
+
+test("a credit whose ledger row fails leaves the balance untouched", async () => {
+  const u = await makeUser(1000);
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+
+  const res = await creditUser(u._id, 250, 0, { type: TX.CRASH_CASHOUT });
+
+  expect(res).toBeNull();
+  expect((await User.findById(u._id)).walletBalance).toBe(1000);
+  expect(await Transaction.countDocuments({ userId: u._id })).toBe(0);
+});
+
+test("insufficient funds writes nothing and does not throw", async () => {
+  const u = await makeUser(50);
+  const res = await chargeUser(u._id, 100, { awardXp: false, type: TX.CRASH_BET });
+  expect(res).toBeNull();
+  expect((await User.findById(u._id)).walletBalance).toBe(50);
+  expect(await Transaction.countDocuments({ userId: u._id })).toBe(0);
+});
+
+test("many concurrent charges each get their own row and never overspend", async () => {
+  const u = await makeUser(1000);
+  const results = await Promise.all(
+    Array.from({ length: 20 }, () => chargeUser(u._id, 100, { awardXp: false, type: TX.SLOT_BET }))
+  );
+  const ok = results.filter(Boolean).length;
+  const balance = (await User.findById(u._id)).walletBalance;
+  const rows = await Transaction.countDocuments({ userId: u._id });
+  expect(ok).toBe(10); // exactly ten of twenty could be covered
+  expect(balance).toBe(0);
+  expect(rows).toBe(ok); // one row per successful charge, none for the refused ones
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -72,6 +72,7 @@ const crash = require("./games/crash");
 const caseBattle = require("./games/caseBattle");
 const { recoverStuckRounds } = require("./utils/rounds");
 const { completeStuckBattles } = require("./games/battleEngine");
+const { probeTransactions, setTransactionsSupported } = require("./utils/economy");
 const userRoutes = require("./routes/userRoutes");
 const caseRoutes = require("./routes/caseRoutes");
 const itemRoutes = require("./routes/itemRoutes");
@@ -90,7 +91,19 @@ mongoose
     useUnifiedTopology: true,
     // useCreateIndex: true,
   })
-  .then(() => console.log("MongoDB connected"))
+  .then(async () => {
+    console.log("MongoDB connected");
+    // money writes are only atomic where transactions exist; refuse to run prod without
+    const ok = await probeTransactions();
+    setTransactionsSupported(ok);
+    if (!ok) {
+      if (process.env.NODE_ENV === "production") {
+        console.error("mongo is not a replica set: money writes cannot be atomic, refusing to start");
+        process.exit(1);
+      }
+      console.warn("mongo is not a replica set: money writes are best-effort (dev only)");
+    }
+  })
   .catch((err) => console.log(err));
 
 // Middleware

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -5,7 +5,7 @@ const User = require("../models/User");
 const Case = require("../models/Case");
 const Item = require("../models/Item");
 const { recomputeCaseValues } = require("../utils/itemValue");
-const { recordTransaction, TX } = require("../utils/economy");
+const { recordTransaction, runAtomic, TX } = require("../utils/economy");
 
 router.get("/users", isAuthenticated, isAdmin, async (req, res) => {
   try {
@@ -131,28 +131,38 @@ router.put("/users/:id/wallet", isAuthenticated, isAdmin, async (req, res) => {
   }
 
   try {
-    const user = await User.findById(req.params.id);
-    if (!user) {
+    // set the balance and record the adjustment together, computing the delta inside the
+    // transaction so two concurrent admin sets cannot clobber each other or mis-record
+    const result = await runAtomic(async (session) => {
+      const user = await User.findById(req.params.id).session(session);
+      if (!user) return { notFound: true };
+
+      const previous = user.walletBalance;
+      const delta = walletBalance - previous;
+      user.walletBalance = walletBalance;
+      await user.save({ session });
+
+      if (delta !== 0) {
+        await recordTransaction(
+          {
+            userId: user._id,
+            type: TX.ADMIN_ADJUST,
+            direction: delta > 0 ? "credit" : "debit",
+            amount: Math.abs(delta),
+            balanceAfter: user.walletBalance,
+            meta: { adminId: req.user._id, previous },
+          },
+          session
+        );
+      }
+      return { balance: user.walletBalance };
+    });
+
+    if (result.notFound) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const previous = user.walletBalance;
-    const delta = walletBalance - previous;
-    user.walletBalance = walletBalance;
-    await user.save();
-
-    if (delta !== 0) {
-      await recordTransaction({
-        userId: user._id,
-        type: TX.ADMIN_ADJUST,
-        direction: delta > 0 ? "credit" : "debit",
-        amount: Math.abs(delta),
-        balanceAfter: user.walletBalance,
-        meta: { adminId: req.user._id, previous },
-      });
-    }
-
-    res.json(user.walletBalance);
+    res.json(result.balance);
   } catch (err) {
     console.error(err.message);
     res.status(500).send("Server error");

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -6,7 +6,7 @@ const User = require("../models/User");
 const Case = require("../models/Case");
 const upgradeItems = require("../games/upgrade");
 const SlotGameController = require("../games/slot");
-const { calculateLevelFromXp, recordTransaction, TX } = require("../utils/economy");
+const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
 const { buildRangeTable } = require("../utils/caseRanges");
 const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
@@ -78,28 +78,35 @@ module.exports = (io) => {
         draws.push({ nonce, roll: rollValue, itemId: picked.itemId, uniqueId: itemWithUniqueId.uniqueId });
       }
 
-      // atomically charge the cost and add the items only if the balance covers it
-      const updatedUser = await User.findOneAndUpdate(
-        { _id: user._id, walletBalance: { $gte: cost } },
-        {
-          $inc: { walletBalance: -cost, xp: cost * 5 },
-          $push: { inventory: { $each: winningItems } },
-        },
-        { new: true }
-      );
+      // charge the cost, add the items and write the ledger row together: a failed row
+      // rolls the charge back, so the player is never charged without a record
+      const updatedUser = await runAtomic(async (session) => {
+        const u = await User.findOneAndUpdate(
+          { _id: user._id, walletBalance: { $gte: cost } },
+          {
+            $inc: { walletBalance: -cost, xp: cost * 5 },
+            $push: { inventory: { $each: winningItems } },
+          },
+          { new: true, session }
+        );
+        if (!u) return null;
+        await recordTransaction(
+          {
+            userId: user._id,
+            type: TX.CASE_OPEN,
+            direction: "debit",
+            amount: cost,
+            balanceAfter: u.walletBalance,
+            meta: { caseId: caseData._id, caseTitle: caseData.title, quantity: quantityToOpen },
+          },
+          session
+        );
+        return u;
+      });
 
       if (!updatedUser) {
         return res.status(400).json({ message: "Insufficient balance" });
       }
-
-      await recordTransaction({
-        userId: user._id,
-        type: TX.CASE_OPEN,
-        direction: "debit",
-        amount: cost,
-        balanceAfter: updatedUser.walletBalance,
-        meta: { caseId: caseData._id, caseTitle: caseData.title, quantity: quantityToOpen },
-      });
 
       // record one provably-fair audit roll per open (after the charge commits)
       const rollIds = [];

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -11,7 +11,7 @@ const Transaction = require("../models/Transaction");
 const authMiddleware = require("../middleware/authMiddleware");
 const { loginLimiter, registerLimiter } = require("../middleware/rateLimit");
 const { sellValue } = require("../utils/itemValue");
-const { creditUser, recordTransaction, TX } = require("../utils/economy");
+const { creditUser, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const { sellUniqueIds } = require("../utils/inventorySell");
 const getRandomPlaceholderImage = require("../utils/placeholderImages");
 const { ObjectId } = require('mongodb');
@@ -451,28 +451,28 @@ router.post('/claimBonus', authMiddleware.isAuthenticated, async (req, res) => {
     const nextBonus = new Date(currentTime.getTime() + 8 * 60000); // 8 min later
     const nextBonusAmount = Math.floor(200 * (1 + 0.1 * req.user.level));
 
-    // claim atomically: the nextBonus condition lets only one concurrent request through
-    const updated = await User.findOneAndUpdate(
-      { _id: req.user._id, nextBonus: { $lte: currentTime } },
-      {
-        $inc: { walletBalance: currentBonus },
-        $set: { nextBonus, bonusAmount: nextBonusAmount },
-      },
-      { new: true }
-    );
+    // claim and record together: the nextBonus condition lets only one concurrent
+    // request through, and a failed row rolls the claim back so it can be retried
+    const updated = await runAtomic(async (session) => {
+      const u = await User.findOneAndUpdate(
+        { _id: req.user._id, nextBonus: { $lte: currentTime } },
+        {
+          $inc: { walletBalance: currentBonus },
+          $set: { nextBonus, bonusAmount: nextBonusAmount },
+        },
+        { new: true, session }
+      );
+      if (!u) return null;
+      await recordTransaction(
+        { userId: req.user._id, type: TX.BONUS, direction: "credit", amount: currentBonus, balanceAfter: u.walletBalance, meta: {} },
+        session
+      );
+      return u;
+    });
 
     if (!updated) {
       return res.status(400).json({ message: 'Bonus not yet available' });
     }
-
-    await recordTransaction({
-      userId: req.user._id,
-      type: TX.BONUS,
-      direction: "credit",
-      amount: currentBonus,
-      balanceAfter: updated.walletBalance,
-      meta: {},
-    });
 
     res.json({ message: `Claimed K₽${currentBonus}!`, value: currentBonus, nextBonus: updated.nextBonus });
   } catch (err) {

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -45,23 +45,58 @@ function calculateLevelFromXp(xp) {
   return level;
 }
 
-// append a balance-history entry. best-effort audit: a failed write here must
-// never break the money path, so it logs and swallows rather than throwing.
-async function recordTransaction({ userId, type, direction, amount, balanceAfter, meta, counterparty }) {
-  if (!userId || !amount) return null;
-  // counterparty is the account on the other side; most types have a fixed one, and
-  // caller-supplied wins so market trades can name the actual player or system leg
-  const other = counterparty !== undefined ? counterparty : COUNTERPARTY_FOR_TYPE[type];
+// whether the connected mongo supports multi-document transactions, probed at boot.
+// production is Atlas (a replica set) and always does; a standalone dev mongod does not.
+let txSupported = false;
+function setTransactionsSupported(v) { txSupported = Boolean(v); }
+function transactionsSupported() { return txSupported; }
+
+// true on a replica set or a mongos, the topologies where transactions work
+async function probeTransactions() {
   try {
-    return await Transaction.create({
-      userId,
-      type: type || (direction === "debit" ? "charge" : "credit"),
-      direction,
-      amount: Math.abs(amount),
-      balanceAfter,
-      counterparty: other,
-      meta: meta || {},
+    const info = await mongoose.connection.db.admin().command({ hello: 1 });
+    return Boolean(info.setName || info.msg === "isdbgrid");
+  } catch (err) {
+    return false;
+  }
+}
+
+// run a money operation atomically when transactions are available, else best-effort
+// without a session. prod always has them, so prod gets the guarantee.
+async function runAtomic(fn) {
+  if (!txSupported) return fn(null);
+  const session = await mongoose.startSession();
+  try {
+    let result;
+    await session.withTransaction(async () => {
+      result = await fn(session);
     });
+    return result;
+  } finally {
+    await session.endSession();
+  }
+}
+
+// append a balance-history entry. inside a transaction a failed row must abort the
+// money move, so it throws; without one it stays best-effort and swallows.
+async function recordTransaction({ userId, type, direction, amount, balanceAfter, meta, counterparty }, session = null) {
+  if (!userId || !amount) return null;
+  const other = counterparty !== undefined ? counterparty : COUNTERPARTY_FOR_TYPE[type];
+  const doc = {
+    userId,
+    type: type || (direction === "debit" ? "charge" : "credit"),
+    direction,
+    amount: Math.abs(amount),
+    balanceAfter,
+    counterparty: other,
+    meta: meta || {},
+  };
+  if (session) {
+    const [row] = await Transaction.create([doc], { session });
+    return row;
+  }
+  try {
+    return await Transaction.create(doc);
   } catch (err) {
     console.error("recordTransaction failed:", err);
     return null;
@@ -97,68 +132,72 @@ async function ledgerSupply() {
   return -(await accountBalance(MINT));
 }
 
-// atomically debit `cost` only if the balance covers it, optionally granting xp.
-// returns the updated user, or null when funds are insufficient.
-async function chargeUser(userId, cost, { awardXp = true, type, meta, counterparty } = {}) {
+// debit `cost` if the balance covers it, with its ledger row in the same transaction:
+// a failed row rolls the charge back and returns null, like insufficient funds
+async function chargeUser(userId, cost, { awardXp = true, type, meta, counterparty, session } = {}) {
   const inc = awardXp
     ? { walletBalance: -cost, xp: cost * 5 }
     : { walletBalance: -cost };
 
-  const user = await User.findOneAndUpdate(
-    { _id: userId, walletBalance: { $gte: cost } },
-    { $inc: inc },
-    { new: true }
-  );
+  const body = async (s) => {
+    const user = await User.findOneAndUpdate(
+      { _id: userId, walletBalance: { $gte: cost } },
+      { $inc: inc },
+      { new: true, session: s }
+    );
+    if (!user) return null;
 
-  if (!user) {
+    if (awardXp) {
+      const newLevel = calculateLevelFromXp(user.xp);
+      if (newLevel !== user.level) {
+        user.level = newLevel;
+        await User.updateOne({ _id: userId }, { $set: { level: newLevel } }, { session: s });
+      }
+    }
+
+    await recordTransaction(
+      { userId, type, direction: "debit", amount: cost, balanceAfter: user.walletBalance, meta, counterparty },
+      s
+    );
+    return user;
+  };
+
+  // joining a caller's transaction: let a failure propagate so their whole op aborts
+  if (session) return body(session);
+  try {
+    return await runAtomic(body);
+  } catch (err) {
+    console.error("chargeUser rolled back:", err);
     return null;
   }
-
-  if (awardXp) {
-    const newLevel = calculateLevelFromXp(user.xp);
-    if (newLevel !== user.level) {
-      user.level = newLevel;
-      await User.updateOne({ _id: userId }, { $set: { level: newLevel } });
-    }
-  }
-
-  await recordTransaction({
-    userId,
-    type,
-    direction: "debit",
-    amount: cost,
-    balanceAfter: user.walletBalance,
-    meta,
-    counterparty,
-  });
-
-  return user;
 }
 
-// atomically credit winnings to the wallet (and weekly winnings).
-// returns the updated user, or null when the account no longer exists.
-async function creditUser(userId, amount, winnings = 0, { type, meta, counterparty } = {}) {
-  const user = await User.findByIdAndUpdate(
-    userId,
-    { $inc: { walletBalance: amount, weeklyWinnings: winnings } },
-    { new: true }
-  );
+// atomically credit winnings to the wallet (and weekly winnings). the credit and its
+// ledger row commit together; a failed row rolls the credit back and returns null.
+async function creditUser(userId, amount, winnings = 0, { type, meta, counterparty, session } = {}) {
+  const body = async (s) => {
+    const user = await User.findByIdAndUpdate(
+      userId,
+      { $inc: { walletBalance: amount, weeklyWinnings: winnings } },
+      { new: true, session: s }
+    );
+    if (!user) return null;
 
-  if (!user) {
+    await recordTransaction(
+      { userId, type, direction: "credit", amount, balanceAfter: user.walletBalance, meta, counterparty },
+      s
+    );
+    return user;
+  };
+
+  // joining a caller's transaction: let a failure propagate so their whole op aborts
+  if (session) return body(session);
+  try {
+    return await runAtomic(body);
+  } catch (err) {
+    console.error("creditUser rolled back:", err);
     return null;
   }
-
-  await recordTransaction({
-    userId,
-    type,
-    direction: "credit",
-    amount,
-    balanceAfter: user.walletBalance,
-    meta,
-    counterparty,
-  });
-
-  return user;
 }
 
 // grant xp without touching the wallet, then recompute the derived level.
@@ -190,5 +229,9 @@ module.exports = {
   awardXp,
   accountBalance,
   ledgerSupply,
+  runAtomic,
+  probeTransactions,
+  setTransactionsSupported,
+  transactionsSupported,
   TX,
 };


### PR DESCRIPTION
## The problem

`recordTransaction` wrote the ledger row as a separate best-effort write *after* the balance moved, and swallowed its own failures. Money could change with no record, by design. There were zero mongo transactions in the backend.

## The change

- `recordTransaction` now runs inside a mongo transaction with the balance `$inc`. A failed row aborts the whole thing, so the charge rolls back with it.
- `chargeUser` / `creditUser` wrap their `$inc` and row in one transaction and return `null` if it rolls back, so every existing caller treats a failed row exactly like insufficient funds - no call-site changes. They also accept a `session` to join a caller's transaction.
- The three combined-atomic sites (case open, bonus claim, admin wallet set) are wrapped the same way. The admin set now computes its delta *inside* the transaction, so two concurrent sets can't clobber each other.
- Transactions need a replica set. Production is Atlas and always has them; a standalone dev mongod does not, so a boot probe **hard-fails in production** and falls back to best-effort writes in development.

## Tests

`ledgerAtomicity.test.js` runs its own replica set and proves it: a charge whose row fails leaves the balance untouched with no history, and 20 concurrent charges against a balance covering 10 produce exactly 10 successes and 10 rows.

`adminWallet.test.js` covers the admin wallet route (previously untested; `adminRoutes` is now wired into the test app).

231 backend tests pass. The existing suite runs on a standalone in-memory mongo, so it exercises the best-effort fallback and is unchanged.