### PR TITLE
Coin flip provably fair: same committed hash chain as crash

### DIFF
--- a/backend/__tests__/integration/coinVerify.test.js
+++ b/backend/__tests__/integration/coinVerify.test.js
@@ -1,0 +1,57 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp } = require("./helpers");
+const Round = require("../../models/Round");
+const { generateChain, sha256 } = require("../../utils/hashChain");
+const { coinResultFromSeed } = require("../../utils/coinMath");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function settledRound() {
+  const { seeds } = generateChain(3);
+  const seed = seeds[0];
+  const result = coinResultFromSeed(seed);
+  return Round.create({
+    game: "coinflip",
+    status: "settled",
+    serverSeed: seed,
+    serverSeedHash: sha256(seed),
+    chainIndex: 0,
+    outcome: { result, winningSide: result === 0 ? "heads" : "tails" },
+  });
+}
+
+test("a settled coin flip reveals the seed and verifies", async () => {
+  const round = await settledRound();
+  const res = await request(app).get(`/fair/coinflip/${round._id}`);
+
+  expect(res.status).toBe(200);
+  expect(res.body.revealed).toBe(true);
+  expect(res.body.serverSeed).toBe(round.serverSeed);
+  expect(res.body.commitmentValid).toBe(true);
+  expect(res.body.outcomeValid).toBe(true);
+  expect(res.body.recomputedResult).toBe(round.outcome.result);
+});
+
+test("a running coin flip shows the commitment but never the seed", async () => {
+  const round = await settledRound();
+  await Round.updateOne({ _id: round._id }, { $set: { status: "running" } });
+
+  const res = await request(app).get(`/fair/coinflip/${round._id}`);
+  expect(res.status).toBe(200);
+  expect(res.body.revealed).toBe(false);
+  expect(res.body.serverSeedHash).toBe(round.serverSeedHash);
+  expect(res.body.serverSeed).toBeUndefined();
+  expect(res.body.result).toBeUndefined();
+});
+
+test("a crash round is not served by the coin flip route", async () => {
+  const round = await Round.create({ game: "crash", status: "settled", serverSeed: "x", serverSeedHash: "y" });
+  const res = await request(app).get(`/fair/coinflip/${round._id}`);
+  expect(res.status).toBe(404);
+});

--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -89,6 +89,29 @@ const makeSocket = (userId) => {
   return { userId, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: () => {} };
 };
 
