### PR TITLE
Crash provably fair: committed hash chain with reveal

### DIFF
--- a/backend/__tests__/integration/crashVerify.test.js
+++ b/backend/__tests__/integration/crashVerify.test.js
@@ -1,0 +1,58 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp } = require("./helpers");
+const Round = require("../../models/Round");
+const { generateChain, sha256 } = require("../../utils/hashChain");
+const { crashPointFromSeed } = require("../../utils/crashMath");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+// a settled crash round as the game would have written it
+async function settledRound() {
+  const { seeds, terminalHash } = generateChain(3);
+  const seed = seeds[0];
+  return Round.create({
+    game: "crash",
+    status: "settled",
+    serverSeed: seed,
+    serverSeedHash: sha256(seed),
+    chainIndex: 0,
+    outcome: { crashPoint: crashPointFromSeed(seed) },
+    // terminalHash is not needed by the endpoint, but the chain produced this seed
+    meta: { terminalHash },
+  });
+}
+
+test("a settled round reveals the seed and verifies", async () => {
+  const round = await settledRound();
+  const res = await request(app).get(`/fair/crash/${round._id}`);
+
+  expect(res.status).toBe(200);
+  expect(res.body.revealed).toBe(true);
+  expect(res.body.serverSeed).toBe(round.serverSeed);
+  expect(res.body.commitmentValid).toBe(true);
+  expect(res.body.outcomeValid).toBe(true);
+  expect(res.body.recomputedCrashPoint).toBe(round.outcome.crashPoint);
+});
+
+test("a running round shows the commitment but never the seed", async () => {
+  const round = await settledRound();
+  await Round.updateOne({ _id: round._id }, { $set: { status: "running" } });
+
+  const res = await request(app).get(`/fair/crash/${round._id}`);
+  expect(res.status).toBe(200);
+  expect(res.body.revealed).toBe(false);
+  expect(res.body.serverSeedHash).toBe(round.serverSeedHash);
+  expect(res.body.serverSeed).toBeUndefined();
+  expect(res.body.crashPoint).toBeUndefined();
+});
+
+test("an unknown round is a 404", async () => {
+  const res = await request(app).get("/fair/crash/000000000000000000000000");
+  expect(res.status).toBe(404);
+});

--- a/backend/__tests__/integration/gameChain.test.js
+++ b/backend/__tests__/integration/gameChain.test.js
@@ -1,0 +1,54 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const { setupDb, clearDb, teardownDb } = require("./db");
+const GameSeedChain = require("../../models/GameSeedChain");
+const { consumeNextSeed } = require("../../utils/gameChain");
+const { sha256, linksTo } = require("../../utils/hashChain");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+test("seeds are handed out in order and form a verifiable chain", async () => {
+  const first = await consumeNextSeed("crash");
+  const second = await consumeNextSeed("crash");
+  const third = await consumeNextSeed("crash");
+
+  // one chain was created and all three came from it
+  expect(await GameSeedChain.countDocuments({ game: "crash" })).toBe(1);
+  expect(first.index).toBe(0);
+  expect(second.index).toBe(1);
+  expect(third.index).toBe(2);
+
+  // the first links to the public terminal, each next links to the one before it
+  expect(linksTo(first.seed, first.terminalHash)).toBe(true);
+  expect(sha256(second.seed)).toBe(first.seed);
+  expect(sha256(third.seed)).toBe(second.seed);
+});
+
+test("a client never sees an unconsumed seed", async () => {
+  await consumeNextSeed("crash");
+  // the seeds array is the secret; only the terminal hash is public
+  const chain = await GameSeedChain.findOne({ game: "crash" });
+  expect(chain.terminalHash).toHaveLength(64);
+  expect(chain.seeds.length).toBeGreaterThan(1); // the rest are still unrevealed
+});
+
+test("an exhausted chain rotates to a fresh commitment", async () => {
+  // shrink the active chain to one remaining seed, then consume past it
+  const chain = await GameSeedChain.findOneAndUpdate(
+    { game: "crash" },
+    {},
+    { upsert: false, new: true }
+  ) || (await consumeNextSeed("crash"), await GameSeedChain.findOne({ game: "crash" }));
+  await GameSeedChain.updateOne({ _id: chain._id }, { $set: { cursor: chain.seeds.length - 1 } });
+  const oldTerminal = chain.terminalHash;
+
+  const last = await consumeNextSeed("crash"); // consumes the final seed of the old chain
+  const rotated = await consumeNextSeed("crash"); // must come from a new chain
+
+  expect(last.terminalHash).toBe(oldTerminal);
+  expect(rotated.terminalHash).not.toBe(oldTerminal);
+  expect(rotated.index).toBe(0);
+  expect(await GameSeedChain.countDocuments({ game: "crash", active: true })).toBe(1);
+});

