### PR TITLE
Upgrade: make rare targets hard to reach again

### DIFF
--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -89,6 +89,29 @@ const makeSocket = (userId) => {
   return { userId, handlers, on: (e, fn) => { handlers[e] = fn; }, emit: () => {} };
 };
 
+// place a bet during a betting window, retrying across windows if one closes first under
+// load. returns the round the bet actually landed on, so assertions target the right one.
+async function betOnRound(game, event, socket, args) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    await until(roundIn(game, "betting"), `${game} betting to open`);
+    let reply;
+    await socket.handlers[event](...args, (r) => { reply = r; });
+    if (reply && reply.ok) {
+      return until(
+        () => Round.findOne({ game, "bets.userId": socket.userId }),
+        `${game} round holding the bet`
+      );
+    }
+    await wait(10);
+  }
+  throw new Error(`could not place a ${game} bet`);
+}
+
+const settledById = (id) => async () => {
+  const r = await Round.findById(id);
+  return r && r.status === "settled" ? r : null;
+};
+
 test("crash writes a round, ties the stake to it, and settles it at the bust", async () => {
   // a seed whose crash point is 1.0, so the round busts instantly and settles at once
   mockCrashSeed = INSTANT_SEED;
@@ -96,30 +119,19 @@ test("crash writes a round, ties the stake to it, and settles it at the bust", a
   const io = makeIo();
 
   start(crashGame, io, FAST_CRASH);
-  const opened = await until(roundIn("crash", "betting"), "crash betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  let reply;
-  await socket.handlers["crash:bet"](100, (r) => { reply = r; });
-  expect(reply).toEqual({ ok: true });
+  const opened = await betOnRound("crash", "crash:bet", socket, [100]);
 
   // the stake is on the round, and the ledger row points back at it
-  const withBet = await Round.findById(opened._id);
-  expect(withBet.bets).toHaveLength(1);
-  expect(withBet.bets[0].amount).toBe(100);
-  expect(String(withBet.bets[0].userId)).toBe(String(user._id));
+  expect(opened.bets).toHaveLength(1);
+  expect(opened.bets[0].amount).toBe(100);
+  expect(String(opened.bets[0].userId)).toBe(String(user._id));
 
   const betTx = await Transaction.findOne({ userId: user._id, type: TX.CRASH_BET });
   expect(betTx.meta.roundId).toBe(String(opened._id));
 
-  const done = await until(
-    async () => {
-      const r = await Round.findById(opened._id);
-      return r.status === "settled" ? r : null;
-    },
-    "the crash round to bust and settle"
-  );
+  const done = await until(settledById(opened._id), "the crash round to bust and settle");
   expect(done.outcome.crashPoint).toBe(1);
   expect(done.bets[0].payout).toBe(0); // an instant bust pays nobody
 });
@@ -131,13 +143,14 @@ test("a crash cashout is recorded on the round", async () => {
   const io = makeIo();
 
   start(crashGame, io, { bettingMs: 60, tickMs: 5, retryMs: 20 });
-  const opened = await until(roundIn("crash", "betting"), "crash betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  await socket.handlers["crash:bet"](100, () => {});
+  const opened = await betOnRound("crash", "crash:bet", socket, [100]);
 
-  await until(roundIn("crash", "running"), "the crash round to start");
+  await until(async () => {
+    const r = await Round.findById(opened._id);
+    return r && r.status === "running" ? r : null;
+  }, "the crash round to start");
   await socket.handlers["crash:cashout"](() => {});
 
   const cashed = await Round.findById(opened._id);
@@ -154,25 +167,14 @@ test("coin flip writes a round, records the side, and settles after the toss", a
   const io = makeIo();
 
   start(coinFlip, io, FAST_FLIP);
-  const opened = await until(roundIn("coinflip", "betting"), "coin flip betting to open");
-
   const socket = makeSocket(String(user._id));
   io.connection(socket);
-  let reply;
-  await socket.handlers["coinFlip:bet"](100, 0, (r) => { reply = r; });
-  expect(reply).toEqual({ ok: true });
+  const opened = await betOnRound("coinflip", "coinFlip:bet", socket, [100, 0]);
 
-  const withBet = await Round.findById(opened._id);
-  expect(withBet.bets[0].side).toBe("heads");
-  expect(withBet.bets[0].amount).toBe(100);
+  expect(opened.bets[0].side).toBe("heads");
+  expect(opened.bets[0].amount).toBe(100);
 
-  const settled = await until(
-    async () => {
-      const r = await Round.findById(opened._id);
-      return r.status === "settled" ? r : null;
-    },
-    "the coin flip to land and pay out"
-  );
+  const settled = await until(settledById(opened._id), "the coin flip to land and pay out");
   expect(settled.outcome.winningSide).toBe("heads");
   expect(settled.bets[0].payout).toBe(194);
   expect((await User.findById(user._id)).walletBalance).toBe(5000 - 100 + 194);

--- a/backend/__tests__/unit/upgrade.test.js
+++ b/backend/__tests__/unit/upgrade.test.js
@@ -1,67 +1,56 @@
-const { calculateSuccessRate, MAX_UPGRADE_CHANCE } = require("../../games/upgrade");
-const { RARITY_MULTIPLIER, UPGRADE_RTP } = require("../../utils/itemValue");
+const { calculateSuccessRate, UPGRADE_RTP_BY_RARITY, UPGRADE_CEILING } = require("../../games/upgrade");
+const { RARITY_MULTIPLIER } = require("../../utils/itemValue");
 
-// within a case an item's value is A * RARITY_MULTIPLIER[rarity], so a rarity is worth
-// its multiplier. A cancels out of every edge below, so it can be 1.
+// within a case an item's value is A * RARITY_MULTIPLIER[rarity], so a rarity is worth its
+// multiplier. A cancels out of every edge below, so it can be 1.
 const value = (rarity) => RARITY_MULTIPLIER[String(rarity)];
 const staked = (...rarities) => rarities.reduce((s, r) => s + value(r), 0);
 
-// what the player gets back per unit staked
-const edgeOf = (rarities, target) => {
-  const inValue = staked(...rarities);
-  const outValue = value(target);
-  return 1 - (calculateSuccessRate(inValue, outValue) * outValue) / inValue;
-};
+const rateOf = (rarities, target) => calculateSuccessRate(staked(...rarities), value(target), target);
+const edgeOf = (rarities, target) => 1 - (rateOf(rarities, target) * value(target)) / staked(...rarities);
 
 const RARITIES = [1, 2, 3, 4, 5];
+const atCeiling = (rarities, target) => rateOf(rarities, target) >= UPGRADE_CEILING[String(target)] - 1e-12;
 
 describe("upgrade success rate", () => {
-  test("the edge is exactly 1 - UPGRADE_RTP for every rarity pair", () => {
-    for (const from of RARITIES) {
-      for (const to of RARITIES) {
-        // skip the ones a big stake pushes into the cap; covered separately below
-        if (calculateSuccessRate(value(from), value(to)) >= MAX_UPGRADE_CHANCE) continue;
-        expect(edgeOf([from], to)).toBeCloseTo(1 - UPGRADE_RTP, 10);
-      }
+  test("below its ceiling, the edge is exactly 1 - RTP for the target rarity", () => {
+    for (const target of RARITIES) {
+      // one rarity-1 item is a small enough stake to stay under every ceiling
+      if (atCeiling([1], target)) continue;
+      expect(edgeOf([1], target)).toBeCloseTo(1 - UPGRADE_RTP_BY_RARITY[String(target)], 10);
     }
   });
 
+  test("both the edge and the ceiling get worse as the target rarity climbs", () => {
+    for (let r = 2; r <= 5; r++) {
+      expect(UPGRADE_RTP_BY_RARITY[String(r)]).toBeLessThanOrEqual(UPGRADE_RTP_BY_RARITY[String(r - 1)]);
+      expect(UPGRADE_CEILING[String(r)]).toBeLessThan(UPGRADE_CEILING[String(r - 1)]);
+    }
+    // the top tier is a genuine long shot, not a near-certainty
+    expect(UPGRADE_CEILING["5"]).toBeLessThanOrEqual(0.15);
+  });
+
+  test("stacking cheap items cannot beat the ceiling of a rare target", () => {
+    // a hundred rarity-1 items poured into a rarity-5: the old flat cap gave ~0.95
+    const rate = calculateSuccessRate(staked(...Array(100).fill(1)), value(5), 5);
+    expect(rate).toBe(UPGRADE_CEILING["5"]);
+    expect(rate).toBeLessThanOrEqual(0.12);
+  });
+
   test("no combination of rarities is ever player-positive", () => {
-    // the old table paid the player +40% on 1x rarity-1 -> rarity-4, and stayed
-    // player-positive on that trade for stacks of up to six
     for (const target of RARITIES) {
       for (const from of RARITIES) {
-        for (let n = 1; n <= 30; n++) {
-          const edge = edgeOf(Array(n).fill(from), target);
-          expect(edge).toBeGreaterThanOrEqual(-1e-12);
+        for (let n = 1; n <= 40; n++) {
+          expect(edgeOf(Array(n).fill(from), target)).toBeGreaterThanOrEqual(-1e-12);
         }
       }
     }
   });
 
-  test("mixing colors does not move the edge", () => {
-    const mixes = [
-      [1, 4], [4, 1], [1, 1, 5], [3, 3, 1], [2, 3, 4], [1, 2, 3, 4, 5], [5, 1, 1, 1],
-    ];
-    for (const mix of mixes) {
-      for (const target of RARITIES) {
-        if (calculateSuccessRate(staked(...mix), value(target)) >= MAX_UPGRADE_CHANCE) continue;
-        expect(edgeOf(mix, target)).toBeCloseTo(1 - UPGRADE_RTP, 10);
-      }
-    }
-  });
-
-  test("an extra item buys exactly the chance it pays for", () => {
-    // adding a 1 KP rarity-1 to a 24 KP pair of rarity-3s used to buy 8.6% more chance
-    // for 4% more value. the chance must now move in step with the stake.
-    const before = calculateSuccessRate(staked(3, 3), value(4));
-    const after = calculateSuccessRate(staked(3, 3, 1), value(4));
-    expect(after / before).toBeCloseTo(staked(3, 3, 1) / staked(3, 3), 10);
-  });
-
-  test("order of items does not change the result", () => {
-    expect(calculateSuccessRate(staked(1, 3, 2), value(4)))
-      .toBe(calculateSuccessRate(staked(3, 2, 1), value(4)));
+  test("mixing colors does not move the rate for a given target and stake", () => {
+    // same total value, different mixes, both under the ceiling -> identical rate
+    const target = 4; // ceiling reached only well above these stakes
+    expect(rateOf([3, 1], target)).toBeCloseTo(rateOf([2, 2, 2, 1], target), 10);
   });
 
   test("adding an item never lowers the rate", () => {
@@ -69,30 +58,23 @@ describe("upgrade success rate", () => {
       let prev = 0;
       const pool = [1, 2, 3, 1, 2, 1];
       for (let n = 1; n <= pool.length; n++) {
-        const rate = calculateSuccessRate(staked(...pool.slice(0, n)), value(target));
+        const rate = calculateSuccessRate(staked(...pool.slice(0, n)), value(target), target);
         expect(rate + 1e-12).toBeGreaterThanOrEqual(prev);
         prev = rate;
       }
     }
   });
 
-  test("an oversized stake is capped rather than promised", () => {
-    // 100x rarity-5 against a rarity-1 target would ask for a chance of 9000
-    const rate = calculateSuccessRate(staked(...Array(100).fill(5)), value(1));
-    expect(rate).toBe(MAX_UPGRADE_CHANCE);
+  test("an oversized stake is capped at the target's ceiling, not promised", () => {
+    const rate = calculateSuccessRate(staked(...Array(100).fill(5)), value(1), 1);
+    expect(rate).toBe(UPGRADE_CEILING["1"]);
     expect(rate).toBeLessThan(1);
   });
 
-  test("a capped trade is still house-positive", () => {
-    // overpaying is the player's own bad trade; it must never turn into a player edge
-    expect(edgeOf(Array(100).fill(5), 1)).toBeGreaterThan(0);
-    expect(edgeOf([4, 4], 4)).toBeGreaterThan(0);
-  });
-
   test("worthless or missing values never produce a chance", () => {
-    expect(calculateSuccessRate(0, 100)).toBe(0);
-    expect(calculateSuccessRate(100, 0)).toBe(0);
-    expect(calculateSuccessRate(undefined, 100)).toBe(0);
-    expect(calculateSuccessRate(-5, 100)).toBe(0);
+    expect(calculateSuccessRate(0, 100, 5)).toBe(0);
+    expect(calculateSuccessRate(100, 0, 5)).toBe(0);
+    expect(calculateSuccessRate(undefined, 100, 5)).toBe(0);
+    expect(calculateSuccessRate(-5, 100, 5)).toBe(0);
   });
 });

--- a/backend/games/upgrade.js
+++ b/backend/games/upgrade.js
@@ -3,26 +3,24 @@ const Item = require("../models/Item");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
-const { UPGRADE_RTP } = require("../utils/itemValue");
 
-const UPGRADE_ALGO_VERSION = 2; // bump if calculateSuccessRate ever changes
+const UPGRADE_ALGO_VERSION = 3; // bump if calculateSuccessRate ever changes
 
-// nothing is ever a certainty: staking more than the target is worth still leaves a
-// sliver of risk, and this is what stops an oversized stake asking for a chance above 1
-const MAX_UPGRADE_CHANCE = 0.95;
+// return by target rarity: the edge grows with rarity, so upgrading into a rare item is a
+// worse deal per attempt than upgrading into a common one
+const UPGRADE_RTP_BY_RARITY = { "1": 0.9, "2": 0.9, "3": 0.85, "4": 0.75, "5": 0.6 };
 
-// the chance is the stake measured against the prize: p = RTP * staked / target. the
-// player's return is p * target / staked, so it is UPGRADE_RTP for every trade, and the
-// edge is a flat 1 - UPGRADE_RTP whatever mix of rarities goes in.
-//
-// it used to be read off a rarity-to-rarity table that had nothing to do with the
-// rarity multipliers item values are built from. the two were never reconciled, so the
-// edge swung from -40% (the player profiting, on 1x rarity-1 -> rarity-4) to +90%
-// depending purely on which colors were fed in, and adding a 1 KP item to a 24 KP stake
-// bought more chance than it paid for.
-const calculateSuccessRate = (stakedValue, targetValue) => {
+// max success chance by target rarity: piling in cheap items cannot make a rare upgrade a
+// sure thing, so stacking a heap of low items into an ultra is still a gamble. no case odds.
+const UPGRADE_CEILING = { "1": 0.9, "2": 0.7, "3": 0.45, "4": 0.25, "5": 0.12 };
+
+// the stake measured against the prize, p = RTP * staked / target, capped by the target's
+// rarity ceiling; below the ceiling the edge is 1 - RTP(rarity), so mixing colors never moves it.
+const calculateSuccessRate = (stakedValue, targetValue, targetRarity) => {
   if (!(stakedValue > 0) || !(targetValue > 0)) return 0;
-  return Math.min((UPGRADE_RTP * stakedValue) / targetValue, MAX_UPGRADE_CHANCE);
+  const rtp = UPGRADE_RTP_BY_RARITY[String(targetRarity)] || 0.9;
+  const ceiling = UPGRADE_CEILING[String(targetRarity)] || 0.9;
+  return Math.min((rtp * stakedValue) / targetValue, ceiling);
 };
 
 // Helper function to validate if all items belong to the same case
@@ -115,7 +113,7 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
     }
 
     // success is the provably-fair roll: succeed when the [0,1) draw is below the rate
-    const successRate = calculateSuccessRate(stakedValue, targetValue);
+    const successRate = calculateSuccessRate(stakedValue, targetValue, targetItem.rarity);
     const rollFloatValue = rollFloat(reserved.serverSeed, reserved.clientSeed, nonce);
     const isSuccess = rollFloatValue < successRate;
 
@@ -179,4 +177,5 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
 module.exports = upgradeItems;
 // exposed for unit testing
 module.exports.calculateSuccessRate = calculateSuccessRate;
-module.exports.MAX_UPGRADE_CHANCE = MAX_UPGRADE_CHANCE;
+module.exports.UPGRADE_RTP_BY_RARITY = UPGRADE_RTP_BY_RARITY;
+module.exports.UPGRADE_CEILING = UPGRADE_CEILING;

--- a/backend/utils/itemValue.js
+++ b/backend/utils/itemValue.js
@@ -3,7 +3,6 @@ const { Rarities } = require("./caseOpening");
 // tunable economy knobs
 const RARITY_MULTIPLIER = { "1": 1, "2": 4, "3": 12, "4": 40, "5": 100 };
 const RTP = 0.9; // expected item value per open = case price * RTP (10% open edge)
-const UPGRADE_RTP = 0.9; // expected item value out per value staked (10% upgrade edge)
 const SELL_RATE = 0.75; // instant sell-to-house = base value * SELL_RATE
 const MARKET_FEE_RATE = 0.05; // house cut on a marketplace sale, paid by the seller
 
@@ -87,7 +86,6 @@ async function recomputeCaseValues(caseId) {
 module.exports = {
   RARITY_MULTIPLIER,
   RTP,
-  UPGRADE_RTP,
   SELL_RATE,
   MARKET_FEE_RATE,
   baseValuesForCase,

--- a/src/pages/Upgrade/Items.tsx
+++ b/src/pages/Upgrade/Items.tsx
@@ -21,10 +21,9 @@ const Items: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedT
 
 
     // mirrors backend/games/upgrade.js exactly, so the rate on screen is the rate the
-    // server rolls. the chance is the stake measured against the prize, which holds the
-    // edge at 1 - UPGRADE_RTP however the rarities are mixed.
-    const UPGRADE_RTP = 0.9;
-    const MAX_UPGRADE_CHANCE = 0.95;
+    // server rolls: p = RTP(targetRarity) * staked / target, capped by the rarity ceiling.
+    const UPGRADE_RTP_BY_RARITY: { [k: string]: number } = { "1": 0.9, "2": 0.9, "3": 0.85, "4": 0.75, "5": 0.6 };
+    const UPGRADE_CEILING: { [k: string]: number } = { "1": 0.9, "2": 0.7, "3": 0.45, "4": 0.25, "5": 0.12 };
 
     const calculateSuccessRate = (items: any, target: any) => {
         const stakedValue = items.reduce(
@@ -33,7 +32,9 @@ const Items: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedT
         );
         const targetValue = target?.baseValue || 0;
         if (stakedValue <= 0 || targetValue <= 0) return 0;
-        return Math.min((UPGRADE_RTP * stakedValue) / targetValue, MAX_UPGRADE_CHANCE);
+        const rtp = UPGRADE_RTP_BY_RARITY[String(target?.rarity)] || 0.9;
+        const ceiling = UPGRADE_CEILING[String(target?.rarity)] || 0.9;
+        return Math.min((rtp * stakedValue) / targetValue, ceiling);
     };
 
     useEffect(() => {


### PR DESCRIPTION
> Stacked on #142 for stable CI. Independent of the other open PRs (only touches upgrade.js, itemValue.js, Items.tsx).

## The problem

The flat-edge upgrade (from an earlier change) made rares too easy: success was `min(0.9 * staked/target, 0.95)`, so a heap of cheap items reliably reached ~95% on **any** target, ultra-rares included. Players could farm the bonus, open blues, and stack them into reds - and the scarcity that keeps the game interesting was gone.

## The change

Both the ceiling and the edge now scale with the **target rarity**:

| target | edge | max chance | ~tries to land |
|---|---|---|---|
| rarity 2 | 10% | 70% | ~1.4 |
| rarity 3 | 15% | 45% | ~2 |
| rarity 4 (red) | 25% | 25% | ~4 |
| rarity 5 (ultra) | 40% | 12% | ~8 |

The ceiling means no amount of stacking makes a rare a sure thing (stacking blues into an ultra now caps at **12%**, ~8 attempts on average, where it used to be one at 95%). The steeper edge on rares means each attempt is a worse deal too.

**Case odds are untouched** - only the upgrade success formula changes. The value math and the no-player-positive / mixing-does-not-help properties still hold below the ceiling. The frontend mirrors the new tables so the wheel shows the real rate, and `UPGRADE_ALGO_VERSION` is bumped so past rolls stay checkable.

## Tests

`upgrade.test.js` rewritten: the edge is `1 - RTP(targetRarity)` below the ceiling; edge and ceiling both worsen as rarity climbs; **stacking cheap items cannot beat a rare target's ceiling**; no combination is ever player-positive; mixing colors does not move the rate; oversized stakes cap at the ceiling.

256 backend tests pass. Frontend builds.