### PR TITLE
Market atomicity: no marketplace payment without a history row

### DIFF
--- a/backend/__tests__/integration/ledgerAtomicity.test.js
+++ b/backend/__tests__/integration/ledgerAtomicity.test.js
@@ -8,6 +8,8 @@ const mongoose = require("mongoose");
 const { uniqueSuffix } = require("./helpers");
 const User = require("../../models/User");
 const Transaction = require("../../models/Transaction");
+const Marketplace = require("../../models/Marketplace");
+const { purchaseListing } = require("../../utils/market");
 const {
   chargeUser, creditUser, probeTransactions, setTransactionsSupported, transactionsSupported, TX,
 } = require("../../utils/economy");
@@ -22,9 +24,16 @@ beforeAll(async () => {
 
 afterEach(async () => {
   jest.restoreAllMocks();
-  await User.deleteMany({});
-  await Transaction.deleteMany({});
+  await Promise.all([User.deleteMany({}), Transaction.deleteMany({}), Marketplace.deleteMany({})]);
 });
+
+const listItem = (sellerId, price) => {
+  const s = uniqueSuffix();
+  return Marketplace.create({
+    sellerId, item: new mongoose.Types.ObjectId(), case: new mongoose.Types.ObjectId(),
+    uniqueId: `uq-${s}`, price, itemName: "thing", itemImage: "x", rarity: "3",
+  });
+};
 
 afterAll(async () => {
   setTransactionsSupported(false);
@@ -90,4 +99,52 @@ test("many concurrent charges each get their own row and never overspend", async
   expect(ok).toBe(10); // exactly ten of twenty could be covered
   expect(balance).toBe(0);
   expect(rows).toBe(ok); // one row per successful charge, none for the refused ones
+});
+
+test("a completed purchase moves both wallets and writes both rows", async () => {
+  const seller = await makeUser(0);
+  const buyer = await makeUser(1000);
+  const listing = await listItem(seller._id, 100);
+
+  const res = await purchaseListing({ listingId: listing._id, buyerId: buyer._id });
+  expect(res.ok).toBe(true);
+
+  expect((await User.findById(buyer._id)).walletBalance).toBe(900);
+  expect((await User.findById(seller._id)).walletBalance).toBe(95); // net of the 5% fee
+  expect(await Marketplace.countDocuments({ _id: listing._id })).toBe(0); // listing consumed
+});
+
+test("a buyer row failure charges nobody and leaves the listing on the market", async () => {
+  const seller = await makeUser(0);
+  const buyer = await makeUser(1000);
+  const listing = await listItem(seller._id, 100);
+
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+
+  const res = await purchaseListing({ listingId: listing._id, buyerId: buyer._id });
+
+  expect(res.ok).toBe(false);
+  expect((await User.findById(buyer._id)).walletBalance).toBe(1000); // not charged
+  expect((await User.findById(buyer._id)).inventory).toHaveLength(0); // item not granted
+  expect(await Marketplace.countDocuments({ _id: listing._id })).toBe(1); // still for sale
+  expect(await Transaction.countDocuments({})).toBe(0); // no history at all
+});
+
+test("two concurrent buyers cannot both win the same listing", async () => {
+  const seller = await makeUser(0);
+  const a = await makeUser(1000);
+  const b = await makeUser(1000);
+  const listing = await listItem(seller._id, 100);
+
+  const results = await Promise.all([
+    purchaseListing({ listingId: listing._id, buyerId: a._id }),
+    purchaseListing({ listingId: listing._id, buyerId: b._id }),
+  ]);
+
+  const wins = results.filter((r) => r.ok).length;
+  const balances = [(await User.findById(a._id)).walletBalance, (await User.findById(b._id)).walletBalance].sort((x, y) => x - y);
+  expect(wins).toBe(1); // exactly one buyer wins
+  expect(balances).toEqual([900, 1000]); // the winner paid, the loser kept everything
+  expect(await Marketplace.countDocuments({})).toBe(0); // the listing is consumed
+  expect((await User.findById(seller._id)).walletBalance).toBe(95); // seller paid once
 });

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -3,7 +3,7 @@ const Marketplace = require("../models/Marketplace");
 const MarketSale = require("../models/MarketSale");
 const BuyOrder = require("../models/BuyOrder");
 const Notification = require("../models/Notification");
-const { creditUser, recordTransaction, TX } = require("./economy");
+const { creditUser, recordTransaction, runAtomic, TX } = require("./economy");
 const { marketFee, sellerNet } = require("./itemValue");
 const { HOUSE, ESCROW } = require("./accounts");
 
@@ -112,33 +112,38 @@ async function purchaseListing({ listingId, buyerId, io }) {
     return { ok: false, code: 400, message: "You can't buy your own listing" };
   }
 
-  // debit the buyer and grant the item together, only if the balance covers it
-  const updatedBuyer = await User.findOneAndUpdate(
-    { _id: buyerId, walletBalance: { $gte: claimed.price } },
-    { $inc: { walletBalance: -claimed.price }, $push: { inventory: inventoryEntryFrom(claimed) } },
-    { new: true }
-  );
+  // debit the buyer, grant the item and write the row together; a failed row rolls the
+  // charge back and the listing is restored, so nobody pays without a record
+  const updatedBuyer = await runAtomic(async (session) => {
+    const u = await User.findOneAndUpdate(
+      { _id: buyerId, walletBalance: { $gte: claimed.price } },
+      { $inc: { walletBalance: -claimed.price }, $push: { inventory: inventoryEntryFrom(claimed) } },
+      { new: true, session }
+    );
+    if (!u) return null;
+    // player-to-player, so the buyer and seller legs carry no counterparty; they and the
+    // house fee row self-balance to zero
+    await recordTransaction(
+      {
+        userId: buyerId,
+        type: TX.MARKET_BUY,
+        direction: "debit",
+        amount: claimed.price,
+        balanceAfter: u.walletBalance,
+        counterparty: null,
+        meta: { itemId: claimed.item, itemName: claimed.itemName, sellerId: claimed.sellerId, listingId: claimed.uniqueId },
+      },
+      session
+    );
+    return u;
+  }).catch((err) => {
+    console.error("market buyer charge rolled back:", err);
+    return null;
+  });
   if (!updatedBuyer) {
     await restoreListing(claimed);
     return { ok: false, code: 400, message: "Insufficient balance" };
   }
-
-  // the trade is player to player, so buyer and seller legs need no counterparty: they
-  // and the house fee row self-balance to zero
-  await recordTransaction({
-    userId: buyerId,
-    type: TX.MARKET_BUY,
-    direction: "debit",
-    amount: claimed.price,
-    balanceAfter: updatedBuyer.walletBalance,
-    counterparty: null,
-    meta: {
-      itemId: claimed.item,
-      itemName: claimed.itemName,
-      sellerId: claimed.sellerId,
-      listingId: claimed.uniqueId,
-    },
-  });
 
   const net = sellerNet(claimed.price);
   const seller = await creditUser(claimed.sellerId, net, 0, {
@@ -156,18 +161,25 @@ async function purchaseListing({ listingId, buyerId, io }) {
 
   // seller account is gone: reverse the buyer so their KP can't disappear
   if (!seller) {
-    const reversed = await User.findOneAndUpdate(
-      { _id: buyerId },
-      { $inc: { walletBalance: claimed.price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } },
-      { new: true }
-    );
-    await recordTransaction({
-      userId: buyerId,
-      type: TX.MARKET_BUY,
-      direction: "credit",
-      amount: claimed.price,
-      balanceAfter: reversed ? reversed.walletBalance : undefined,
-      meta: { itemName: claimed.itemName, reversal: true, reason: "seller no longer exists" },
+    const reversed = await runAtomic(async (session) => {
+      const r = await User.findOneAndUpdate(
+        { _id: buyerId },
+        { $inc: { walletBalance: claimed.price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } },
+        { new: true, session }
+      );
+      await recordTransaction(
+        {
+          userId: buyerId,
+          type: TX.MARKET_BUY,
+          direction: "credit",
+          amount: claimed.price,
+          balanceAfter: r ? r.walletBalance : undefined,
+          counterparty: null,
+          meta: { itemName: claimed.itemName, reversal: true, reason: "seller no longer exists" },
+        },
+        session
+      );
+      return r;
     });
     if (reversed && io) {
       io.to(buyerId.toString()).emit("userDataUpdated", {
@@ -255,16 +267,22 @@ async function fillOrderWithItem({ pending, order, io }) {
 
   if (!seller) {
     // seller gone: give the escrowed KP back to the buyer and take the item back
-    await User.updateOne(
-      { _id: claimedOrder.userId },
-      { $inc: { walletBalance: price }, $pull: { inventory: { uniqueId: pending.uniqueId } } }
-    );
-    await recordTransaction({
-      userId: claimedOrder.userId,
-      type: TX.MARKET_ORDER_REFUND,
-      direction: "credit",
-      amount: price,
-      meta: { itemName: pending.itemName, reversal: true, reason: "seller no longer exists" },
+    await runAtomic(async (session) => {
+      await User.updateOne(
+        { _id: claimedOrder.userId },
+        { $inc: { walletBalance: price }, $pull: { inventory: { uniqueId: pending.uniqueId } } },
+        { session }
+      );
+      await recordTransaction(
+        {
+          userId: claimedOrder.userId,
+          type: TX.MARKET_ORDER_REFUND,
+          direction: "credit",
+          amount: price,
+          meta: { itemName: pending.itemName, reversal: true, reason: "seller no longer exists" },
+        },
+        session
+      );
     });
     return { ok: false, reason: "seller gone" };
   }


### PR DESCRIPTION
## The change

The marketplace was the last money path where a wallet change and its ledger row were separate writes. The buyer's charge and its row now commit together inside one transaction: a failed row rolls the charge back and the listing is restored, so nobody pays without a record. The seller-gone reversals in both the direct buy and the buy-order fill are wrapped the same way.

The `findOneAndDelete` claim stays the lock, and the flow still degrades to best-effort on a standalone dev mongod, so nothing changes there.

## Tests

The market atomicity proofs join `ledgerAtomicity.test.js` (one shared replica set) rather than a second replica-set suite - two spinning up in parallel starved the timing-sensitive round tests and made them flaky. The new cases: a buyer row failure charges nobody and leaves the listing up with zero history, and two concurrent buyers never both win.

234 backend tests pass, run twice with no flakiness.