### PR TITLE
Marketplace price band: cap listings at 10x book value (real-money mode only)

### DIFF
--- a/backend/__tests__/integration/marketPriceBand.test.js
+++ b/backend/__tests__/integration/marketPriceBand.test.js
@@ -10,7 +10,9 @@ const BuyOrder = require("../../models/BuyOrder");
 
 let app;
 beforeAll(async () => { await setupDb(); app = makeApp(); });
-afterEach(clearDb);
+// the ceiling only applies in real-money mode; each cap test turns it on
+beforeEach(() => { process.env.REAL_MONEY_MODE = "true"; });
+afterEach(async () => { delete process.env.REAL_MONEY_MODE; await clearDb(); });
 afterAll(teardownDb);
 
 const auth = (user) => ["Authorization", `Bearer ${tokenFor(user)}`];
@@ -89,4 +91,16 @@ test("a buy order within the band still works", async () => {
   const res = await request(app).post("/marketplace/orders").set(...auth(buyer)).send({ itemId: item._id, price: 5000, quantity: 1 });
 
   expect(res.status).toBe(200);
+});
+
+test("fake-balance mode leaves the market uncapped", async () => {
+  delete process.env.REAL_MONEY_MODE; // the default: fake balances
+  const seller = await makeUser();
+  const item = await makeItem(1000); // would be capped at 10,000 in real mode
+  const uniqueId = await giveItem(seller, item);
+
+  const res = await request(app).post("/marketplace").set(...auth(seller)).send({ item: uniqueId, price: 1000000 });
+
+  expect(res.status).toBe(200);
+  expect(await Marketplace.countDocuments({ sellerId: seller._id })).toBe(1);
 });

--- a/backend/__tests__/integration/marketPriceBand.test.js
+++ b/backend/__tests__/integration/marketPriceBand.test.js
@@ -1,0 +1,92 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Marketplace = require("../../models/Marketplace");
+const BuyOrder = require("../../models/BuyOrder");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const auth = (user) => ["Authorization", `Bearer ${tokenFor(user)}`];
+
+const makeUser = (overrides = {}) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance: 100000, level: 20, ...overrides });
+};
+
+const makeItem = (baseValue) =>
+  Item.create({ name: `i-${uniqueSuffix()}`, image: "x", rarity: "3", baseValue });
+
+// give the seller one copy of the item in inventory, return its uniqueId
+async function giveItem(user, item) {
+  const uniqueId = `uq-${uniqueSuffix()}`;
+  await User.updateOne(
+    { _id: user._id },
+    { $push: { inventory: { _id: item._id, name: item.name, image: item.image, rarity: item.rarity, uniqueId } } }
+  );
+  return uniqueId;
+}
+
+test("a listing at up to 10x book value is allowed", async () => {
+  const seller = await makeUser();
+  const item = await makeItem(1000); // ceiling 10,000
+  const uniqueId = await giveItem(seller, item);
+
+  const res = await request(app).post("/marketplace").set(...auth(seller)).send({ item: uniqueId, price: 10000 });
+
+  expect(res.status).toBe(200);
+  expect(await Marketplace.countDocuments({ sellerId: seller._id })).toBe(1);
+});
+
+test("a listing far above book value is rejected (chip dumping)", async () => {
+  const seller = await makeUser();
+  const item = await makeItem(1000); // ceiling 10,000
+  const uniqueId = await giveItem(seller, item);
+
+  const res = await request(app).post("/marketplace").set(...auth(seller)).send({ item: uniqueId, price: 1000000 });
+
+  expect(res.status).toBe(400);
+  expect(res.body.message).toMatch(/too high/i);
+  // the item stays in inventory, nothing is listed
+  expect(await Marketplace.countDocuments({ sellerId: seller._id })).toBe(0);
+  expect((await User.findById(seller._id)).inventory).toHaveLength(1);
+});
+
+test("an unvalued item is capped at the stand-in reference", async () => {
+  const seller = await makeUser();
+  const item = await makeItem(0); // ceiling = 100 * 10 = 1000
+  const uniqueId = await giveItem(seller, item);
+
+  const tooHigh = await request(app).post("/marketplace").set(...auth(seller)).send({ item: uniqueId, price: 5000 });
+  expect(tooHigh.status).toBe(400);
+
+  const ok = await request(app).post("/marketplace").set(...auth(seller)).send({ item: uniqueId, price: 1000 });
+  expect(ok.status).toBe(200);
+});
+
+test("a buy order far above book value is rejected", async () => {
+  const buyer = await makeUser();
+  const item = await makeItem(1000); // ceiling 10,000
+
+  const res = await request(app).post("/marketplace/orders").set(...auth(buyer)).send({ itemId: item._id, price: 500000, quantity: 1 });
+
+  expect(res.status).toBe(400);
+  expect(res.body.message).toMatch(/too high/i);
+  expect(await BuyOrder.countDocuments({ userId: buyer._id })).toBe(0);
+  expect((await User.findById(buyer._id)).walletBalance).toBe(100000); // no escrow taken
+});
+
+test("a buy order within the band still works", async () => {
+  const buyer = await makeUser();
+  const item = await makeItem(1000);
+
+  const res = await request(app).post("/marketplace/orders").set(...auth(buyer)).send({ itemId: item._id, price: 5000, quantity: 1 });
+
+  expect(res.status).toBe(200);
+});

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -12,6 +12,7 @@ const BuyOrder = require("../models/BuyOrder");
 const { chargeUser, creditUser, TX } = require("../utils/economy");
 const { sellValue, marketFee, sellerNet, MARKET_FEE_RATE } = require("../utils/itemValue");
 const market = require("../utils/market");
