### PR TITLE
Game fixes: crash mid-round sync, coin flip history, slot reel and layout

### DIFF
--- a/backend/__tests__/integration/coinflipHistory.test.js
+++ b/backend/__tests__/integration/coinflipHistory.test.js
@@ -1,0 +1,50 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp } = require("./helpers");
+const Round = require("../../models/Round");
+
+let app;
+beforeAll(async () => { await setupDb(); app = makeApp(); });
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const settledFlip = (result, at) =>
+  Round.create({
+    game: "coinflip",
+    status: "settled",
+    outcome: { result, winningSide: result === 0 ? "heads" : "tails" },
+    createdAt: at,
+  });
+
+test("returns recent settled coin flips, newest first", async () => {
+  await settledFlip(0, new Date("2026-01-01"));
+  await settledFlip(1, new Date("2026-01-02"));
+  await settledFlip(0, new Date("2026-01-03"));
+
+  const res = await request(app).get("/games/coinflip/history");
+
+  expect(res.status).toBe(200);
+  expect(res.body).toHaveLength(3);
+  expect(res.body[0].winningSide).toBe("heads"); // the 01-03 flip, newest
+  expect(res.body.map((r) => r.result)).toEqual([0, 1, 0]);
+});
+
+test("only settled coin flips are returned, and the limit is honoured", async () => {
+  for (let i = 0; i < 20; i++) await settledFlip(i % 2, new Date(2026, 0, i + 1));
+  await Round.create({ game: "coinflip", status: "betting" }); // in-flight, excluded
+  await Round.create({ game: "crash", status: "settled", outcome: { crashPoint: 2 } }); // wrong game
+
+  const res = await request(app).get("/games/coinflip/history?limit=5");
+
+  expect(res.status).toBe(200);
+  expect(res.body).toHaveLength(5);
+  for (const r of res.body) expect([0, 1]).toContain(r.result);
+});
+
+test("no history is an empty list, not an error", async () => {
+  const res = await request(app).get("/games/coinflip/history");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual([]);
+});

--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -89,6 +89,29 @@ const makeSocket = (userId) => {
   return { userId, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: () => {} };
 };
 