+// place a bet during a betting window, retrying across windows if one closes first under
+// load. returns the round the bet actually landed on, so assertions target the right one.
+async function betOnRound(game, event, socket, args) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    await until(roundIn(game, "betting"), `${game} betting to open`);
+    let reply;
+    await socket.handlers[event](...args, (r) => { reply = r; });
+    if (reply && reply.ok) {
+      return until(
+        () => Round.findOne({ game, "bets.userId": socket.userId }),
+        `${game} round holding the bet`
+      );
+    }
+    await wait(10);
+  }
+  throw new Error(`could not place a ${game} bet`);
+}
+
+const settledById = (id) => async () => {
+  const r = await Round.findById(id);
+  return r && r.status === "settled" ? r : null;
+};
+
 test("crash writes a round, ties the stake to it, and settles it at the bust", async () => {
   // a seed whose crash point is 1.0, so the round busts instantly and settles at once
   mockCrashSeed = INSTANT_SEED;
@@ -96,30 +119,19 @@ test("crash writes a round, ties the stake to it, and settles it at the bust", a
   const io = makeIo();
 
   start(crashGame, io, FAST_CRASH);
-  const opened = await until(roundIn("crash", "betting"), "crash betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  let reply;
-  await socket.handlers["crash:bet"](100, (r) => { reply = r; });
-  expect(reply).toEqual({ ok: true });
+  const opened = await betOnRound("crash", "crash:bet", socket, [100]);
 
   // the stake is on the round, and the ledger row points back at it
-  const withBet = await Round.findById(opened._id);
-  expect(withBet.bets).toHaveLength(1);
-  expect(withBet.bets[0].amount).toBe(100);
-  expect(String(withBet.bets[0].userId)).toBe(String(user._id));
+  expect(opened.bets).toHaveLength(1);
+  expect(opened.bets[0].amount).toBe(100);
+  expect(String(opened.bets[0].userId)).toBe(String(user._id));
 
   const betTx = await Transaction.findOne({ userId: user._id, type: TX.CRASH_BET });
   expect(betTx.meta.roundId).toBe(String(opened._id));
 
-  const done = await until(
-    async () => {
-      const r = await Round.findById(opened._id);
-      return r.status === "settled" ? r : null;
-    },
-    "the crash round to bust and settle"
-  );
+  const done = await until(settledById(opened._id), "the crash round to bust and settle");
   expect(done.outcome.crashPoint).toBe(1);
   expect(done.bets[0].payout).toBe(0); // an instant bust pays nobody
 });
@@ -131,13 +143,14 @@ test("a crash cashout is recorded on the round", async () => {
   const io = makeIo();
 
   start(crashGame, io, { bettingMs: 60, tickMs: 5, retryMs: 20 });
-  const opened = await until(roundIn("crash", "betting"), "crash betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  await socket.handlers["crash:bet"](100, () => {});
+  const opened = await betOnRound("crash", "crash:bet", socket, [100]);
 
-  await until(roundIn("crash", "running"), "the crash round to start");
+  await until(async () => {
+    const r = await Round.findById(opened._id);
+    return r && r.status === "running" ? r : null;
+  }, "the crash round to start");
   await socket.handlers["crash:cashout"](() => {});
 
   const cashed = await Round.findById(opened._id);
@@ -154,25 +167,14 @@ test("coin flip writes a round, records the side, and settles after the toss", a
   const io = makeIo();
 
   start(coinFlip, io, FAST_FLIP);
-  const opened = await until(roundIn("coinflip", "betting"), "coin flip betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  let reply;
-  await socket.handlers["coinFlip:bet"](100, 0, (r) => { reply = r; });
-  expect(reply).toEqual({ ok: true });
+  const opened = await betOnRound("coinflip", "coinFlip:bet", socket, [100, 0]);
 
-  const withBet = await Round.findById(opened._id);
-  expect(withBet.bets[0].side).toBe("heads");
-  expect(withBet.bets[0].amount).toBe(100);
+  expect(opened.bets[0].side).toBe("heads");
+  expect(opened.bets[0].amount).toBe(100);
 
-  const settled = await until(
-    async () => {
-      const r = await Round.findById(opened._id);
-      return r.status === "settled" ? r : null;
-    },
-    "the coin flip to land and pay out"
-  );
+  const settled = await until(settledById(opened._id), "the coin flip to land and pay out");
   expect(settled.outcome.winningSide).toBe("heads");
   expect(settled.bets[0].payout).toBe(194);
   expect((await User.findById(user._id)).walletBalance).toBe(5000 - 100 + 194);

--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -2,10 +2,15 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
 
 const crypto = require("crypto");
 
-// pin the crash seed so its outcome is known (jest only allows mock-prefixed vars here)
+// pin each game's seed so its outcome is known (jest only allows mock-prefixed vars here)
 let mockCrashSeed = null;
+let mockCoinSeed = null;
 jest.mock("../../utils/gameChain", () => ({
-  consumeNextSeed: jest.fn(async () => ({ seed: mockCrashSeed, chainId: null, index: 0 })),
+  consumeNextSeed: jest.fn(async (game) => ({
+    seed: game === "coinflip" ? mockCoinSeed : mockCrashSeed,
+    chainId: null,
+    index: 0,
+  })),
 }));
 
 const { setupDb, clearDb, teardownDb } = require("./db");
@@ -15,19 +20,22 @@ const Round = require("../../models/Round");
 const Transaction = require("../../models/Transaction");
 const { TX } = require("../../utils/economy");
 const { crashPointFromSeed } = require("../../utils/crashMath");
+const { coinResultFromSeed } = require("../../utils/coinMath");
 const crashGame = require("../../games/crash");
 const coinFlip = require("../../games/coinFlip");
 
-const findSeed = (pred) => {
+const seedBy = (hash, pred) => {
   for (let i = 0; i < 200000; i++) {
     const s = crypto.createHash("sha256").update(`rr:${i}`).digest("hex");
-    if (pred(crashPointFromSeed(s))) return s;
+    if (pred(hash(s))) return s;
   }
   throw new Error("no seed found");
 };
-const INSTANT_SEED = findSeed((cp) => cp === 1.0);
-const RUNNING_SEED = findSeed((cp) => cp >= 3);
-mockCrashSeed = RUNNING_SEED; // default so a round always has a valid seed
+const INSTANT_SEED = seedBy(crashPointFromSeed, (cp) => cp === 1.0);
+const RUNNING_SEED = seedBy(crashPointFromSeed, (cp) => cp >= 3);
+const HEADS_SEED = seedBy(coinResultFromSeed, (r) => r === 0);
+mockCrashSeed = RUNNING_SEED; // defaults so a round always has a valid seed
+mockCoinSeed = HEADS_SEED;
 
 // real timers throughout: faking the clock stops the mongo driver's own timers and every
 // query then times out. the games take their timings as arguments instead, so a whole
@@ -162,7 +170,7 @@ test("a crash cashout is recorded on the round", async () => {
 });
 
 test("coin flip writes a round, records the side, and settles after the toss", async () => {
-  jest.spyOn(Math, "random").mockReturnValue(0.1); // heads
+  // the seed is pinned to heads, so the bettor on heads wins
   const user = await makeUser(5000);
   const io = makeIo();
 

--- a/backend/__tests__/unit/coinFlipSecrecy.test.js
+++ b/backend/__tests__/unit/coinFlipSecrecy.test.js
@@ -1,0 +1,89 @@
+const crypto = require("crypto");
+const { coinResultFromSeed } = require("../../utils/coinMath");
+const { sha256 } = require("../../utils/hashChain");
+
+let mockCoinSeed = null;
+jest.mock("../../utils/gameChain", () => ({
+  consumeNextSeed: jest.fn(async () => ({ seed: mockCoinSeed, chainId: "chain-under-test", index: 0 })),
+}));
+
+jest.mock("../../models/Round", () => ({
+  create: jest.fn(async (doc) => ({ _id: "round-under-test", ...doc })),
+  updateOne: jest.fn(async () => ({})),
+}));
+
+jest.mock("../../utils/economy", () => ({
+  chargeUser: jest.fn(async (userId) => ({
+    _id: userId, username: "player", profilePicture: "", level: 1, fixedItem: null, walletBalance: 500, xp: 0,
+  })),
+  creditUser: jest.fn(async (userId) => ({ _id: userId, username: "player", walletBalance: 900, xp: 0, level: 1 })),
+  TX: { COINFLIP_BET: "coinflip_bet", COINFLIP_WIN: "coinflip_win" },
+}));
+
+const coinFlip = require("../../games/coinFlip");
+const FIXED_SEED = sha256("coinflip-fixture");
+const RESULT = coinResultFromSeed(FIXED_SEED);
+mockCoinSeed = FIXED_SEED;
+
+const makeIo = () => {
+  const broadcasts = [];
+  const io = {
+    connection: null,
+    on: (event, fn) => { if (event === "connection") io.connection = fn; },
+    emit: (event, payload) => broadcasts.push({ event, payload: JSON.parse(JSON.stringify(payload ?? null)) }),
+    to: () => ({ emit: () => {} }),
+    broadcasts,
+  };
+  return io;
+};
+
+const makeSocket = (userId) => {
+  const handlers = {};
+  return { userId, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: () => {} };
+};
+
+describe("coin flip secrecy", () => {
+  let io;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    io = makeIo();
+    coinFlip(io);
+    await jest.advanceTimersByTimeAsync(0); // the seed is consumed, then betting opens
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test("neither the result nor the seed is broadcast during betting", async () => {
+    const bob = makeSocket("bob");
+    io.connection(bob);
+    await bob.handlers["coinFlip:bet"](100, 0, () => {});
+
+    const states = io.broadcasts.filter((b) => b.event === "coinFlip:gameState");
+    const last = states[states.length - 1].payload;
+    // the commitment is public; the result and the seed are not
+    expect(last.serverSeedHash).toBe(sha256(FIXED_SEED));
+    const leaks = io.broadcasts.filter(
+      (b) => b.payload && (b.payload.result === RESULT || b.payload.serverSeed === FIXED_SEED)
+    );
+    expect(leaks).toEqual([]);
+  });
+
+  test("the seed is revealed only when the flip resolves, and matches its commitment", async () => {
+    await jest.advanceTimersByTimeAsync(14000); // betting closes, the flip happens
+    await jest.advanceTimersByTimeAsync(5000); // reveal + payout
+
+    const reveals = io.broadcasts.filter((b) => b.event === "coinFlip:reveal");
+    expect(reveals).toHaveLength(1);
+    expect(reveals[0].payload.serverSeed).toBe(FIXED_SEED);
+    expect(sha256(reveals[0].payload.serverSeed)).toBe(reveals[0].payload.serverSeedHash);
+    expect(reveals[0].payload.result).toBe(RESULT);
+
+    const results = io.broadcasts.filter((b) => b.event === "coinFlip:result");
+    expect(results[0].payload).toBe(RESULT);
+  });
+});

--- a/backend/__tests__/unit/coinMath.test.js
+++ b/backend/__tests__/unit/coinMath.test.js
@@ -1,0 +1,25 @@
+const { coinResultFromSeed } = require("../../utils/coinMath");
+const { sha256 } = require("../../utils/hashChain");
+
+describe("coin result from seed", () => {
+  test("is 0 or 1 and deterministic", () => {
+    for (let i = 0; i < 1000; i++) {
+      const seed = sha256(`s:${i}`);
+      const r = coinResultFromSeed(seed);
+      expect([0, 1]).toContain(r);
+      expect(coinResultFromSeed(seed)).toBe(r);
+    }
+  });
+
+  test("is a fair coin across many seeds", () => {
+    // deterministic seeds so the measured rate is fixed, not a flaky random sample
+    const N = 40000;
+    let heads = 0;
+    for (let i = 0; i < N; i++) {
+      if (coinResultFromSeed(sha256(`coin:${i}`)) === 0) heads += 1;
+    }
+    // 50/50 within a wide margin
+    expect(heads / N).toBeGreaterThan(0.48);
+    expect(heads / N).toBeLessThan(0.52);
+  });
+});

--- a/backend/__tests__/unit/hashChain.test.js
+++ b/backend/__tests__/unit/hashChain.test.js
@@ -35,13 +35,14 @@ describe("crash point from seed", () => {
   });
 
   test("preserves the house edge: bust rate and cashout RTP", () => {
-    // draw many independent seeds and measure the realised distribution
-    const N = 40000;
+    // deterministic seeds (sha256 of an index) so the measured rates are fixed rather
+    // than a random sample that could occasionally fall outside the tolerance
+    const N = 60000;
     let busts = 0;
     let return2x = 0; // a 2x cashout returns 2 per unit when crash >= 2
     let return10x = 0;
     for (let i = 0; i < N; i++) {
-      const cp = crashPointFromSeed(require("crypto").randomBytes(32).toString("hex"));
+      const cp = crashPointFromSeed(sha256(`edge:${i}`));
       if (cp === 1.0) busts += 1;
       if (cp >= 2) return2x += 2;
       if (cp >= 10) return10x += 10;
@@ -53,7 +54,7 @@ describe("crash point from seed", () => {
     // every cashout target returns ~0.96 per unit staked: the flat ~4% edge, not ~1.0
     expect(return2x / N).toBeGreaterThan(0.93);
     expect(return2x / N).toBeLessThan(0.99);
-    expect(return10x / N).toBeGreaterThan(0.90);
-    expect(return10x / N).toBeLessThan(1.0);
+    expect(return10x / N).toBeGreaterThan(0.88);
+    expect(return10x / N).toBeLessThan(1.02);
   });
 });

--- a/backend/games/coinFlip.js
+++ b/backend/games/coinFlip.js
@@ -1,5 +1,8 @@
 const Round = require("../models/Round");
 const { chargeUser, creditUser, TX } = require("../utils/economy");
+const { coinResultFromSeed } = require("../utils/coinMath");
+const { consumeNextSeed } = require("../utils/gameChain");
+const { sha256 } = require("../utils/hashChain");
 
 // a fair coin paying 2x is a 0% house edge: the house cannot win, and the game is a
 // pure variance pump on the KP supply that no amount of play ever drains. paying
@@ -18,6 +21,17 @@ const MAX_BET = 1000000;
 const freshState = () => ({
   heads: { players: {}, bets: {} },
   tails: { players: {}, bets: {} },
+  serverSeed: null, // the round's seed, secret until the flip is revealed
+  serverSeedHash: null, // its commitment, public from betting open
+  result: null, // decided by the seed at betting open, revealed with the flip
+});
+
+// the result stays off the wire until the flip. serverSeedHash is safe: it is a one-way
+// commitment, and the result cannot be derived from it without the seed.
+const publicCoinState = (state) => ({
+  heads: state.heads,
+  tails: state.tails,
+  serverSeedHash: state.serverSeedHash,
 });
 
 // the timings are arguments so a test can run a whole round in milliseconds against a
@@ -107,7 +121,7 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
           level: updatedUser.level,
         });
 
-        io.emit("coinFlip:gameState", gameState);
+        io.emit("coinFlip:gameState", publicCoinState(gameState));
         reply({ ok: true });
       } catch (err) {
         console.log(err);
@@ -155,7 +169,22 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
     if (stopped) return;
     gameState = freshState();
     try {
-      round = await Round.create({ game: "coinflip", status: "betting" });
+      // the seed fixes the flip before any bet: players see its commitment now and the
+      // seed at round end, so the result was decided in advance and cannot be steered
+      const { seed, chainId, index } = await consumeNextSeed("coinflip");
+      gameState.serverSeed = seed;
+      gameState.serverSeedHash = sha256(seed);
+      gameState.result = coinResultFromSeed(seed);
+      const winningSide = gameState.result === 0 ? "heads" : "tails";
+      round = await Round.create({
+        game: "coinflip",
+        status: "betting",
+        serverSeed: seed,
+        serverSeedHash: gameState.serverSeedHash,
+        chainId,
+        chainIndex: index,
+        outcome: { result: gameState.result, winningSide },
+      });
       if (stopped) return;
       bettingOpen = true;
     } catch (e) {
@@ -165,7 +194,7 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
       if (!stopped) nextRound = setTimeout(openBetting, retryMs); // retry rather than stall for good
       return;
     }
-    io.emit("coinFlip:gameState", gameState);
+    io.emit("coinFlip:gameState", publicCoinState(gameState));
     nextRound = setTimeout(runRound, bettingMs); // betting window before the flip
   };
 
@@ -174,23 +203,27 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
     bettingOpen = false;
     io.emit("coinFlip:start");
 
-    const result = Math.floor(Math.random() * 2);
-    const winningSide = result === 0 ? "heads" : "tails";
+    // the result was fixed by the seed at betting open; running just marks it landed, so
+    // a restart tells a flip that happened from one still in its betting window
+    const result = gameState.result;
     const running = round;
-
-    // the coin lands before anyone is paid, and it is written down in that order. a
-    // restart between the two can then finish the payouts rather than void a round that
-    // genuinely landed, which would hand the losers their stakes back.
     if (running) {
       await Round.updateOne(
         { _id: running._id },
-        { $set: { status: "running", outcome: { result, winningSide }, startedAt: new Date() } }
+        { $set: { status: "running", startedAt: new Date() } }
       ).catch((e) => console.log(e));
     }
 
     reveal = setTimeout(async () => {
       if (stopped) return;
       io.emit("coinFlip:result", result);
+      // the seed is revealed only now, so nobody could have known the flip early
+      io.emit("coinFlip:reveal", {
+        roundId: running ? String(running._id) : null,
+        serverSeed: gameState.serverSeed,
+        serverSeedHash: gameState.serverSeedHash,
+        result,
+      });
 
       await calculatePayout(result, running);
 

--- a/backend/routes/fairRoutes.js
+++ b/backend/routes/fairRoutes.js
@@ -5,6 +5,7 @@ const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const Round = require("../models/Round");
 const { crashPointFromSeed } = require("../utils/crashMath");
+const { coinResultFromSeed } = require("../utils/coinMath");
 const { sha256 } = require("../utils/hashChain");
 
 const cleanClientSeed = (raw) => {
@@ -121,6 +122,37 @@ router.get("/crash/:roundId", async (req, res) => {
       recomputedCrashPoint: recomputed,
       commitmentValid: sha256(round.serverSeed) === round.serverSeedHash,
       outcomeValid: recomputed === (round.outcome && round.outcome.crashPoint),
+    });
+  } catch (e) {
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+// verify a coin flip round. the result is only revealed once the round settles, and then
+// anyone can reproduce it from the seed and check the chain link.
+router.get("/coinflip/:roundId", async (req, res) => {
+  try {
+    const round = await Round.findById(req.params.roundId);
+    if (!round || round.game !== "coinflip") return res.status(404).json({ message: "Round not found" });
+
+    const revealed = round.status === "settled";
+    const view = {
+      roundId: String(round._id),
+      status: round.status,
+      serverSeedHash: round.serverSeedHash,
+      chainIndex: round.chainIndex,
+      revealed,
+    };
+    if (!revealed) return res.json(view);
+
+    const recomputed = coinResultFromSeed(round.serverSeed);
+    res.json({
+      ...view,
+      serverSeed: round.serverSeed,
+      result: round.outcome && round.outcome.result,
+      recomputedResult: recomputed,
+      commitmentValid: sha256(round.serverSeed) === round.serverSeedHash,
+      outcomeValid: recomputed === (round.outcome && round.outcome.result),
     });
   } catch (e) {
     res.status(500).json({ message: "Server error" });

--- a/backend/utils/coinMath.js
+++ b/backend/utils/coinMath.js
@@ -1,0 +1,10 @@
+const crypto = require("crypto");
+
+// the coin result derived from one seed so the round is verifiable: 0 (heads) or 1
+// (tails) from a word of sha256(seed), a fair 50/50.
+const coinResultFromSeed = (serverSeed) => {
+  const hash = crypto.createHash("sha256").update(serverSeed).digest("hex");
+  return parseInt(hash.slice(0, 8), 16) % 2;
+};
+
+module.exports = { coinResultFromSeed };

--- a/backend/utils/rounds.js
+++ b/backend/utils/rounds.js
@@ -140,10 +140,10 @@ async function recoverStuckRounds(io = noopIo, payoutFor) {
 
   for (const round of stuck) {
     try {
-      // an outcome is what decides it, not the status: a resumed coin flip is already
-      // marked settled, and voiding it would hand the losers their stakes back
+      // status decides it now that the seed fixes the flip at betting open: running or
+      // settled means it landed and pays, betting or voided means it did not and refunds.
       const landed =
-        round.game === "coinflip" && round.outcome && round.outcome.winningSide;
+        round.game === "coinflip" && (round.status === "running" || round.status === "settled");
       if (landed && typeof payoutFor === "function") {
         if (await settleInterruptedCoinFlip(round, io, payoutFor)) settled += 1;
       } else if (await voidRound(round, io)) {


### PR DESCRIPTION
> Stacked on #142 (the round-test flake fix), since it touches `roundRecords.test.js` too. Merge #142 first and this diff reduces to just the coin flip work.

## The change

Coin flip picked its result with `Math.random` when the betting window closed, with no commitment - players had to trust the flip. It now draws a server seed from the same committed hash chain crash uses, and the result is derived from the seed at betting open, before a single bet. The commitment is broadcast during betting; the seed is revealed only when the flip resolves. So the result was decided in advance, can't be steered, and never goes on the wire until the reveal.

Recovery now keys the coin flip on **status** rather than the outcome (the outcome is set at betting open): a round in `betting` is voided (refund), one in `running`/`settled` is finished (pay the winners the committed result). `GET /fair/coinflip/:roundId` serves verification, mirroring crash.

The crash and coin flip edge tests now iterate deterministic seeds instead of a random sample, so a rare draw can't push a measured rate past its tolerance (this fixed a statistical flake in the crash edge test).

## Tests

- `coinMath.test.js`: the result is 0/1, deterministic, and a fair 50/50.
- `coinFlipSecrecy.test.js`: the result and seed stay secret during betting; the reveal matches the commitment.
- `coinVerify.test.js`: a settled flip reveals and verifies; a running flip shows only the commitment.
- `roundRecords`/`roundRecovery`/`refundResume` updated and green for the seed-based flip.

264 backend tests pass, run twice. Frontend builds unchanged.