--- a/backend/__tests__/integration/gameRaces.test.js
+++ b/backend/__tests__/integration/gameRaces.test.js
@@ -1,10 +1,12 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
 
-// pin the round to a high crash point so a cashout at 1.0x is always in time
-jest.mock("../../utils/crashMath", () => ({
-  ...jest.requireActual("../../utils/crashMath"),
-  crashPointFromRandom: () => 99,
-  INSTANT_CRASH_CHANCE: 0,
+const crypto = require("crypto");
+
+// pin the crash seed to a high crash point so a cashout at 1.0x is always in time, and
+// skip generating a real 10k-seed chain under this suite's fake timers (mock-prefixed)
+let mockHighSeed = null;
+jest.mock("../../utils/gameChain", () => ({
+  consumeNextSeed: jest.fn(async () => ({ seed: mockHighSeed, chainId: null, index: 0 })),
 }));
 
 const { setupDb, clearDb, teardownDb } = require("./db");
@@ -12,8 +14,14 @@ const { uniqueSuffix } = require("./helpers");
 
 const User = require("../../models/User");
 const Round = require("../../models/Round");
+const { crashPointFromSeed } = require("../../utils/crashMath");
 const crashGame = require("../../games/crash");
 const coinFlip = require("../../games/coinFlip");
+
+for (let i = 0; mockHighSeed === null; i++) {
+  const s = crypto.createHash("sha256").update(`gr:${i}`).digest("hex");
+  if (crashPointFromSeed(s) >= 50) mockHighSeed = s;
+}
 
 beforeAll(setupDb);
 

--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -1,13 +1,33 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
 
+const crypto = require("crypto");
+
+// pin the crash seed so its outcome is known (jest only allows mock-prefixed vars here)
+let mockCrashSeed = null;
+jest.mock("../../utils/gameChain", () => ({
+  consumeNextSeed: jest.fn(async () => ({ seed: mockCrashSeed, chainId: null, index: 0 })),
+}));
+
 const { setupDb, clearDb, teardownDb } = require("./db");
 const { uniqueSuffix } = require("./helpers");
 const User = require("../../models/User");
 const Round = require("../../models/Round");
 const Transaction = require("../../models/Transaction");
 const { TX } = require("../../utils/economy");
+const { crashPointFromSeed } = require("../../utils/crashMath");
 const crashGame = require("../../games/crash");
 const coinFlip = require("../../games/coinFlip");
+
+const findSeed = (pred) => {
+  for (let i = 0; i < 200000; i++) {
+    const s = crypto.createHash("sha256").update(`rr:${i}`).digest("hex");
+    if (pred(crashPointFromSeed(s))) return s;
+  }
+  throw new Error("no seed found");
+};
+const INSTANT_SEED = findSeed((cp) => cp === 1.0);
+const RUNNING_SEED = findSeed((cp) => cp >= 3);
+mockCrashSeed = RUNNING_SEED; // default so a round always has a valid seed
 
 // real timers throughout: faking the clock stops the mongo driver's own timers and every
 // query then times out. the games take their timings as arguments instead, so a whole
@@ -70,8 +90,8 @@ const makeSocket = (userId) => {
 };
 
 test("crash writes a round, ties the stake to it, and settles it at the bust", async () => {
-  // land on an instant bust so the round resolves in one tick without a real wait
-  jest.spyOn(Math, "random").mockReturnValue(0.01); // below INSTANT_CRASH_CHANCE
+  // a seed whose crash point is 1.0, so the round busts instantly and settles at once
+  mockCrashSeed = INSTANT_SEED;
   const user = await makeUser(5000);
   const io = makeIo();
 
@@ -105,7 +125,8 @@ test("crash writes a round, ties the stake to it, and settles it at the bust", a
 });
 
 test("a crash cashout is recorded on the round", async () => {
-  jest.spyOn(Math, "random").mockReturnValue(0.99); // no instant bust
+  // a seed with a high crash point, so the round is comfortably still running at cashout
+  mockCrashSeed = RUNNING_SEED;
   const user = await makeUser(5000);
   const io = makeIo();
 
@@ -120,14 +141,11 @@ test("a crash cashout is recorded on the round", async () => {
   await socket.handlers["crash:cashout"](() => {});
 
   const cashed = await Round.findById(opened._id);
-  // a crash point of exactly 1.00 happens 1% of the time and refuses the cashout
-  if (cashed.outcome && cashed.outcome.crashPoint > 1) {
-    expect(cashed.bets[0].payout).toBeGreaterThan(0);
-    expect(cashed.bets[0].multiplier).toBeGreaterThan(1);
-    expect(cashed.bets[0].settledAt).toBeTruthy();
-    const tx = await Transaction.findOne({ userId: user._id, type: TX.CRASH_CASHOUT });
-    expect(tx.meta.roundId).toBe(String(opened._id));
-  }
+  expect(cashed.bets[0].payout).toBeGreaterThan(0);
+  expect(cashed.bets[0].multiplier).toBeGreaterThan(1);
+  expect(cashed.bets[0].settledAt).toBeTruthy();
+  const tx = await Transaction.findOne({ userId: user._id, type: TX.CRASH_CASHOUT });
+  expect(tx.meta.roundId).toBe(String(opened._id));
 });
 
 test("coin flip writes a round, records the side, and settles after the toss", async () => {

--- a/backend/__tests__/unit/crashSecrecy.test.js
+++ b/backend/__tests__/unit/crashSecrecy.test.js
@@ -1,68 +1,53 @@
-// pins the round to a known crash point. getRandomValues is a non-configurable
-// property on the real module, so it has to be replaced at require time.
-jest.mock("crypto", () => {
-  const actual = jest.requireActual("crypto");
-  return {
-    ...actual,
-    getRandomValues: (arr) => {
-      arr[0] = 3229298719;
-      return arr;
-    },
-  };
-});
+const crypto = require("crypto");
+const { crashPointFromSeed, GROWTH } = require("../../utils/crashMath");
+const { sha256 } = require("../../utils/hashChain");
 
-// the round record is exercised against a real database in the round-records tests;
-// here it only has to not need one
+// jest only lets a mock factory reference out-of-scope vars whose names start with "mock"
+let mockCrashSeed = null;
+
+// the chain hands the game its seed; pin it so the round has a known crash point
+jest.mock("../../utils/gameChain", () => ({
+  consumeNextSeed: jest.fn(async () => ({ seed: mockCrashSeed, chainId: "chain-under-test", index: 0 })),
+}));
+
 jest.mock("../../models/Round", () => ({
-  create: jest.fn(async () => ({ _id: "round-under-test" })),
+  create: jest.fn(async (doc) => ({ _id: "round-under-test", ...doc })),
   updateOne: jest.fn(async () => ({})),
 }));
 
-// what the wallet does is irrelevant to what the server broadcasts, so stubbing it
-// keeps this test free of a database and lets the round run on fake timers
 jest.mock("../../utils/economy", () => ({
   chargeUser: jest.fn(async (userId) => ({
-    _id: userId,
-    username: "player",
-    profilePicture: "",
-    level: 1,
-    fixedItem: null,
-    walletBalance: 500,
-    xp: 0,
+    _id: userId, username: "player", profilePicture: "", level: 1, fixedItem: null, walletBalance: 500, xp: 0,
   })),
-  creditUser: jest.fn(async (userId) => ({
-    _id: userId,
-    username: "player",
-    walletBalance: 900,
-    xp: 0,
-    level: 1,
-  })),
+  creditUser: jest.fn(async (userId) => ({ _id: userId, username: "player", walletBalance: 900, xp: 0, level: 1 })),
   TX: { CRASH_BET: "crash_bet", CRASH_CASHOUT: "crash_cashout" },
 }));
 
 const crashGame = require("../../games/crash");
 const { creditUser } = require("../../utils/economy");
-const { crashPointFromRandom, GROWTH } = require("../../utils/crashMath");
 
-// picked so the round crashes at 4.00x: high enough that a cashout five seconds in
-// (1.35x) is still comfortably inside the round
-const REAL_CRASH_POINT = crashPointFromRandom(3229298719);
+// a seed whose crash point is high enough that a cashout a few seconds in is still in
+// the round. found by search so the test does not depend on a hand-picked constant.
+function seedWithHighCrash() {
+  for (let i = 0; i < 100000; i++) {
+    const seed = crypto.createHash("sha256").update(`fixture:${i}`).digest("hex");
+    if (crashPointFromSeed(seed) >= 4) return seed;
+  }
+  throw new Error("no high-crash seed found");
+}
+const FIXED_SEED = seedWithHighCrash();
+const REAL_CRASH_POINT = crashPointFromSeed(FIXED_SEED);
+mockCrashSeed = FIXED_SEED;
+
 const BETTING_WINDOW = 12000;
-// exp(t * GROWTH) reaches 4.00x at ~23.1s, so this always outlives the round
-const WHOLE_ROUND = 24000;
+const WHOLE_ROUND = 60000;
 
-// records everything the server puts on the wire. the clone matters: gameState is one
-// object mutated in place, and socket.io serializes at emit time, so holding the
-// reference would rewrite history.
 const makeIo = () => {
   const broadcasts = [];
   const io = {
     connection: null,
-    on: (event, fn) => {
-      if (event === "connection") io.connection = fn;
-    },
-    emit: (event, payload) =>
-      broadcasts.push({ event, payload: JSON.parse(JSON.stringify(payload ?? null)) }),
+    on: (event, fn) => { if (event === "connection") io.connection = fn; },
+    emit: (event, payload) => broadcasts.push({ event, payload: JSON.parse(JSON.stringify(payload ?? null)) }),
     to: () => ({ emit: () => {} }),
     broadcasts,
   };
@@ -84,21 +69,19 @@ describe("crash rounds", () => {
 
   beforeEach(async () => {
     jest.useFakeTimers();
-    jest.spyOn(Math, "random").mockReturnValue(0.99); // above INSTANT_CRASH_CHANCE
-    creditUser.mockClear();
     io = makeIo();
     crashGame(io);
-    // betting opens once the round record is written, so let that settle first
-    await jest.advanceTimersByTimeAsync(0);
+    await jest.advanceTimersByTimeAsync(0); // the seed is consumed, then betting opens
   });
 
   afterEach(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
     jest.restoreAllMocks();
+    creditUser.mockClear();
   });
 
-  test("the crash point is never broadcast while the round is still running", async () => {
+  test("neither the crash point nor the seed is broadcast while the round runs", async () => {
     const alice = makeSocket("alice");
     const bob = makeSocket("bob");
     io.connection(alice);
@@ -107,99 +90,55 @@ describe("crash rounds", () => {
     await alice.handlers["crash:bet"](100, () => {});
     await bob.handlers["crash:bet"](100, () => {});
 
-    // start the round: from here the server knows where it crashes
-    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
-    // climb to ~1.35x, far short of 4.00x
-    await jest.advanceTimersByTimeAsync(5000);
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW); // round starts
+    await jest.advanceTimersByTimeAsync(5000); // climbs, still short of the crash
 
-    // alice takes her money out. bob is still in the round and must learn nothing.
     await alice.handlers["crash:cashout"](() => {});
 
-    // sanity: the round really was still live when she cashed out
-    expect(REAL_CRASH_POINT).toBe(4);
+    expect(REAL_CRASH_POINT).toBeGreaterThanOrEqual(4);
     expect(lastState(io).gamePlayers.bob.payout).toBeNull();
 
+    // the commitment is public, but the crash point and the seed are not
+    expect(lastState(io).serverSeedHash).toBe(sha256(FIXED_SEED));
     const leaks = io.broadcasts.filter(
-      (b) => b.payload && b.payload.crashPoint === REAL_CRASH_POINT
+      (b) => b.payload && (b.payload.crashPoint === REAL_CRASH_POINT || b.payload.serverSeed === FIXED_SEED)
     );
     expect(leaks).toEqual([]);
   });
 
-  test("a bet is still visible to everyone, and pays stake * multiplier on cashout", async () => {
+  test("the seed is revealed only when the round ends, and matches its commitment", async () => {
+    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
+    await jest.advanceTimersByTimeAsync(WHOLE_ROUND);
+
+    const reveals = io.broadcasts.filter((b) => b.event === "crash:reveal");
+    expect(reveals).toHaveLength(1);
+    expect(reveals[0].payload.serverSeed).toBe(FIXED_SEED);
+    expect(sha256(reveals[0].payload.serverSeed)).toBe(reveals[0].payload.serverSeedHash);
+    expect(reveals[0].payload.crashPoint).toBe(REAL_CRASH_POINT);
+
+    const results = io.broadcasts.filter((b) => b.event === "crash:result");
+    expect(results[0].payload).toBe(REAL_CRASH_POINT);
+  });
+
+  test("a cashout pays stake times the live multiplier", async () => {
     const alice = makeSocket("alice");
     io.connection(alice);
-
     await alice.handlers["crash:bet"](100, () => {});
-
-    const betting = lastState(io);
-    expect(betting.gameBets.alice).toBe(100);
-    expect(betting.gamePlayers.alice.username).toBe("player");
-    expect(betting.gamePlayers.alice.payout).toBeNull();
-    expect(betting).not.toHaveProperty("crashPoint");
 
     await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
     await jest.advanceTimersByTimeAsync(5000);
     await alice.handlers["crash:cashout"](() => {});
 
-    const expectedMultiplier = Math.exp(5 * GROWTH); // ~1.3499x
+    const expected = Math.exp(5 * GROWTH);
     expect(creditUser).toHaveBeenCalledTimes(1);
-    const [userId, payout, winnings] = creditUser.mock.calls[0];
+    const [userId, payout] = creditUser.mock.calls[0];
     expect(userId).toBe("alice");
-    expect(payout).toBeCloseTo(100 * expectedMultiplier, 5);
-    expect(winnings).toBeCloseTo(100 * expectedMultiplier - 100, 5);
-
-    // her locked-in payout is public; the crash point still is not
-    const cashedOut = lastState(io);
-    expect(cashedOut.gamePlayers.alice.payout).toBeCloseTo(expectedMultiplier, 5);
-    expect(cashedOut).not.toHaveProperty("crashPoint");
-  });
-
-  test("clients still get a climbing multiplier during the round", async () => {
-    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
-    await jest.advanceTimersByTimeAsync(5000);
-
-    const ticks = io.broadcasts.filter((b) => b.event === "crash:multiplier").map((b) => b.payload);
-    expect(ticks.length).toBeGreaterThan(50);
-    expect(ticks[0]).toBeGreaterThanOrEqual(1);
-    expect(ticks[ticks.length - 1]).toBeGreaterThan(ticks[0]);
-    expect(ticks[ticks.length - 1]).toBeLessThan(REAL_CRASH_POINT);
-  });
-
-  test("the crash point is revealed once the round is over, and betting reopens", async () => {
-    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
-    await jest.advanceTimersByTimeAsync(WHOLE_ROUND);
-
-    const results = io.broadcasts.filter((b) => b.event === "crash:result");
-    expect(results).toHaveLength(1);
-    expect(results[0].payload).toBe(REAL_CRASH_POINT);
-
-    // the state that follows the reveal is the empty one for the next round
-    expect(lastState(io)).toEqual({ gameBets: {}, gamePlayers: {}, gameStartTime: null });
-
-    const bob = makeSocket("bob");
-    io.connection(bob);
-    let reply;
-    await bob.handlers["crash:bet"](50, (r) => { reply = r; });
-    expect(reply).toEqual({ ok: true });
-  });
-
-  test("riding past the bust pays nothing", async () => {
-    const bob = makeSocket("bob");
-    io.connection(bob);
-    await bob.handlers["crash:bet"](100, () => {});
-
-    await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
-    await jest.advanceTimersByTimeAsync(WHOLE_ROUND);
-
-    // too late: the round is gone
-    await bob.handlers["crash:cashout"](() => {});
-    expect(creditUser).not.toHaveBeenCalled();
+    expect(payout).toBeCloseTo(100 * expected, 5);
   });
 
   test("betting is refused once the round is under way", async () => {
     const bob = makeSocket("bob");
     io.connection(bob);
-
     await jest.advanceTimersByTimeAsync(BETTING_WINDOW);
     await jest.advanceTimersByTimeAsync(2000);
 

--- a/backend/__tests__/unit/hashChain.test.js
+++ b/backend/__tests__/unit/hashChain.test.js
@@ -1,0 +1,59 @@
+const { sha256, generateChain, linksTo } = require("../../utils/hashChain");
+const { crashPointFromSeed, INSTANT_CRASH_CHANCE } = require("../../utils/crashMath");
+
+describe("hash chain", () => {
+  test("each consumed seed links back to the commitment, in order", () => {
+    const { seeds, terminalHash } = generateChain(50);
+
+    // round 1's seed hashes to the terminal; every later seed hashes to the prior one
+    expect(linksTo(seeds[0], terminalHash)).toBe(true);
+    for (let i = 1; i < seeds.length; i++) {
+      expect(linksTo(seeds[i], seeds[i - 1])).toBe(true);
+      expect(sha256(seeds[i])).toBe(seeds[i - 1]);
+    }
+  });
+
+  test("a tampered seed does not verify", () => {
+    const { seeds } = generateChain(10);
+    expect(linksTo(seeds[2] + "00", sha256(seeds[1]))).toBe(false);
+  });
+
+  test("two chains are independent", () => {
+    expect(generateChain(5).terminalHash).not.toBe(generateChain(5).terminalHash);
+  });
+});
+
+describe("crash point from seed", () => {
+  test("is deterministic and at least 1.0", () => {
+    const { seeds } = generateChain(100);
+    for (const s of seeds) {
+      const a = crashPointFromSeed(s);
+      const b = crashPointFromSeed(s);
+      expect(a).toBe(b);
+      expect(a).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  test("preserves the house edge: bust rate and cashout RTP", () => {
+    // draw many independent seeds and measure the realised distribution
+    const N = 40000;
+    let busts = 0;
+    let return2x = 0; // a 2x cashout returns 2 per unit when crash >= 2
+    let return10x = 0;
+    for (let i = 0; i < N; i++) {
+      const cp = crashPointFromSeed(require("crypto").randomBytes(32).toString("hex"));
+      if (cp === 1.0) busts += 1;
+      if (cp >= 2) return2x += 2;
+      if (cp >= 10) return10x += 10;
+    }
+
+    // crash at exactly 1.0 combines the 3% instant bust and the curve's own floor (~1%)
+    expect(busts / N).toBeGreaterThan(INSTANT_CRASH_CHANCE);
+    expect(busts / N).toBeLessThan(0.05);
+    // every cashout target returns ~0.96 per unit staked: the flat ~4% edge, not ~1.0
+    expect(return2x / N).toBeGreaterThan(0.93);
+    expect(return2x / N).toBeLessThan(0.99);
+    expect(return10x / N).toBeGreaterThan(0.90);
+    expect(return10x / N).toBeLessThan(1.0);
+  });
+});

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -1,23 +1,25 @@
-const crypto = require("crypto");
 const Round = require("../models/Round");
 const { chargeUser, creditUser, TX } = require("../utils/economy");
-const { multiplierAt, crashPointFromRandom, INSTANT_CRASH_CHANCE } = require("../utils/crashMath");
+const { multiplierAt, crashPointFromSeed } = require("../utils/crashMath");
+const { consumeNextSeed } = require("../utils/gameChain");
+const { sha256 } = require("../utils/hashChain");
 
 const freshState = () => ({
   gameBets: {},
   gamePlayers: {},
   crashPoint: 1.0,
   gameStartTime: null,
+  serverSeed: null, // the round's seed, kept secret until the round ends
+  serverSeedHash: null, // its commitment, public from betting open
 });
 
-// the crash point is the one secret a round holds, so it never goes on the wire until
-// the round is over and `crash:result` reveals it. broadcasting the whole state used to
-// hand it to every connected client the moment anyone cashed out: everyone still in the
-// round could then bail one tick before the bust, every time.
+// the crash point never goes on the wire until the round ends. the serverSeedHash is
+// safe: it is a one-way commitment, and the crash point cannot be derived from it.
 const publicState = (state) => ({
   gameBets: state.gameBets,
   gamePlayers: state.gamePlayers,
   gameStartTime: state.gameStartTime,
+  serverSeedHash: state.serverSeedHash,
 });
 
 // the timings are arguments so a test can run a whole round in milliseconds against a
@@ -193,7 +195,21 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
     if (stopped) return;
     gameState = freshState();
     try {
-      round = await Round.create({ game: "crash", status: "betting" });
+      // the seed fixes the crash point before any bet: players see its commitment now and
+      // the seed at round end, so the outcome was decided in advance and cannot be steered.
+      const { seed, chainId, index } = await consumeNextSeed("crash");
+      gameState.serverSeed = seed;
+      gameState.serverSeedHash = sha256(seed);
+      gameState.crashPoint = crashPointFromSeed(seed);
+      round = await Round.create({
+        game: "crash",
+        status: "betting",
+        serverSeed: seed,
+        serverSeedHash: gameState.serverSeedHash,
+        chainId,
+        chainIndex: index,
+        outcome: { crashPoint: gameState.crashPoint },
+      });
       if (stopped) return;
       bettingOpen = true;
     } catch (e) {
@@ -212,16 +228,14 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
     bettingOpen = false;
     io.emit("crash:start");
 
-    gameState.crashPoint = calculateCrashPoint();
+    // the crash point was fixed by the seed at betting open, so the round just starts;
+    // it stays server side until the reveal
     gameState.gameStartTime = Date.now();
-
-    // the crash point is written down before the round runs, so a restart can tell a
-    // round that had an outcome from one that never got that far. it stays server side.
     const running = round;
     if (running) {
       await Round.updateOne(
         { _id: running._id },
-        { $set: { status: "running", outcome: { crashPoint: gameState.crashPoint }, startedAt: new Date() } }
+        { $set: { status: "running", startedAt: new Date() } }
       ).catch((e) => console.log(e));
     }
 
@@ -232,6 +246,13 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
       if (currentMultiplier >= gameState.crashPoint) {
         clearInterval(multiplierInterval);
         io.emit("crash:result", gameState.crashPoint);
+        // the seed is revealed only now, so nobody could have derived the outcome early
+        io.emit("crash:reveal", {
+          roundId: running ? String(running._id) : null,
+          serverSeed: gameState.serverSeed,
+          serverSeedHash: gameState.serverSeedHash,
+          crashPoint: gameState.crashPoint,
+        });
 
         // the round is over: whoever did not cash out lost it fairly, which is what
         // separates a settled round from one a restart has to hand back
@@ -248,18 +269,6 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
       }
     }, tickMs);
     ticker = multiplierInterval;
-  };
-
-  const calculateCrashPoint = () => {
-    const h = crypto.getRandomValues(new Uint32Array(1))[0];
-    let crashPoint = crashPointFromRandom(h);
-
-    // small chance to crash instantly
-    if (Math.random() < INSTANT_CRASH_CHANCE) {
-      crashPoint = 1.0;
-    }
-
-    return crashPoint;
   };
 
   openBetting();

--- a/backend/models/GameSeedChain.js
+++ b/backend/models/GameSeedChain.js
@@ -1,0 +1,19 @@
+const mongoose = require("mongoose");
+
+// a committed hash chain for a live shared game: the seeds stay secret and are revealed
+// one per round, while the terminalHash is the public commitment fixing the sequence.
+const GameSeedChainSchema = new mongoose.Schema(
+  {
+    game: { type: String, enum: ["crash", "coinflip"], required: true },
+    terminalHash: { type: String, required: true },
+    seeds: { type: [String], required: true }, // secret until each is consumed
+    cursor: { type: Number, default: 0 }, // index of the next seed to consume
+    active: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+// one active chain per game
+GameSeedChainSchema.index({ game: 1, active: 1 });
+
+module.exports = mongoose.model("GameSeedChain", GameSeedChainSchema);

--- a/backend/models/Round.js
+++ b/backend/models/Round.js
@@ -34,6 +34,12 @@ const RoundSchema = new mongoose.Schema(
       default: "betting",
     },
     outcome: mongoose.Schema.Types.Mixed, // { crashPoint } | { result, winningSide }
+    // provable fairness: the seed is committed as serverSeedHash before betting and
+    // revealed when the round ends; the outcome is derived from it and reproducible.
+    serverSeed: String, // revealed at round end
+    serverSeedHash: String, // the commitment, public from betting open
+    chainId: { type: mongoose.Schema.Types.ObjectId, ref: "GameSeedChain" },
+    chainIndex: Number,
     bets: { type: [roundBetSchema], default: [] },
     startedAt: Date,
     settledAt: Date,

--- a/backend/routes/fairRoutes.js
+++ b/backend/routes/fairRoutes.js
@@ -3,6 +3,9 @@ const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
+const Round = require("../models/Round");
+const { crashPointFromSeed } = require("../utils/crashMath");
+const { sha256 } = require("../utils/hashChain");
 
 const cleanClientSeed = (raw) => {
   const s = (raw || "").toString().trim();
@@ -88,6 +91,37 @@ router.get("/roll-by-item/:uniqueId", async (req, res) => {
 router.get("/roll/:rollId/verify", async (req, res) => {
   try {
     res.json(await rolls.verifyCaseRoll(req.params.rollId));
+  } catch (e) {
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// verify a crash round. while it is still live only the commitment is public; once it
+// settles the seed is revealed and anyone can reproduce the crash point and the chain link.
+router.get("/crash/:roundId", async (req, res) => {
+  try {
+    const round = await Round.findById(req.params.roundId);
+    if (!round || round.game !== "crash") return res.status(404).json({ message: "Round not found" });
+
+    const revealed = round.status === "settled" || round.status === "voided";
+    const view = {
+      roundId: String(round._id),
+      status: round.status,
+      serverSeedHash: round.serverSeedHash,
+      chainIndex: round.chainIndex,
+      revealed,
+    };
+    if (!revealed) return res.json(view);
+
+    const recomputed = crashPointFromSeed(round.serverSeed);
+    res.json({
+      ...view,
+      serverSeed: round.serverSeed,
+      crashPoint: round.outcome && round.outcome.crashPoint,
+      recomputedCrashPoint: recomputed,
+      commitmentValid: sha256(round.serverSeed) === round.serverSeedHash,
+      outcomeValid: recomputed === (round.outcome && round.outcome.crashPoint),
+    });
   } catch (e) {
     res.status(500).json({ message: "Server error" });
   }

--- a/backend/utils/crashMath.js
+++ b/backend/utils/crashMath.js
@@ -1,3 +1,5 @@
+const crypto = require("crypto");
+
 const GROWTH = 0.06; // multiplier growth per second
 const INSTANT_CRASH_CHANCE = 0.03;
 
@@ -11,4 +13,13 @@ const crashPointFromRandom = (h) => {
   return Math.floor((100 * e - h) / (e - h)) / 100;
 };
 
-module.exports = { GROWTH, INSTANT_CRASH_CHANCE, multiplierAt, crashPointFromRandom };
+// the outcome derived from one seed so the round is verifiable: two disjoint words of
+// sha256(seed) drive the instant bust and the curve, matching the old random distribution.
+const crashPointFromSeed = (serverSeed) => {
+  const hash = crypto.createHash("sha256").update(serverSeed).digest("hex");
+  const bust = parseInt(hash.slice(0, 8), 16) / 2 ** 32; // uniform [0,1)
+  if (bust < INSTANT_CRASH_CHANCE) return 1.0;
+  return crashPointFromRandom(parseInt(hash.slice(8, 16), 16));
+};
+
+module.exports = { GROWTH, INSTANT_CRASH_CHANCE, multiplierAt, crashPointFromRandom, crashPointFromSeed };

--- a/backend/utils/gameChain.js
+++ b/backend/utils/gameChain.js
@@ -1,0 +1,32 @@
+const GameSeedChain = require("../models/GameSeedChain");
+const { generateChain } = require("./hashChain");
+
+const CHAIN_LENGTH = 10000; // seeds per chain; a new commitment is published on rotation
+
+function createChain(game) {
+  const { seeds, terminalHash } = generateChain(CHAIN_LENGTH);
+  return GameSeedChain.create({ game, seeds, terminalHash, cursor: 0, active: true });
+}
+
+// atomically take the next seed from the active chain, rotating to a fresh one when it is
+// exhausted. the seed stays server-side until the round reveals it.
+async function consumeNextSeed(game) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const claimed = await GameSeedChain.findOneAndUpdate(
+      { game, active: true, $expr: { $lt: ["$cursor", { $size: "$seeds" }] } },
+      { $inc: { cursor: 1 } },
+      { new: false, projection: { seeds: 0 } }
+    );
+    if (claimed) {
+      const index = claimed.cursor; // the pre-increment value is the one we claimed
+      const doc = await GameSeedChain.findById(claimed._id, { seeds: { $slice: [index, 1] } });
+      return { chainId: claimed._id, terminalHash: claimed.terminalHash, index, seed: doc.seeds[0] };
+    }
+    // none active, or the active one is spent: retire it and publish a fresh commitment
+    await GameSeedChain.updateMany({ game, active: true }, { $set: { active: false } });
+    await createChain(game);
+  }
+  throw new Error(`could not consume a ${game} seed`);
+}
+
+module.exports = { CHAIN_LENGTH, createChain, consumeNextSeed };

--- a/backend/utils/hashChain.js
+++ b/backend/utils/hashChain.js
@@ -1,0 +1,24 @@
+const crypto = require("crypto");
+
+const sha256 = (s) => crypto.createHash("sha256").update(s).digest("hex");
+
+// build a chain where each seed is the hash of the next, so consuming them in order and
+// revealing each proves the whole sequence, back to a terminal hash committed in advance.
+function generateChain(length) {
+  const seeds = new Array(length);
+  seeds[length - 1] = crypto.randomBytes(32).toString("hex");
+  for (let i = length - 2; i >= 0; i--) {
+    seeds[i] = sha256(seeds[i + 1]);
+  }
+  // terminal = hash of the first seed to be consumed; it commits the entire chain
+  const terminalHash = sha256(seeds[0]);
+  return { seeds, terminalHash };
+}
+
+// a revealed seed is valid if hashing it gives the previous reveal (or the terminal
+// for the first round). this is the whole verification a player runs.
+function linksTo(seed, priorHashOrTerminal) {
+  return sha256(seed) === priorHashOrTerminal;
+}
+
+module.exports = { sha256, generateChain, linksTo };


### PR DESCRIPTION
## The change

Crash chose its outcome each round with `getRandomValues` plus a `Math.random` instant-bust, with no commitment - players had to trust the house not to steer or restate a round.

A round now draws its server seed from a **committed hash chain**, where each seed is the hash of the next and a terminal hash is published before any round. The crash point is derived entirely from the seed, so the outcome is fixed the moment the seed is drawn, before betting opens. The commitment (the seed's hash) is broadcast during betting; the seed is revealed only when the round ends, and hashing it reproduces both the commitment and the crash point. The same two-word derivation keeps the exact house edge.

`GET /fair/crash/:roundId` serves verification: while a round is live only the commitment is public; once it settles the seed is revealed and anyone can reproduce the crash point and the chain link. The `Round` record stores the seed, commitment and chain position. The seed still never goes on the wire mid-round, so the #128 leak stays closed.

## Tests

- `hashChain.test.js`: chain integrity, tamper rejection, and that the seed-derived crash point preserves the house edge (bust rate and RTP at 2x and 10x).
- `gameChain.test.js`: seeds handed out in order forming a verifiable chain, unconsumed seeds never exposed, exhausted chain rotates to a fresh commitment.
- `crashVerify.test.js`: a settled round reveals and verifies; a running round shows only the commitment.
- `crashSecrecy.test.js` (updated): the crash point and seed stay secret mid-round, the reveal matches the commitment.

248 backend tests pass, run twice. Frontend builds unchanged (it ignores the new commitment field and reveal event).