### PR TITLE
Token revocation: let a leaked token be invalidated

### DIFF
--- a/backend/__tests__/integration/tokenRevocation.test.js
+++ b/backend/__tests__/integration/tokenRevocation.test.js
@@ -1,0 +1,57 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeUser = () => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance: 100 });
+};
+
+const tokenFor = (user, tokenVersion) =>
+  jwt.sign({ userId: user._id.toString(), tokenVersion }, process.env.JWT_SECRET, { expiresIn: "30d" });
+
+const bearer = (t) => ["Authorization", `Bearer ${t}`];
+
+test("a token matching the account version is accepted", async () => {
+  const user = await makeUser();
+  const res = await request(app).get("/users/me").set(...bearer(tokenFor(user, 0)));
+  expect(res.status).toBe(200);
+});
+
+test("logout-all revokes every existing token", async () => {
+  const user = await makeUser();
+  const token = tokenFor(user, 0);
+
+  // the token works, then the user signs out of all devices
+  expect((await request(app).get("/users/me").set(...bearer(token))).status).toBe(200);
+  const out = await request(app).post("/users/logout-all").set(...bearer(token));
+  expect(out.status).toBe(200);
+
+  // the same token is now rejected
+  const after = await request(app).get("/users/me").set(...bearer(token));
+  expect(after.status).toBe(401);
+
+  // a freshly issued token (next version) works again
+  const fresh = tokenFor(user, 1);
+  expect((await request(app).get("/users/me").set(...bearer(fresh))).status).toBe(200);
+});
+
+test("a legacy token with no version keeps working until the first revoke", async () => {
+  const user = await makeUser();
+  // a token issued before token versions existed carries no tokenVersion claim
+  const legacy = jwt.sign({ userId: user._id.toString() }, process.env.JWT_SECRET, { expiresIn: "30d" });
+
+  expect((await request(app).get("/users/me").set(...bearer(legacy))).status).toBe(200);
+
+  await request(app).post("/users/logout-all").set(...bearer(legacy));
+  expect((await request(app).get("/users/me").set(...bearer(legacy))).status).toBe(401);
+});

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -27,6 +27,12 @@ const isAuthenticated = async (req, res, next) => {
       return res.status(401).json({ message: "Token is not valid" });
     }
 
+    // a token from before the current version has been revoked. a missing version reads
+    // as 0 so tokens issued before this existed keep working until the next revoke.
+    if ((decoded.tokenVersion || 0) !== (user.tokenVersion || 0)) {
+      return res.status(401).json({ message: "Session expired. Please log in again." });
+    }
+
     req.user = user;
     next();
   } catch (error) {

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -18,6 +18,11 @@ const UserSchema = new mongoose.Schema({
   password: {
     type: String,
   },
+  // bumped to invalidate every token issued so far (logout everywhere, password change)
+  tokenVersion: {
+    type: Number,
+    default: 0,
+  },
   walletBalance: {
     type: Number,
     default: 200,

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -81,7 +81,7 @@ router.post(
       });
 
       // Generate and send JWT
-      const payload = { userId: user.id };
+      const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };
       jwt.sign(
         payload,
         process.env.JWT_SECRET,
@@ -136,7 +136,7 @@ router.post(
       }
 
       // Generate and send JWT
-      const payload = { userId: user.id };
+      const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };
       jwt.sign(
         payload,
         process.env.JWT_SECRET,
@@ -190,7 +190,7 @@ router.post('/googlelogin', async (req, res) => {
       });
     }
     // Generate and send JWT
-    const payload = { userId: user.id };
+    const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };
     jwt.sign(
       payload,
       process.env.JWT_SECRET,
@@ -482,6 +482,18 @@ router.post('/claimBonus', authMiddleware.isAuthenticated, async (req, res) => {
 });
 
 
+
+// revoke every token issued for this account by bumping its version; the caller and
+// every other device must log in again. the fix for a stolen or leaked token.
+router.post('/logout-all', authMiddleware.isAuthenticated, async (req, res) => {
+  try {
+    await User.updateOne({ _id: req.user._id }, { $inc: { tokenVersion: 1 } });
+    res.json({ message: "Signed out of all devices." });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
 
 const isValidBase64 = (str) => {
   const base64Regex = /^data:image\/(png|jpeg|jpg);base64,/;


### PR DESCRIPTION
## The problem

Tokens last 30 days and there was no way to invalidate one before then: a leaked or stolen token was good for a month, and there was no "log out everywhere."

## The change

The User doc carries a `tokenVersion`, stamped into every token it signs. The auth middleware rejects a token whose version is behind the account's, and `POST /users/logout-all` bumps it, invalidating every token at once. A missing version reads as zero, so tokens issued before this existed keep working until the first revoke - nobody is logged out by the deploy.

## Tests

`tokenRevocation.test.js`: a matching-version token is accepted; `logout-all` revokes the current token while a freshly issued one works; a legacy version-less token keeps working until the first revoke.

242 backend tests pass.