### PR TITLE
Slots: stop the reel repainting mid-spin

### DIFF
--- a/src/pages/Slot/SlotColumn.tsx
+++ b/src/pages/Slot/SlotColumn.tsx
@@ -16,9 +16,9 @@ const SlotColumn: React.FC<SlotColumnProps> = ({ symbols, isSpinning, position, 
     const rollsize = 5260;
     const [translateValue, setTranslateValue] = useState<string>(`-${rollsize}px`);
     const [loading, setLoading] = useState<boolean>(true);
-    // the scrolling fillers are refreshed only when a spin starts, never when `symbols`
-    // changes; otherwise the result arriving mid-spin re-randomised the whole reel
-    const [fillers, setFillers] = useState<string[]>(makeFillers);
+    // the scrolling fillers are generated once and never change; regenerating them on a spin
+    // repainted the whole reel mid-animation, so only the final three symbols move now
+    const [fillers] = useState<string[]>(makeFillers);
 
     const rouletteRef = useRef<HTMLDivElement | null>(null);
 
@@ -28,11 +28,6 @@ const SlotColumn: React.FC<SlotColumnProps> = ({ symbols, isSpinning, position, 
     const handleImageLoad = () => {
         setLoading(false);
     };
-
-
-    useEffect(() => {
-        if (isSpinning) setFillers(makeFillers());
-    }, [isSpinning]);
 
 
     useEffect(() => {


### PR DESCRIPTION
## The problem

The previous reel fix regenerated the random fillers at the **start of every spin** (`setFillers` on `isSpinning`). That repainted all three reels - over a hundred `<img>` `src` swaps - at the exact instant the scroll animation began. Two consequences, both on every spin:

- the swap painted one frame **into** the scroll, so the images visibly changed right as it started
- repainting that many images at animation-start dropped frames, so the spin felt slow to settle

## The change

The fillers are generated **once** and never change again, the way a physical reel strip is fixed. A spin only writes the final three symbols into the stop position, and those sit off-screen until the scroll ends - so nothing changes mid-spin and the animation starts clean, with no repaint competing with it.

## Notes

- The bottom-bar `aspect-[539/7]` from the earlier fix is correct (the image is exactly 539x7) and stays.
- The settle time between spins is the reel animation (2.8s on the slowest column) plus the network round-trip; that is unchanged and by design. Say the word if you want the whole spin snappier and I'll shorten the animation and the matching delay together.

Typecheck and lint clean.