### PR TITLE
Missions: stop a failed payout burning the reward

### DIFF
--- a/backend/__tests__/integration/ledgerAtomicity.test.js
+++ b/backend/__tests__/integration/ledgerAtomicity.test.js
@@ -1,15 +1,19 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+process.env.MISSIONS_LAUNCH_AT = "2000-01-01T00:00:00.000Z";
 
 // this suite needs real transactions, so it runs its own replica set rather than the
 // shared standalone harness. it proves the guarantee prod relies on: money and its
-// history commit together or not at all.
+// history commit together or not at all. every transaction-dependent test lives here so
+// only one replica set spins up (a second one starves the timing-sensitive round tests).
 const { MongoMemoryReplSet } = require("mongodb-memory-server");
 const mongoose = require("mongoose");
 const { uniqueSuffix } = require("./helpers");
 const User = require("../../models/User");
 const Transaction = require("../../models/Transaction");
 const Marketplace = require("../../models/Marketplace");
+const MissionState = require("../../models/MissionState");
 const { purchaseListing } = require("../../utils/market");
+const { claimMission } = require("../../utils/missions");
 const {
   chargeUser, creditUser, probeTransactions, setTransactionsSupported, transactionsSupported, TX,
 } = require("../../utils/economy");
@@ -24,7 +28,9 @@ beforeAll(async () => {
 
 afterEach(async () => {
   jest.restoreAllMocks();
-  await Promise.all([User.deleteMany({}), Transaction.deleteMany({}), Marketplace.deleteMany({})]);
+  await Promise.all([
+    User.deleteMany({}), Transaction.deleteMany({}), Marketplace.deleteMany({}), MissionState.deleteMany({}),
+  ]);
 });
 
 const listItem = (sellerId, price) => {
@@ -147,4 +153,54 @@ test("two concurrent buyers cannot both win the same listing", async () => {
   expect(balances).toEqual([900, 1000]); // the winner paid, the loser kept everything
   expect(await Marketplace.countDocuments({})).toBe(0); // the listing is consumed
   expect((await User.findById(seller._id)).walletBalance).toBe(95); // seller paid once
+});
+
+// a user who has opened a case (so "first-case" is complete) with an empty mission state
+const REWARD = 250; // the "first-case" mission reward
+async function claimableUser(walletBalance = 1000) {
+  const u = await makeUser(walletBalance);
+  await Transaction.create({ userId: u._id, type: TX.CASE_OPEN, direction: "debit", amount: 100, meta: { quantity: 1 } });
+  await MissionState.create({ userId: u._id });
+  return u;
+}
+const claimedKeys = async (userId) => (await MissionState.findOne({ userId })).claimed;
+
+test("a failed mission credit does not burn the reward: it stays claimable", async () => {
+  const u = await claimableUser(1000);
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+
+  const res = await claimMission(u._id, "first-case", null);
+
+  expect(res.code).toBe(500);
+  expect(await claimedKeys(u._id)).not.toContain("first-case"); // the mark rolled back
+  expect((await User.findById(u._id)).walletBalance).toBe(1000); // nothing paid
+  expect(await Transaction.countDocuments({ userId: u._id, type: TX.MISSION_REWARD })).toBe(0);
+});
+
+test("retrying after a failed mission credit pays the reward exactly once", async () => {
+  const u = await claimableUser(1000);
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+  await claimMission(u._id, "first-case", null); // fails, rolls back
+  jest.restoreAllMocks();
+
+  const res = await claimMission(u._id, "first-case", null); // retry
+  expect(res.body.claimed).toBe(true);
+  expect((await User.findById(u._id)).walletBalance).toBe(1000 + REWARD);
+
+  const again = await claimMission(u._id, "first-case", null);
+  expect(again.body.alreadyClaimed).toBe(true);
+  expect((await User.findById(u._id)).walletBalance).toBe(1000 + REWARD);
+});
+
+test("concurrent mission claims pay the reward exactly once", async () => {
+  const u = await claimableUser(1000);
+
+  const results = await Promise.all([
+    claimMission(u._id, "first-case", null),
+    claimMission(u._id, "first-case", null),
+  ]);
+
+  expect(results.filter((r) => r.body.claimed).length).toBe(1);
+  expect((await User.findById(u._id)).walletBalance).toBe(1000 + REWARD);
+  expect(await Transaction.countDocuments({ userId: u._id, type: TX.MISSION_REWARD })).toBe(1);
 });

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -4,7 +4,7 @@ const Battle = require("../models/Battle");
 const User = require("../models/User");
 const Case = require("../models/Case");
 const MissionState = require("../models/MissionState");
-const { creditUser, TX } = require("./economy");
+const { creditUser, runAtomic, TX } = require("./economy");
 const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 
 // a "big win" is any single game payout (slots / crash cashout / coin flip win)
@@ -205,10 +205,8 @@ async function markVisited(userId, key) {
   return { ok: true };
 }
 
-// claim a completed mission's reward exactly once. the one-time guard lives in the
-// update FILTER (claimed !contains key), so two concurrent claims can never both
-// credit: the second finds the key already present and modifies nothing. the wallet
-// is credited only after the claim is marked, so a failure never double-pays.
+// claim a completed mission's reward exactly once. the mark is the mutex and it commits in
+// one transaction with the credit, so a failed payout rolls it back instead of burning it.
 async function claimMission(userId, key, io) {
   const mission = byKey(key);
   if (!mission || mission.active === false) return { code: 404, body: { message: "Mission not found" } };
@@ -219,20 +217,34 @@ async function claimMission(userId, key, io) {
   if (v.claimed) return { code: 200, body: { claimed: false, alreadyClaimed: true } };
 
   await MissionState.updateOne({ userId }, { $setOnInsert: { userId } }, { upsert: true });
-  const res = await MissionState.updateOne(
-    { userId, claimed: { $ne: key } },
-    { $addToSet: { claimed: key } }
-  );
-  if (res.modifiedCount !== 1) {
+
+  let updated;
+  try {
+    updated = await runAtomic(async (session) => {
+      const res = await MissionState.updateOne(
+        { userId, claimed: { $ne: key } },
+        { $addToSet: { claimed: key } },
+        { session }
+      );
+      if (res.modifiedCount !== 1) return null; // a concurrent request claimed it first
+      const credited = await creditUser(userId, mission.reward, 0, {
+        type: TX.MISSION_REWARD,
+        meta: { missionKey: key, missionTitle: mission.title },
+        session,
+      });
+      if (!credited) throw new Error("mission credit failed"); // abort so the mark rolls back
+      return credited;
+    });
+  } catch (e) {
+    console.error("claimMission failed:", e);
+    return { code: 500, body: { message: "Could not claim the reward, please try again" } };
+  }
+
+  if (updated === null) {
     return { code: 200, body: { claimed: false, alreadyClaimed: true } };
   }
 
-  const updated = await creditUser(userId, mission.reward, 0, {
-    type: TX.MISSION_REWARD,
-    meta: { missionKey: key, missionTitle: mission.title },
-  });
-
-  if (io && updated) {
+  if (io) {
     io.to(userId.toString()).emit("userDataUpdated", {
       walletBalance: updated.walletBalance,
       xp: updated.xp,
@@ -245,7 +257,7 @@ async function claimMission(userId, key, io) {
     body: {
       claimed: true,
       reward: mission.reward,
-      walletBalance: updated ? updated.walletBalance : undefined,
+      walletBalance: updated.walletBalance,
       missionKey: key,
     },
   };


### PR DESCRIPTION
## The problem

`claimMission` marked the reward claimed and only then credited it. A credit that failed - or a crash between the two - left the mission claimed forever with nothing paid. The reward was gone and unrecoverable (the claim mark blocks any retry).

## The change

The mark and the credit now commit in **one transaction**. The mark is still the mutex, so two concurrent claims can never both pay, but a failed credit rolls the mark back and the claim can be retried. On a standalone dev mongo without transactions it stays best-effort like the rest of the money paths; production is Atlas and is atomic.

## Tests

Added to `ledgerAtomicity.test.js` (the existing replica-set suite, so no second replica set spins up and starves the round tests):

- a failed mission credit does not burn the reward - the mission stays claimable, nothing is paid
- retrying after a failed credit pays the reward exactly once
- concurrent claims pay the reward exactly once

271 backend tests pass, run three times with no flakes.