+// place a bet during a betting window, retrying across windows if one closes first under
+// load. returns the round the bet actually landed on, so assertions target the right one.
+async function betOnRound(game, event, socket, args) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    await until(roundIn(game, "betting"), `${game} betting to open`);
+    let reply;
+    await socket.handlers[event](...args, (r) => { reply = r; });
+    if (reply && reply.ok) {
+      return until(
+        () => Round.findOne({ game, "bets.userId": socket.userId }),
+        `${game} round holding the bet`
+      );
+    }
+    await wait(10);
+  }
+  throw new Error(`could not place a ${game} bet`);
+}
+
+const settledById = (id) => async () => {
+  const r = await Round.findById(id);
+  return r && r.status === "settled" ? r : null;
+};
+
 test("crash writes a round, ties the stake to it, and settles it at the bust", async () => {
   // a seed whose crash point is 1.0, so the round busts instantly and settles at once
   mockCrashSeed = INSTANT_SEED;
@@ -96,30 +119,19 @@ test("crash writes a round, ties the stake to it, and settles it at the bust", a
   const io = makeIo();
 
   start(crashGame, io, FAST_CRASH);
-  const opened = await until(roundIn("crash", "betting"), "crash betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  let reply;
-  await socket.handlers["crash:bet"](100, (r) => { reply = r; });
-  expect(reply).toEqual({ ok: true });
+  const opened = await betOnRound("crash", "crash:bet", socket, [100]);
 
   // the stake is on the round, and the ledger row points back at it
-  const withBet = await Round.findById(opened._id);
-  expect(withBet.bets).toHaveLength(1);
-  expect(withBet.bets[0].amount).toBe(100);
-  expect(String(withBet.bets[0].userId)).toBe(String(user._id));
+  expect(opened.bets).toHaveLength(1);
+  expect(opened.bets[0].amount).toBe(100);
+  expect(String(opened.bets[0].userId)).toBe(String(user._id));
 
   const betTx = await Transaction.findOne({ userId: user._id, type: TX.CRASH_BET });
   expect(betTx.meta.roundId).toBe(String(opened._id));
 
-  const done = await until(
-    async () => {
-      const r = await Round.findById(opened._id);
-      return r.status === "settled" ? r : null;
-    },
-    "the crash round to bust and settle"
-  );
+  const done = await until(settledById(opened._id), "the crash round to bust and settle");
   expect(done.outcome.crashPoint).toBe(1);
   expect(done.bets[0].payout).toBe(0); // an instant bust pays nobody
 });
@@ -131,13 +143,14 @@ test("a crash cashout is recorded on the round", async () => {
   const io = makeIo();
 
   start(crashGame, io, { bettingMs: 60, tickMs: 5, retryMs: 20 });
-  const opened = await until(roundIn("crash", "betting"), "crash betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  await socket.handlers["crash:bet"](100, () => {});
+  const opened = await betOnRound("crash", "crash:bet", socket, [100]);
 
-  await until(roundIn("crash", "running"), "the crash round to start");
+  await until(async () => {
+    const r = await Round.findById(opened._id);
+    return r && r.status === "running" ? r : null;
+  }, "the crash round to start");
   await socket.handlers["crash:cashout"](() => {});
 
   const cashed = await Round.findById(opened._id);
@@ -154,25 +167,14 @@ test("coin flip writes a round, records the side, and settles after the toss", a
   const io = makeIo();
 
   start(coinFlip, io, FAST_FLIP);
-  const opened = await until(roundIn("coinflip", "betting"), "coin flip betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  let reply;
-  await socket.handlers["coinFlip:bet"](100, 0, (r) => { reply = r; });
-  expect(reply).toEqual({ ok: true });
+  const opened = await betOnRound("coinflip", "coinFlip:bet", socket, [100, 0]);
 
-  const withBet = await Round.findById(opened._id);
-  expect(withBet.bets[0].side).toBe("heads");
-  expect(withBet.bets[0].amount).toBe(100);
+  expect(opened.bets[0].side).toBe("heads");
+  expect(opened.bets[0].amount).toBe(100);
 
-  const settled = await until(
-    async () => {
-      const r = await Round.findById(opened._id);
-      return r.status === "settled" ? r : null;
-    },
-    "the coin flip to land and pay out"
-  );
+  const settled = await until(settledById(opened._id), "the coin flip to land and pay out");
   expect(settled.outcome.winningSide).toBe("heads");
   expect(settled.bets[0].payout).toBe(194);
   expect((await User.findById(user._id)).walletBalance).toBe(5000 - 100 + 194);

--- a/backend/__tests__/unit/crashSync.test.js
+++ b/backend/__tests__/unit/crashSync.test.js
@@ -1,0 +1,71 @@
+const { sha256 } = require("../../utils/hashChain");
+
+let mockCrashSeed = null;
+jest.mock("../../utils/gameChain", () => ({
+  consumeNextSeed: jest.fn(async () => ({ seed: mockCrashSeed, chainId: "c", index: 0 })),
+}));
+
+jest.mock("../../models/Round", () => ({
+  create: jest.fn(async (doc) => ({ _id: "round-under-test", ...doc })),
+  updateOne: jest.fn(async () => ({})),
+}));
+
+jest.mock("../../utils/economy", () => ({
+  chargeUser: jest.fn(), creditUser: jest.fn(),
+  TX: { CRASH_BET: "crash_bet", CRASH_CASHOUT: "crash_cashout" },
+}));
+
+const crashGame = require("../../games/crash");
+mockCrashSeed = sha256("crash-sync-fixture");
+
+const makeIo = () => {
+  const io = {
+    connection: null,
+    on: (event, fn) => { if (event === "connection") io.connection = fn; },
+    emit: () => {},
+    to: () => ({ emit: () => {} }),
+  };
+  return io;
+};
+
+// a socket that records what the server emits to it, and lets a handler be invoked
+const makeSocket = () => {
+  const handlers = {};
+  const emitted = [];
+  return { emitted, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: (e, p) => emitted.push({ e, p }) };
+};
+
+describe("crash sync on entry", () => {
+  let io;
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    io = makeIo();
+    crashGame(io);
+    await jest.advanceTimersByTimeAsync(0); // betting opens
+  });
+  afterEach(() => { jest.clearAllTimers(); jest.useRealTimers(); jest.restoreAllMocks(); });
+
+  test("a connecting socket is told the current phase, without the crash point", async () => {
+    const socket = makeSocket();
+    io.connection(socket);
+
+    const sync = socket.emitted.find((m) => m.e === "crash:sync");
+    expect(sync).toBeTruthy();
+    expect(sync.p.phase).toBe("betting");
+    expect(sync.p).not.toHaveProperty("crashPoint");
+  });
+
+  test("phase is running once the round starts, and a request re-sends it", async () => {
+    const socket = makeSocket();
+    io.connection(socket);
+    await jest.advanceTimersByTimeAsync(12000); // betting closes, the round runs
+
+    socket.emitted.length = 0;
+    socket.handlers["crash:requestState"](); // a joiner asks for the state
+
+    const sync = socket.emitted.find((m) => m.e === "crash:sync");
+    expect(sync.p.phase).toBe("running");
+    expect(sync.p.gameStartTime).toBeTruthy();
+    expect(sync.p).not.toHaveProperty("crashPoint");
+  });
+});

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -42,6 +42,17 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
   let ticker = null;
 
   io.on("connection", (socket) => {
+    // sync a joiner to the round in progress: without this a missed crash:start leaves
+    // them stuck at 1x with the idle animation until the next round. the crash point is
+    // never sent, only the phase and start time, so nothing about the outcome leaks.
+    const sendState = () =>
+      socket.emit("crash:sync", {
+        phase: bettingOpen ? "betting" : gameState.gameStartTime ? "running" : "idle",
+        ...publicState(gameState),
+      });
+    sendState();
+    socket.on("crash:requestState", sendState);
+
     socket.on("crash:bet", async (bet, callback) => {
       // the client used to get no answer at all when a bet was refused
       const reply = (result) => {

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -4,6 +4,7 @@ const { isAuthenticated } = require("../middleware/authMiddleware");
 
 const User = require("../models/User");
 const Case = require("../models/Case");
+const Round = require("../models/Round");
 const upgradeItems = require("../games/upgrade");
 const SlotGameController = require("../games/slot");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
@@ -193,6 +194,29 @@ module.exports = (io) => {
     }
   });
 
+  // recent coin flip results, so the page has a history the moment it loads. light and
+  // indexed (game + createdAt), capped, public: just the outcome, no bets or seeds.
+  router.get("/coinflip/history", async (req, res) => {
+    try {
+      const limit = Math.min(Math.max(1, Math.floor(Number(req.query.limit)) || 15), 50);
+      const rounds = await Round.find(
+        { game: "coinflip", status: "settled" },
+        { outcome: 1, createdAt: 1 }
+      )
+        .sort({ createdAt: -1 })
+        .limit(limit)
+        .lean();
+      res.json(
+        rounds.map((r) => ({
+          result: r.outcome && r.outcome.result,
+          winningSide: r.outcome && r.outcome.winningSide,
+          at: r.createdAt,
+        }))
+      );
+    } catch (error) {
+      res.status(500).json({ message: "Server error" });
+    }
+  });
 
   return router;
 };

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -5,6 +5,7 @@ import Coin from "./Coin"
 import { motion } from "framer-motion";
 import UserContext from "../../UserContext";
 import LiveBets from "./LiveBets";
+import { getCoinFlipHistory } from "../../services/games/GamesServices";
 
 const socket = SocketConnection.getInstance();
 
@@ -41,6 +42,18 @@ const CoinFlip = () => {
     }
   });
   const { isLogged, userData, toogleUserFlow } = useContext(UserContext);
+
+  // seed the history from past rounds so the page is not blank on entry. the endpoint
+  // returns newest first, so it is reversed into the oldest-first order the row appends to.
+  useEffect(() => {
+    getCoinFlipHistory()
+      .then((rounds: Array<{ result: number }>) => {
+        setHistory(rounds.map((r) => ({ result: r.result })).reverse());
+      })
+      .catch(() => {
+        // best-effort: a missing history must never break the page
+      });
+  }, []);
 
   const handleBet = () => {
     if (!isLogged) {

--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -91,6 +91,36 @@ const CrashGame = () => {
     };
   }, []);
 
+  // sync to a round already in progress on entry, so joining mid-round does not sit at
+  // 1x with the idle animation until the next game. asks the server, and also catches the
+  // server's own emit on (re)connect.
+  useEffect(() => {
+    const syncListener = (sync: any) => {
+      setGameState({
+        gameBets: sync.gameBets || {},
+        gamePlayers: sync.gamePlayers || {},
+        crashPoint: 1.0,
+        gameStartTime: sync.gameStartTime || null,
+      });
+      if (sync.phase === "running") {
+        setGameStarted(true);
+        setGameEnded(false);
+        setAnimationSrc(up);
+      } else if (sync.phase === "betting") {
+        setGameStarted(false);
+        setGameEnded(false);
+        setAnimationSrc(idle);
+      }
+    };
+
+    socket.on("crash:sync", syncListener);
+    socket.emit("crash:requestState");
+
+    return () => {
+      socket.off("crash:sync", syncListener);
+    };
+  }, []);
+
   useEffect(() => {
     const startListener = () => {
       setAnimationSrc(up);

--- a/src/pages/Slot/Game.tsx
+++ b/src/pages/Slot/Game.tsx
@@ -26,7 +26,9 @@ const Game: React.FC<SlotMachineProps> = ({ grid, isSpinning, data, winningLines
 
     const renderBottomBar = (index: number) => {
         return (
-            <img src={bottomBar} alt="bottom bar" className={`w-screen md:w-[416px] z-10 ${index == 0 ? "scale-y-[-1]" : ""} `}
+            // aspect-ratio reserves the bar's height before it loads, so the machine below
+            // it does not jump down when the image arrives
+            <img src={bottomBar} alt="bottom bar" className={`w-screen md:w-[416px] aspect-[539/7] z-10 ${index == 0 ? "scale-y-[-1]" : ""} `}
                 onLoad={() => setLoadedImages(loadedImages + 1)}
             />
         )

--- a/src/pages/Slot/SlotColumn.tsx
+++ b/src/pages/Slot/SlotColumn.tsx
@@ -8,25 +8,22 @@ interface SlotColumnProps {
     winningLines?: any[];
 }
 
+const options = ['red', 'blue', 'green', 'yin_yang', 'hakkero', 'yellow', 'wild'];
+const makeFillers = () =>
+    Array.from({ length: 47 }, () => options[Math.floor(Math.random() * options.length)]);
+
 const SlotColumn: React.FC<SlotColumnProps> = ({ symbols, isSpinning, position, winningLines }) => {
     const rollsize = 5260;
-    const [rouletteItems, setRouletteItems] = useState<any[]>([]);
     const [translateValue, setTranslateValue] = useState<string>(`-${rollsize}px`);
     const [loading, setLoading] = useState<boolean>(true);
+    // the scrolling fillers are refreshed only when a spin starts, never when `symbols`
+    // changes; otherwise the result arriving mid-spin re-randomised the whole reel
+    const [fillers, setFillers] = useState<string[]>(makeFillers);
 
     const rouletteRef = useRef<HTMLDivElement | null>(null);
-    const options = ['red', 'blue', 'green', 'yin_yang', 'hakkero', 'yellow', 'wild'];
 
-    const createRouletteItems = () => {
-        const newItems = symbols.slice();
-        for (let i = 0; i < 46; i++) {
-            newItems.unshift(options[Math.floor(Math.random() * options.length)]);
-        }
-        newItems[47] = symbols[0];
-        newItems[48] = symbols[1];
-        newItems[49] = symbols[2];
-        setRouletteItems(newItems);
-    };
+    // the final three symbols land at the stop position; fillers scroll past above them
+    const rouletteItems = [...fillers, symbols[0], symbols[1], symbols[2]];
 
     const handleImageLoad = () => {
         setLoading(false);
@@ -34,8 +31,8 @@ const SlotColumn: React.FC<SlotColumnProps> = ({ symbols, isSpinning, position, 
 
 
     useEffect(() => {
-        createRouletteItems();
-    }, [symbols]);
+        if (isSpinning) setFillers(makeFillers());
+    }, [isSpinning]);
 
 
     useEffect(() => {

--- a/src/services/games/GamesServices.ts
+++ b/src/services/games/GamesServices.ts
@@ -12,6 +12,11 @@ export async function upgradeItem(selectedItemIds: string[], targetItemId: strin
     return response.data;
 }
 
+export async function getCoinFlipHistory(limit = 15) {
+    const response = await api.get(`/games/coinflip/history`, { params: { limit } });
+    return response.data;
+}
+
 export async function spinSlots(betAmount: number) {
     const response = await api.post(`/games/slots/`, {
         betAmount


### PR DESCRIPTION
> Stacked on #142 (the round-test flake fix) so its CI is stable. Merge #142 first and this diff reduces to just the three fixes below. Does not touch coinFlip.js, so it is independent of #143.

Three game issues reported together, one commit each.

## Crash: sync a joiner to the round in progress

Entering crash mid-round left the player stuck at 1x with the idle animation until the next game - they had missed `crash:start` and the server sent nothing on connect. The server now emits the current phase on connection and answers a `crash:requestState` the page sends on entry, so a joiner switches into the running animation and the multiplier ticks drive the value. The crash point is never in the sync, so nothing about the outcome leaks.

## Slot: stop the reel changing mid-spin, and the layout shifting

The reel rebuilt all its random fillers whenever the grid changed - and the grid changes when the spin result arrives - so the images scrolling by visibly re-randomised mid-spin. Fillers are now refreshed only when a spin starts and stay fixed through it, so the result only lands the final three symbols. The bottom bar had no reserved height, so the machine jumped when it loaded; an aspect-ratio box reserves its space.

## Coin flip: show past results on entry

The page was blank of history on entry. A light, public, indexed endpoint (`GET /games/coinflip/history`) returns recent settled results, and the page seeds its history row on mount. Capped and projected to just the outcome, so it stays cheap on the free tier.

## Tests

`crashSync.test.js` (the sync sends the phase, never the crash point), `coinflipHistory.test.js` (newest-first, settled only, limit honoured, empty is not an error). 262 backend tests pass, run twice. Frontend builds, lint clean.