+const { isRealMoneyMode } = require("../utils/mode");
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
@@ -29,9 +30,10 @@ const cleanPrice = (raw) => {
   return Number.isFinite(n) && n >= 1 && n <= MAX_PRICE ? n : null;
 };
 
-// the ceiling blocks chip-dumping: pricing a cheap item absurdly high is how KP moves to
-// a colluding account. selling cheap only hands over the item, so there is no floor.
+// the ceiling blocks chip-dumping (pricing a cheap item high to move KP to a colluder),
+// which only matters with real value, so it is null and unenforced in fake mode.
 const priceCeiling = (baseValue) => {
+  if (!isRealMoneyMode()) return null;
   const ref = baseValue > 0 ? baseValue : UNVALUED_REFERENCE;
   return Math.min(MAX_PRICE, Math.ceil(ref * PRICE_CEILING_RATE));
 };
@@ -130,7 +132,7 @@ module.exports = (io) => {
       }
 
       const ceiling = priceCeiling(itemDocument.baseValue);
-      if (price > ceiling) {
+      if (ceiling !== null && price > ceiling) {
         return res.status(400).json({ message: `Price too high: at most ${ceiling} K₽ for this item` });
       }
 
@@ -287,7 +289,7 @@ module.exports = (io) => {
       if (!itemDoc) return res.status(404).json({ message: "Item not found" });
 
       const ceiling = priceCeiling(itemDoc.baseValue);
-      if (price > ceiling) {
+      if (ceiling !== null && price > ceiling) {
         return res.status(400).json({ message: `Bid too high: at most ${ceiling} K₽ for this item` });
       }
 

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -20,11 +20,20 @@ const MAX_PRICE = 1000000;
 const MAX_ORDER_QTY = 20;
 const SELL_LEVEL = 5;
 const BUY_LEVEL = 10;
+const PRICE_CEILING_RATE = 10; // a listing or bid may not exceed this multiple of book value
+const UNVALUED_REFERENCE = 100; // stand-in book value for an item with none computed yet
 
 // prices are whole KP; floor rather than reject so a client sending 10.5 is not a hard error
 const cleanPrice = (raw) => {
   const n = Math.floor(Number(raw));
   return Number.isFinite(n) && n >= 1 && n <= MAX_PRICE ? n : null;
+};
+
+// the ceiling blocks chip-dumping: pricing a cheap item absurdly high is how KP moves to
+// a colluding account. selling cheap only hands over the item, so there is no floor.
+const priceCeiling = (baseValue) => {
+  const ref = baseValue > 0 ? baseValue : UNVALUED_REFERENCE;
+  return Math.min(MAX_PRICE, Math.ceil(ref * PRICE_CEILING_RATE));
 };
 
 // the history route is public, but if a token happens to be present we use it to hide
@@ -118,6 +127,11 @@ module.exports = (io) => {
       const itemDocument = await Item.findById(inventoryItem._id);
       if (!itemDocument) {
         return res.status(404).json({ message: "Item not found" });
+      }
+
+      const ceiling = priceCeiling(itemDocument.baseValue);
+      if (price > ceiling) {
+        return res.status(400).json({ message: `Price too high: at most ${ceiling} K₽ for this item` });
       }
 
       // atomically remove exactly this item; if it's already gone, abort without listing
@@ -271,6 +285,11 @@ module.exports = (io) => {
 
       const itemDoc = await Item.findById(itemId);
       if (!itemDoc) return res.status(404).json({ message: "Item not found" });
+
+      const ceiling = priceCeiling(itemDoc.baseValue);
+      if (price > ceiling) {
+        return res.status(400).json({ message: `Bid too high: at most ${ceiling} K₽ for this item` });
+      }
 
       let filled = 0;
       let spent = 0;

--- a/backend/utils/mode.js
+++ b/backend/utils/mode.js
@@ -1,0 +1,5 @@
+// real-money mode gates controls that only matter once balances have real value (anti
+// chip-dumping, later kyc and limits); fake mode leaves them off, where moving KP is harmless.
+const isRealMoneyMode = () => process.env.REAL_MONEY_MODE === "true";
+
+module.exports = { isRealMoneyMode };


### PR DESCRIPTION
## The change

A listing or buy order may exceed book value only up to 10x - a guard against chip-dumping (pricing a cheap item high to move KP to a colluding account). Both the sell-listing and buy-order routes enforce it.

**It only applies in real-money mode.** A `REAL_MONEY_MODE` flag gates it: off by default (fake balances, no cap), on only when real value is in play. In fake-balance mode moving KP between accounts is harmless and the effort is just engagement, so the market is left uncapped. The flag is the hook the other real-money-only controls will hang off later.

## Tests

`marketPriceBand.test.js`: with real-money mode on, a listing up to 10x is allowed and above is rejected with the item kept, an unvalued item is capped at the reference, a bid above the band is rejected with no escrow taken; with fake mode (the default) the market is uncapped.

Backend tests pass.