### PR TITLE
Referral program: links, signup bonus, wager commission

### DIFF
--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -9,6 +9,7 @@ const fairRoutes = require("../../routes/fairRoutes");
 const collectionsRoutes = require("../../routes/collectionsRoutes");
 const missionsRoutes = require("../../routes/missionsRoutes");
 const adminRoutes = require("../../routes/adminRoutes");
+const referralRoutes = require("../../routes/referralRoutes");
 
 // no-op socket.io stand-in
 const io = { emit: () => {}, to: () => ({ emit: () => {} }) };
@@ -24,6 +25,7 @@ function makeApp() {
   app.use("/collections", collectionsRoutes);
   app.use("/missions", missionsRoutes(io));
   app.use("/admin", adminRoutes);
+  app.use("/referrals", referralRoutes(io));
   return app;
 }
 

--- a/backend/__tests__/integration/ledgerAtomicity.test.js
+++ b/backend/__tests__/integration/ledgerAtomicity.test.js
@@ -204,3 +204,43 @@ test("concurrent mission claims pay the reward exactly once", async () => {
   expect((await User.findById(u._id)).walletBalance).toBe(1000 + REWARD);
   expect(await Transaction.countDocuments({ userId: u._id, type: TX.MISSION_REWARD })).toBe(1);
 });
+
+const { claimCommission } = require("../../utils/referrals");
+
+// a referrer with one referee who has wagered enough to earn commission
+async function referrerWithEarnings(wagered) {
+  const me = await makeUser(0);
+  const referee = await makeUser(1000);
+  await User.updateOne({ _id: referee._id }, { $set: { referredBy: me._id } });
+  await Transaction.create({ userId: referee._id, type: TX.CRASH_BET, direction: "debit", amount: wagered });
+  return me;
+}
+
+test("a failed commission credit rolls the claimed counter back", async () => {
+  const me = await referrerWithEarnings(1000); // 10 earned
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+
+  const res = await claimCommission(me._id);
+
+  expect(res.code).toBe(500);
+  const after = await User.findById(me._id);
+  expect(after.referralClaimed || 0).toBe(0); // the counter rolled back
+  expect(after.walletBalance).toBe(0); // nothing paid
+  jest.restoreAllMocks();
+
+  const retry = await claimCommission(me._id); // still all claimable
+  expect(retry.code).toBe(200);
+  expect(retry.body.claimed).toBe(10);
+  expect((await User.findById(me._id)).walletBalance).toBe(10);
+});
+
+test("concurrent commission claims pay exactly once", async () => {
+  const me = await referrerWithEarnings(1000);
+
+  const results = await Promise.all([claimCommission(me._id), claimCommission(me._id)]);
+
+  expect(results.filter((r) => r.code === 200).length).toBe(1);
+  expect((await User.findById(me._id)).walletBalance).toBe(10);
+  expect((await User.findById(me._id)).referralClaimed).toBe(10);
+  expect(await Transaction.countDocuments({ userId: me._id, type: TX.REFERRAL_COMMISSION })).toBe(1);
+});

--- a/backend/__tests__/integration/referrals.test.js
+++ b/backend/__tests__/integration/referrals.test.js
@@ -1,0 +1,217 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+const { HOUSE, MINT } = require("../../utils/accounts");
+const { REFERRAL_SIGNUP_BONUS, COMMISSION_RATE } = require("../../utils/referrals");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 1000,
+    ...overrides,
+  });
+}
+
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+
+const registerWith = (referralCode) => {
+  const s = uniqueSuffix();
+  return request(app).post("/users/register").send({
+    email: `new-${s}@x.com`,
+    username: `new-${s}`,
+    password: "secret1",
+    profilePicture: "",
+    referralCode,
+  });
+};
+
+const wager = (userId, amount, createdAt) => {
+  const doc = { userId, type: TX.CRASH_BET, direction: "debit", amount };
+  if (createdAt) doc.createdAt = createdAt;
+  return Transaction.create(doc);
+};
+
+describe("POST /referrals/code", () => {
+  test("requires auth", async () => {
+    expect((await request(app).post("/referrals/code").send({ code: "ABC" })).status).toBe(401);
+  });
+
+  test("creates the code uppercased and persists it", async () => {
+    const u = await makeUser();
+    const res = await auth(request(app).post("/referrals/code"), u).send({ code: "kani123" });
+    expect(res.status).toBe(200);
+    expect(res.body.referralCode).toBe("KANI123");
+    expect((await User.findById(u._id)).referralCode).toBe("KANI123");
+  });
+
+  test("rejects codes outside 3-16 alphanumerics", async () => {
+    const u = await makeUser();
+    for (const bad of ["ab", "a".repeat(17), "has space", "sneaky-!", ""]) {
+      const res = await auth(request(app).post("/referrals/code"), u).send({ code: bad });
+      expect(res.status).toBe(400);
+    }
+    expect((await User.findById(u._id)).referralCode).toBeUndefined();
+  });
+
+  test("the code is set once and never changes", async () => {
+    const u = await makeUser();
+    await auth(request(app).post("/referrals/code"), u).send({ code: "FIRST" });
+    const res = await auth(request(app).post("/referrals/code"), u).send({ code: "SECOND" });
+    expect(res.status).toBe(400);
+    expect((await User.findById(u._id)).referralCode).toBe("FIRST");
+  });
+
+  test("a taken code is refused", async () => {
+    const a = await makeUser();
+    const b = await makeUser();
+    await auth(request(app).post("/referrals/code"), a).send({ code: "SAME" });
+    const res = await auth(request(app).post("/referrals/code"), b).send({ code: "same" });
+    expect(res.status).toBe(409);
+    expect((await User.findById(b._id)).referralCode).toBeUndefined();
+  });
+});
+
+describe("registering through a referral link", () => {
+  test("both sides get the signup bonus and a minted ledger row", async () => {
+    const referrer = await makeUser({ referralCode: "FRIEND", walletBalance: 0 });
+
+    const res = await registerWith("friend"); // lowercase on purpose
+    expect(res.status).toBe(200);
+
+    const referee = await User.findOne({ referredBy: referrer._id });
+    expect(referee).not.toBeNull();
+    expect(referee.walletBalance).toBe(200 + REFERRAL_SIGNUP_BONUS);
+    expect((await User.findById(referrer._id)).walletBalance).toBe(REFERRAL_SIGNUP_BONUS);
+
+    const rows = await Transaction.find({ type: TX.REFERRAL_BONUS }).lean();
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.direction === "credit" && r.amount === REFERRAL_SIGNUP_BONUS)).toBe(true);
+    expect(rows.every((r) => String(r.counterparty) === String(MINT))).toBe(true);
+    const roles = rows.map((r) => r.meta.role).sort();
+    expect(roles).toEqual(["referee", "referrer"]);
+  });
+
+  test("an unknown code is ignored and the signup still succeeds", async () => {
+    const res = await registerWith("NOBODY");
+    expect(res.status).toBe(200);
+    expect(await Transaction.countDocuments({ type: TX.REFERRAL_BONUS })).toBe(0);
+    const created = await User.findOne({ email: /new-/ });
+    expect(created.referredBy).toBeUndefined();
+    expect(created.walletBalance).toBe(200);
+  });
+});
+
+describe("GET /referrals/me", () => {
+  test("a fresh user has no code and zero totals", async () => {
+    const u = await makeUser();
+    const res = await auth(request(app).get("/referrals/me"), u);
+    expect(res.status).toBe(200);
+    expect(res.body.referralCode).toBeNull();
+    expect(res.body.totals).toEqual({
+      earned: 0, claimed: 0, available: 0, totalWagered: 0, referralCount: 0, activeCount: 0,
+    });
+    expect(res.body.referrals).toEqual([]);
+  });
+
+  test("commission derives from referred wagers only, floored per referee", async () => {
+    const me = await makeUser({ referralCode: "MYCODE" });
+    const whale = await makeUser({ referredBy: me._id });
+    const minnow = await makeUser({ referredBy: me._id });
+    const stranger = await makeUser();
+
+    await wager(whale._id, 2000);
+    await wager(whale._id, 550);
+    await wager(minnow._id, 149);
+    await wager(stranger._id, 100000); // not mine, must not count
+    // a win is not a wager, so it earns nothing
+    await Transaction.create({ userId: whale._id, type: TX.CRASH_CASHOUT, direction: "credit", amount: 5000 });
+
+    const res = await auth(request(app).get("/referrals/me"), me);
+    expect(res.status).toBe(200);
+    const [top, bottom] = res.body.referrals;
+    expect(top.username).toBe(whale.username);
+    expect(top.wagered).toBe(2550);
+    expect(top.commission).toBe(Math.floor(2550 * COMMISSION_RATE));
+    expect(bottom.wagered).toBe(149);
+    expect(bottom.commission).toBe(1);
+    expect(res.body.totals.totalWagered).toBe(2699);
+    expect(res.body.totals.earned).toBe(26);
+    expect(res.body.totals.available).toBe(26);
+    expect(res.body.totals.referralCount).toBe(2);
+  });
+
+  test("a referee is active only if they wagered this week", async () => {
+    const me = await makeUser();
+    const fresh = await makeUser({ referredBy: me._id });
+    const dormant = await makeUser({ referredBy: me._id });
+    await wager(fresh._id, 100);
+    await wager(dormant._id, 100, new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
+
+    const res = await auth(request(app).get("/referrals/me"), me);
+    const byName = Object.fromEntries(res.body.referrals.map((r) => [r.username, r.active]));
+    expect(byName[fresh.username]).toBe(true);
+    expect(byName[dormant.username]).toBe(false);
+    expect(res.body.totals.activeCount).toBe(1);
+  });
+});
+
+describe("POST /referrals/claim", () => {
+  test("with nothing earned there is nothing to claim", async () => {
+    const u = await makeUser();
+    const res = await auth(request(app).post("/referrals/claim"), u);
+    expect(res.status).toBe(400);
+  });
+
+  test("pays out the available commission from the house, exactly once", async () => {
+    const me = await makeUser({ walletBalance: 0 });
+    const referee = await makeUser({ referredBy: me._id });
+    await wager(referee._id, 1000); // 10 earned
+
+    const res = await auth(request(app).post("/referrals/claim"), me);
+    expect(res.status).toBe(200);
+    expect(res.body.claimed).toBe(10);
+    expect(res.body.walletBalance).toBe(10);
+
+    const after = await User.findById(me._id);
+    expect(after.walletBalance).toBe(10);
+    expect(after.referralClaimed).toBe(10);
+    const row = await Transaction.findOne({ userId: me._id, type: TX.REFERRAL_COMMISSION });
+    expect(row.amount).toBe(10);
+    expect(String(row.counterparty)).toBe(String(HOUSE));
+
+    // the well is dry until they wager more
+    expect((await auth(request(app).post("/referrals/claim"), me)).status).toBe(400);
+  });
+
+  test("a later claim pays only what was earned since", async () => {
+    const me = await makeUser({ walletBalance: 0 });
+    const referee = await makeUser({ referredBy: me._id });
+    await wager(referee._id, 1000);
+    await auth(request(app).post("/referrals/claim"), me);
+
+    await wager(referee._id, 500); // 5 more
+    const res = await auth(request(app).post("/referrals/claim"), me);
+    expect(res.status).toBe(200);
+    expect(res.body.claimed).toBe(5);
+    expect((await User.findById(me._id)).walletBalance).toBe(15);
+    expect((await User.findById(me._id)).referralClaimed).toBe(15);
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -83,6 +83,7 @@ const friendsRoutes = require("./routes/friendsRoutes")(io);
 const fairRoutes = require("./routes/fairRoutes");
 const collectionsRoutes = require("./routes/collectionsRoutes");
 const missionsRoutes = require("./routes/missionsRoutes")(io);
+const referralRoutes = require("./routes/referralRoutes")(io);
 
 // Connect to MongoDB
 mongoose
@@ -125,6 +126,7 @@ app.use("/friends", friendsRoutes);
 app.use("/fair", fairRoutes);
 app.use("/collections", collectionsRoutes);
 app.use("/missions", missionsRoutes);
+app.use("/referrals", referralRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -94,7 +94,23 @@ const UserSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  // affiliate identity: the vanity code others register with, set once
+  referralCode: {
+    type: String,
+  },
+  referredBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+  },
+  // commission already paid out, so available = earned - claimed stays ledger-derived
+  referralClaimed: {
+    type: Number,
+    default: 0,
+  },
 
 });
+
+UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });
+UserSchema.index({ referredBy: 1 }, { sparse: true });
 
 module.exports = User = mongoose.model("User", UserSchema);

--- a/backend/routes/referralRoutes.js
+++ b/backend/routes/referralRoutes.js
@@ -1,0 +1,52 @@
+const express = require("express");
+const { isAuthenticated } = require("../middleware/authMiddleware");
+const referrals = require("../utils/referrals");
+
+module.exports = (io) => {
+  const router = express.Router();
+
+  // GET /referrals/me : the affiliate dashboard (code, totals, per-referral stats)
+  router.get("/me", isAuthenticated, async (req, res) => {
+    try {
+      const data = await referrals.getDashboard(req.user._id);
+      if (!data) return res.status(404).json({ message: "User not found" });
+      res.json(data);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  // POST /referrals/code : create the vanity code, once
+  router.post("/code", isAuthenticated, async (req, res) => {
+    try {
+      const r = await referrals.setReferralCode(req.user._id, req.body.code);
+      res.status(r.code).json(r.body);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  // POST /referrals/claim : pay out the commission earned so far (atomic)
+  router.post("/claim", isAuthenticated, async (req, res) => {
+    try {
+      const r = await referrals.claimCommission(req.user._id);
+      if (r.code === 200 && io) {
+        io.to(req.user._id.toString()).emit("userDataUpdated", {
+          walletBalance: r.body.user.walletBalance,
+          xp: r.body.user.xp,
+          level: r.body.user.level,
+        });
+      }
+      res.status(r.code).json(
+        r.code === 200 ? { claimed: r.body.claimed, walletBalance: r.body.user.walletBalance } : r.body
+      );
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  return router;
+};

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -12,6 +12,7 @@ const authMiddleware = require("../middleware/authMiddleware");
 const { loginLimiter, registerLimiter } = require("../middleware/rateLimit");
 const { sellValue } = require("../utils/itemValue");
 const { creditUser, recordTransaction, runAtomic, TX } = require("../utils/economy");
+const { findReferrer, payReferralBonuses } = require("../utils/referrals");
 const { sellUniqueIds } = require("../utils/inventorySell");
 const getRandomPlaceholderImage = require("../utils/placeholderImages");
 const { ObjectId } = require('mongodb');
@@ -39,7 +40,7 @@ router.post(
     }
 
 
-    const { email, password, username, profilePicture } = req.body;
+    const { email, password, username, profilePicture, referralCode } = req.body;
 
     try {
       // Check if user already exists
@@ -54,10 +55,14 @@ router.post(
 
       if (!isValidBase64(profilePicture) && profilePicture !== "") return res.status(400).json({ message: "Invalid profile picture" })
 
+      // an unknown referral code is ignored rather than blocking the signup
+      const referrer = referralCode ? await findReferrer(referralCode) : null;
+
       // Create new user. accept the password as plain text; for backwards
       // compatibility, decrypt a legacy AES-wrapped value if detected.
       const originalPassword = resolvePassword(password);
       user = new User({ email, username, profilePicture, isAdmin: false });
+      if (referrer) user.referredBy = referrer._id;
 
       // Hash password
       const salt = await bcrypt.genSalt(10);
@@ -79,6 +84,8 @@ router.post(
         balanceAfter: user.walletBalance,
         meta: { source: "register" },
       });
+
+      if (referrer) await payReferralBonuses(user, referrer);
 
       // Generate and send JWT
       const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };
@@ -155,7 +162,7 @@ router.post(
 
 // Google login
 router.post('/googlelogin', async (req, res) => {
-  const { token } = req.body;
+  const { token, referralCode } = req.body;
   try {
     const ticket = await client.verifyIdToken({
       idToken: token,
@@ -173,11 +180,14 @@ router.post('/googlelogin', async (req, res) => {
         username = googlePayload.name + Math.floor(Math.random() * 1000);
         existingUser = await User.findOne({ username });
       }
+      // a referral only counts at account creation, never on a later login
+      const referrer = referralCode ? await findReferrer(referralCode) : null;
       user = new User({
         email: googlePayload.email,
         username: username,
         profilePicture: googlePayload.picture,
       });
+      if (referrer) user.referredBy = referrer._id;
       await user.save();
 
       await recordTransaction({
@@ -188,6 +198,8 @@ router.post('/googlelogin', async (req, res) => {
         balanceAfter: user.walletBalance,
         meta: { source: "google" },
       });
+
+      if (referrer) await payReferralBonuses(user, referrer);
     }
     // Generate and send JWT
     const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -16,6 +16,8 @@ const COUNTERPARTY_FOR_TYPE = {
   signup: MINT,
   bonus: MINT,
   mission_reward: MINT,
+  referral_bonus: MINT,
+  referral_commission: HOUSE, // the house shares its edge with the affiliate
   admin_adjust: MINT,
   case_open: HOUSE,
   slot_bet: HOUSE,

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -30,8 +30,13 @@ const TX = {
   ITEM_SELL: "item_sell",
   ADMIN_ADJUST: "admin_adjust",
   MISSION_REWARD: "mission_reward",
+  REFERRAL_BONUS: "referral_bonus", // one-time signup bonus, both sides of a referral
+  REFERRAL_COMMISSION: "referral_commission", // the referrer's cut of referred wagers
   OPENING: "opening_balance", // the pre-ledger balance, booked once against genesis
 };
+
+// every KP put at risk on a game; missions and referral commission both count these
+const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 function calculateXPForLevel(level) {
   return Math.floor(BASE_XP * Math.pow(GROWTH_RATE, level - 1));
@@ -235,4 +240,5 @@ module.exports = {
   setTransactionsSupported,
   transactionsSupported,
   TX,
+  STAKE_TYPES,
 };

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -4,7 +4,7 @@ const Battle = require("../models/Battle");
 const User = require("../models/User");
 const Case = require("../models/Case");
 const MissionState = require("../models/MissionState");
-const { creditUser, runAtomic, TX } = require("./economy");
+const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
 const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 
 // a "big win" is any single game payout (slots / crash cashout / coin flip win)
@@ -36,9 +36,6 @@ async function collectionsProgress(userId) {
 async function countCompletedCollections(userId) {
   return (await collectionsProgress(userId)).done;
 }
-
-// the stakes the "total wagered" mission counts: every KP put at risk on a game
-const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 // ensure the per-user state doc exists, then return it
 async function getState(userId) {

--- a/backend/utils/referrals.js
+++ b/backend/utils/referrals.js
@@ -1,0 +1,167 @@
+const User = require("../models/User");
+const Transaction = require("../models/Transaction");
+const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
+
+// both sides of a referral get this once, at the referee's registration
+const REFERRAL_SIGNUP_BONUS = 100;
+// the referrer's ongoing cut of everything their referees wager, paid by the house
+const COMMISSION_RATE = 0.01;
+// a referee counts as active if they wagered within this window
+const ACTIVE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+const CODE_PATTERN = /^[A-Z0-9]{3,16}$/;
+const normalizeCode = (raw) => String(raw || "").trim().toUpperCase();
+
+// set the user's vanity code once; it never changes so shared links never rot
+async function setReferralCode(userId, raw) {
+  const code = normalizeCode(raw);
+  if (!CODE_PATTERN.test(code)) {
+    return { code: 400, body: { message: "Codes are 3-16 letters or numbers" } };
+  }
+  try {
+    const res = await User.updateOne(
+      { _id: userId, referralCode: { $exists: false } },
+      { $set: { referralCode: code } }
+    );
+    if (res.modifiedCount !== 1) {
+      return { code: 400, body: { message: "Your code is already set" } };
+    }
+    return { code: 200, body: { referralCode: code } };
+  } catch (err) {
+    if (err && err.code === 11000) {
+      return { code: 409, body: { message: "That code is taken" } };
+    }
+    throw err;
+  }
+}
+
+const findReferrer = (raw) => {
+  const code = normalizeCode(raw);
+  if (!CODE_PATTERN.test(code)) return null;
+  return User.findOne({ referralCode: code }, { _id: 1, username: 1 });
+};
+
+// the one-time signup bonuses. issuance (minted), so a failed leg is just a lost gift,
+// never a corrupt ledger; registration must not fail over it
+async function payReferralBonuses(referee, referrer) {
+  await creditUser(referee._id, REFERRAL_SIGNUP_BONUS, 0, {
+    type: TX.REFERRAL_BONUS,
+    meta: { role: "referee", referrerId: String(referrer._id), referrerUsername: referrer.username },
+  });
+  await creditUser(referrer._id, REFERRAL_SIGNUP_BONUS, 0, {
+    type: TX.REFERRAL_BONUS,
+    meta: { role: "referrer", referredUserId: String(referee._id), referredUsername: referee.username },
+  });
+}
+
+// per-referee wagered totals from the ledger; commission is derived, never accumulated,
+// so a missed hook can never exist and the numbers always agree with history
+async function refereeStats(userId) {
+  const referees = await User.find(
+    { referredBy: userId },
+    { username: 1, profilePicture: 1 }
+  ).lean();
+  if (!referees.length) return [];
+
+  const ids = referees.map((r) => r._id);
+  const agg = await Transaction.aggregate([
+    { $match: { userId: { $in: ids }, type: { $in: STAKE_TYPES } } },
+    { $group: { _id: "$userId", wagered: { $sum: "$amount" }, lastAt: { $max: "$createdAt" } } },
+  ]);
+  const byId = new Map(agg.map((row) => [String(row._id), row]));
+
+  const now = Date.now();
+  return referees.map((r) => {
+    const row = byId.get(String(r._id));
+    const wagered = row ? row.wagered : 0;
+    return {
+      id: String(r._id),
+      username: r.username,
+      profilePicture: r.profilePicture || "",
+      joinedAt: r._id.getTimestamp(),
+      wagered,
+      commission: Math.floor(wagered * COMMISSION_RATE),
+      active: !!row && now - new Date(row.lastAt).getTime() < ACTIVE_WINDOW_MS,
+    };
+  });
+}
+
+// total commission ever earned: the sum of per-referee floors, so the table adds up
+const earnedFrom = (referrals) => referrals.reduce((s, r) => s + r.commission, 0);
+
+async function getDashboard(userId) {
+  const [me, referrals] = await Promise.all([
+    User.findById(userId, { referralCode: 1, referralClaimed: 1 }),
+    refereeStats(userId),
+  ]);
+  if (!me) return null;
+
+  const earned = earnedFrom(referrals);
+  const claimed = me.referralClaimed || 0;
+  return {
+    referralCode: me.referralCode || null,
+    signupBonus: REFERRAL_SIGNUP_BONUS,
+    commissionRate: COMMISSION_RATE,
+    totals: {
+      earned,
+      claimed,
+      available: Math.max(0, earned - claimed),
+      totalWagered: referrals.reduce((s, r) => s + r.wagered, 0),
+      referralCount: referrals.length,
+      activeCount: referrals.filter((r) => r.active).length,
+    },
+    referrals: referrals.sort((a, b) => b.wagered - a.wagered),
+  };
+}
+
+// pay out everything earned but not yet claimed. the claimed-counter update is the
+// mutex and commits in one transaction with the credit, like a mission claim.
+async function claimCommission(userId) {
+  const me = await User.findById(userId, { referralClaimed: 1 });
+  if (!me) return { code: 404, body: { message: "User not found" } };
+
+  const earned = earnedFrom(await refereeStats(userId));
+  const claimed = me.referralClaimed || 0;
+  const available = earned - claimed;
+  if (available < 1) return { code: 400, body: { message: "Nothing to claim yet" } };
+
+  // older docs have no referralClaimed field at all, and null matches missing
+  const claimedFilter = claimed === 0 ? { $in: [0, null] } : claimed;
+  let updated;
+  try {
+    updated = await runAtomic(async (session) => {
+      const res = await User.updateOne(
+        { _id: userId, referralClaimed: claimedFilter },
+        { $inc: { referralClaimed: available } },
+        { session }
+      );
+      if (res.modifiedCount !== 1) return null; // a concurrent claim got here first
+      const credited = await creditUser(userId, available, 0, {
+        type: TX.REFERRAL_COMMISSION,
+        meta: { earned, claimedBefore: claimed },
+        session,
+      });
+      if (!credited) throw new Error("commission credit failed"); // abort, roll the counter back
+      return credited;
+    });
+  } catch (e) {
+    console.error("claimCommission failed:", e);
+    return { code: 500, body: { message: "Could not claim, please try again" } };
+  }
+
+  if (updated === null) {
+    return { code: 409, body: { message: "Already claiming, try again" } };
+  }
+  return { code: 200, body: { claimed: available, user: updated } };
+}
+
+module.exports = {
+  REFERRAL_SIGNUP_BONUS,
+  COMMISSION_RATE,
+  normalizeCode,
+  setReferralCode,
+  findReferrer,
+  payReferralBonuses,
+  getDashboard,
+  claimCommission,
+};

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -12,6 +12,8 @@ import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
 import BattleRoom from "./pages/Battles/BattleRoom";
 import ProvablyFair from "./pages/ProvablyFair";
+import Affiliates from "./pages/Affiliates/Affiliates";
+import ReferralRedirect from "./pages/Affiliates/ReferralRedirect";
 
 const defaultRoutes = (
   <>
@@ -27,6 +29,8 @@ const defaultRoutes = (
     <Route path="/battles" element={<Battles />} />
     <Route path="/battles/:id" element={<BattleRoom />} />
     <Route path="/provably-fair" element={<ProvablyFair />} />
+    <Route path="/affiliates" element={<Affiliates />} />
+    <Route path="/r/:code" element={<ReferralRedirect />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
   </>
 );

--- a/src/components/header/Navbar/Navbar.tsx
+++ b/src/components/header/Navbar/Navbar.tsx
@@ -13,7 +13,7 @@ import { SlPlane } from "react-icons/sl";
 import { GiUpgrade, GiCrossedSwords } from 'react-icons/gi';
 import { TbCat } from "react-icons/tb";
 import { toast } from "react-toastify";
-import { FaBars } from 'react-icons/fa';
+import { FaBars, FaUserFriends } from 'react-icons/fa';
 import RightContent from "./RightContent";
 
 interface Navbar {
@@ -94,6 +94,11 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
       name: "Case Battles",
       path: "/battles",
       icon: <GiCrossedSwords className="text-2xl" />,
+    },
+    {
+      name: "Affiliates",
+      path: "/affiliates",
+      icon: <FaUserFriends className="text-2xl" />,
     }
   ];
 

--- a/src/components/header/Sidebar.tsx
+++ b/src/components/header/Sidebar.tsx
@@ -2,7 +2,7 @@ import { BsCoin } from "react-icons/bs";
 import { GiUpgrade, GiCrossedSwords } from "react-icons/gi";
 import { MdOutlineSell } from "react-icons/md";
 import { SlPlane } from "react-icons/sl";
-import { FaHome } from "react-icons/fa";
+import { FaHome, FaUserFriends } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { TbCat } from "react-icons/tb";
 import ClaimBonus from "../header/ClaimBonus";
@@ -53,6 +53,11 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
             name: "Case Battles",
             path: "/battles",
             icon: <GiCrossedSwords className="text-2xl" />,
+        },
+        {
+            name: "Affiliates",
+            path: "/affiliates",
+            icon: <FaUserFriends className="text-2xl" />,
         }
     ];
 

--- a/src/components/header/userFlow/Login.tsx
+++ b/src/components/header/userFlow/Login.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from "react";
 import { login, googleLogin } from "../../../services/auth/auth";
 import { saveTokens } from "../../../services/auth/authUtils";
+import { getPendingReferralCode, clearPendingReferralCode } from "../../../services/referrals/ReferralServices";
 import MainButton from "../../MainButton";
 import UserContext from "../../../UserContext";
 import { Tooltip } from "react-tooltip";
@@ -38,10 +39,12 @@ const LoginPage = () => {
 
   const handleGoogleLoginSuccess = async (credentialResponse: any) => {
     try {
-      const response = await googleLogin(credentialResponse.credential)
+      // a first google sign-in creates the account, so the referral code rides along
+      const response = await googleLogin(credentialResponse.credential, getPendingReferralCode() || undefined)
       const data = await response;
       if (data.token) {
         saveTokens(data.token, "");
+        clearPendingReferralCode();
         toggleLogin();
       }
     } catch (error) {

--- a/src/components/header/userFlow/SignUp.tsx
+++ b/src/components/header/userFlow/SignUp.tsx
@@ -5,6 +5,7 @@ import { register } from "../../../services/auth/auth";
 import MainButton from "../../MainButton";
 import { saveTokens } from "../../../services/auth/authUtils";
 import UserContext from "../../../UserContext";
+import { getPendingReferralCode, clearPendingReferralCode } from "../../../services/referrals/ReferralServices";
 // import { FaImage } from "react-icons/fa";
 // import { toast } from "react-toastify";
 
@@ -14,6 +15,7 @@ const SignUpPage: React.FC = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [nickname, setNickname] = useState("");
+  const [referralCode, setReferralCode] = useState(getPendingReferralCode());
   const [profilePicture, _setProfilePicture] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -25,9 +27,10 @@ const SignUpPage: React.FC = () => {
     setLoading(true);
     e.preventDefault();
     try {
-      await register(email, password, nickname, profilePicture)
+      await register(email, password, nickname, profilePicture, referralCode.trim() || undefined)
         .then((response) => {
           saveTokens(response.token, "");
+          clearPendingReferralCode();
           toggleLogin();
         })
         .catch((error) => {
@@ -148,6 +151,16 @@ const SignUpPage: React.FC = () => {
                         setPassword(e.target.value),
                       placeholder: "Password",
                       label: "Password",
+                    },
+                    {
+                      name: "referralCode",
+                      type: "text",
+                      required: false,
+                      value: referralCode,
+                      onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                        setReferralCode(e.target.value.toUpperCase()),
+                      placeholder: "Referral code",
+                      label: "Referral code (optional)",
                     }
                   ].map((input) => (
                     <div className="relative" key={input.name}>

--- a/src/components/header/userFlow/index.tsx
+++ b/src/components/header/userFlow/index.tsx
@@ -6,6 +6,7 @@ import "./UserFlow.css";
 import UserContext from "../../../UserContext";
 import useOutsideClick from "../../../hooks/useOutsideClick";
 import Modal from "../../Modal";
+import { getPendingReferralCode } from "../../../services/referrals/ReferralServices";
 
 // the provider fetches google's sign-in script the moment it mounts, so it lives here
 // with the only two components that need it (Login and SignUp) rather than around the
@@ -14,7 +15,8 @@ import Modal from "../../Modal";
 const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 
 const UserFlow: React.FC = () => {
-  const [isLogin, setIsLogin] = useState<boolean>(true);
+  // a visitor arriving through a referral link is here to create the account
+  const [isLogin, setIsLogin] = useState<boolean>(() => !getPendingReferralCode());
   const { toogleUserFlow } = useContext(UserContext);
   const loginRef = useRef(null);
 
@@ -29,7 +31,7 @@ const UserFlow: React.FC = () => {
         <Modal open={true} setOpen={toogleUserFlow} width={"400px"}>
           <div className="flex items-center justify-center p-8" >
             <div
-              className={`flex flex-col justify-center transition-all ${isLogin ? "h-[340px]" : "h-[380px]"
+              className={`flex flex-col justify-center transition-all ${isLogin ? "h-[340px]" : "h-[460px]"
                 }`}
             >
               {isLogin ? <Login /> : <SignUp />}

--- a/src/pages/Affiliates/Affiliates.services.ts
+++ b/src/pages/Affiliates/Affiliates.services.ts
@@ -1,0 +1,72 @@
+import { useContext, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  getReferralDashboard,
+  createReferralCode,
+  claimReferralEarnings,
+  ReferralDashboard,
+} from "../../services/referrals/ReferralServices";
+import UserContext from "../../UserContext";
+
+export const useAffiliatesServices = () => {
+  const { userData } = useContext(UserContext);
+  const [data, setData] = useState<ReferralDashboard | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [claiming, setClaiming] = useState<boolean>(false);
+
+  const load = async () => {
+    try {
+      setData(await getReferralDashboard());
+      setError(false);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (userData) {
+      load();
+    } else {
+      setLoading(false);
+    }
+  }, [userData?.id]);
+
+  const saveCode = async (code: string) => {
+    setSaving(true);
+    try {
+      await createReferralCode(code);
+      toast.success("Your referral link is live");
+      await load();
+    } catch (e: any) {
+      toast.error(e.response?.data?.message || "Could not save the code");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const link = data?.referralCode ? `${window.location.origin}/r/${data.referralCode}` : "";
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(link);
+    toast.info("Link copied");
+  };
+
+  const claim = async () => {
+    setClaiming(true);
+    try {
+      const res = await claimReferralEarnings();
+      toast.success(`Claimed +${res.claimed} K₽`);
+      await load();
+    } catch (e: any) {
+      toast.error(e.response?.data?.message || "Could not claim");
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  return { userData, data, loading, error, saving, claiming, saveCode, claim, copyLink, link };
+};

--- a/src/pages/Affiliates/Affiliates.tsx
+++ b/src/pages/Affiliates/Affiliates.tsx
@@ -1,0 +1,6 @@
+import { useAffiliatesServices } from "./Affiliates.services";
+import AffiliatesView from "./Affiliates.view";
+
+const Affiliates = () => <AffiliatesView {...useAffiliatesServices()} />;
+
+export default Affiliates;

--- a/src/pages/Affiliates/Affiliates.view.tsx
+++ b/src/pages/Affiliates/Affiliates.view.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import Skeleton from "react-loading-skeleton";
+import { FiCopy } from "react-icons/fi";
+import MainButton from "../../components/MainButton";
+import Monetary from "../../components/Monetary";
+import Avatar from "../../components/Avatar";
+import { ReferralDashboard, ReferralRow } from "../../services/referrals/ReferralServices";
+
+interface Props {
+  userData: any;
+  data: ReferralDashboard | null;
+  loading: boolean;
+  error: boolean;
+  saving: boolean;
+  claiming: boolean;
+  saveCode: (code: string) => void;
+  claim: () => void;
+  copyLink: () => void;
+  link: string;
+}
+
+const StatCard = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="bg-surface rounded-lg p-4 flex flex-col items-center gap-1">
+    <span className="text-sm text-ink-muted">{label}</span>
+    <span className="text-xl font-semibold text-ink">{children}</span>
+  </div>
+);
+
+const ReferralTable = ({ referrals }: { referrals: ReferralRow[] }) => (
+  <div className="overflow-x-auto">
+    <table className="w-full text-left text-sm">
+      <thead>
+        <tr className="text-ink-muted">
+          <th className="font-medium py-2 pr-4">User</th>
+          <th className="font-medium py-2 pr-4">Joined</th>
+          <th className="font-medium py-2 pr-4">Total wagered</th>
+          <th className="font-medium py-2 pr-4">Commission earned</th>
+          <th className="font-medium py-2">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {referrals.map((r) => (
+          <tr key={r.id} className="border-t border-line">
+            <td className="py-3 pr-4">
+              <div className="flex items-center gap-3">
+                <Avatar image={r.profilePicture} loading={false} id={r.id} size="small" level={0} />
+                <span className="text-ink">{r.username}</span>
+              </div>
+            </td>
+            <td className="py-3 pr-4 text-ink-soft">{new Date(r.joinedAt).toLocaleDateString()}</td>
+            <td className="py-3 pr-4 text-ink-soft">
+              <Monetary value={r.wagered} />
+            </td>
+            <td className="py-3 pr-4 text-green-400">
+              <Monetary value={r.commission} />
+            </td>
+            <td className={`py-3 ${r.active ? "text-green-400" : "text-red-400"}`}>
+              {r.active ? "Active" : "Inactive"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+const AffiliatesView: React.FC<Props> = ({
+  userData, data, loading, error, saving, claiming, saveCode, claim, copyLink, link,
+}) => {
+  const [draftCode, setDraftCode] = useState<string>("");
+
+  if (!userData) {
+    return <div className="w-full flex justify-center py-16 text-ink-soft">Sign in to refer friends</div>;
+  }
+  if (loading) {
+    return (
+      <div className="w-full flex justify-center">
+        <div className="w-full max-w-[1100px] px-4 py-8">
+          <Skeleton height={320} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />
+        </div>
+      </div>
+    );
+  }
+  if (error || !data) {
+    return <div className="w-full flex justify-center py-16 text-ink-muted">Could not load your referrals.</div>;
+  }
+
+  const { totals } = data;
+
+  return (
+    <div className="w-full flex justify-center">
+      <div className="w-full max-w-[1100px] px-4 py-8 flex flex-col gap-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-ink">Refer friends</h1>
+          <p className="text-ink-muted mt-1">
+            You both get <span className="text-accent-gold">+{data.signupBonus} K₽</span> when a friend signs up
+            with your link, and you keep earning{" "}
+            <span className="text-accent-gold">{Math.round(data.commissionRate * 100)}%</span> of everything they wager.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <StatCard label="Total earned">
+            <span className="text-accent-gold">
+              <Monetary value={totals.earned} />
+            </span>
+          </StatCard>
+          <StatCard label="Total wagered by referrals">
+            <Monetary value={totals.totalWagered} />
+          </StatCard>
+          <StatCard label="Referrals">{totals.referralCount}</StatCard>
+          <StatCard label="Active this week">
+            <span className="text-green-400">{totals.activeCount}</span>
+          </StatCard>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div className="bg-surface rounded-lg p-5 flex flex-col gap-3">
+            <h2 className="text-ink font-semibold">Your referral link</h2>
+            {data.referralCode ? (
+              <div className="flex items-center gap-2">
+                <div className="flex-1 bg-surface-nav rounded-md px-3 py-2 text-ink-soft text-sm truncate">{link}</div>
+                <button
+                  onClick={copyLink}
+                  className="flex items-center gap-2 bg-surface-raised hover:bg-surface-hover transition-all rounded-md px-3 py-2 text-ink text-sm"
+                >
+                  <FiCopy /> Copy
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <input
+                  value={draftCode}
+                  onChange={(e) => setDraftCode(e.target.value.toUpperCase())}
+                  placeholder="PICKACODE"
+                  maxLength={16}
+                  className="flex-1 bg-surface-nav rounded-md px-3 py-2 text-ink text-sm focus:outline-none"
+                />
+                <MainButton text="Save" onClick={() => saveCode(draftCode)} disabled={saving || draftCode.length < 3} loading={saving} />
+              </div>
+            )}
+            <p className="text-xs text-ink-muted">
+              {data.referralCode
+                ? "Share it anywhere. The code never changes, so old links keep working."
+                : "3-16 letters or numbers. Choose well, it cannot be changed later."}
+            </p>
+          </div>
+
+          <div className="bg-surface rounded-lg p-5 flex flex-col gap-3">
+            <h2 className="text-ink font-semibold">Available earnings</h2>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-2xl font-semibold text-green-400">
+                <Monetary value={totals.available} />
+              </span>
+              <MainButton text="Claim" onClick={claim} disabled={claiming || totals.available < 1} loading={claiming} />
+            </div>
+            <p className="text-xs text-ink-muted">
+              Already claimed <Monetary value={totals.claimed} /> in commission.
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-surface rounded-lg p-5">
+          <h2 className="text-ink font-semibold mb-3">Your referrals</h2>
+          {data.referrals.length === 0 ? (
+            <p className="text-ink-muted text-sm py-6 text-center">
+              No one yet. Share your link and both of you get paid.
+            </p>
+          ) : (
+            <ReferralTable referrals={data.referrals} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AffiliatesView;

--- a/src/pages/Affiliates/ReferralRedirect.tsx
+++ b/src/pages/Affiliates/ReferralRedirect.tsx
@@ -1,0 +1,26 @@
+import { useContext, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import UserContext from "../../UserContext";
+import { setPendingReferralCode } from "../../services/referrals/ReferralServices";
+import { getAccessToken } from "../../services/auth/authUtils";
+
+// landing point of a shared /r/<code> link: remember the code, send the visitor
+// home and open the signup flow with it prefilled
+const ReferralRedirect = () => {
+  const { code } = useParams();
+  const navigate = useNavigate();
+  const { toogleUserFlow } = useContext(UserContext);
+
+  useEffect(() => {
+    if (code && /^[a-zA-Z0-9]{3,16}$/.test(code) && !getAccessToken()) {
+      setPendingReferralCode(code);
+      toogleUserFlow(true);
+    }
+    navigate("/", { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+};
+
+export default ReferralRedirect;

--- a/src/services/auth/auth.ts
+++ b/src/services/auth/auth.ts
@@ -5,15 +5,16 @@ export async function login(email: string, password: string) {
     return response.data;
 }
 
-export async function googleLogin(token: string) {
-    const response = await api.post('/users/googlelogin', { token });
+export async function googleLogin(token: string, referralCode?: string) {
+    const response = await api.post('/users/googlelogin', { token, referralCode });
     return response.data;
 }
 
-export async function register(email: string, password: string, username: string, profilePicture: any) {
+export async function register(email: string, password: string, username: string, profilePicture: any, referralCode?: string) {
     const response = await api.post('/users/register', {
         email, password, username,
-        profilePicture: profilePicture ? profilePicture : ""
+        profilePicture: profilePicture ? profilePicture : "",
+        referralCode
     });
     return response.data;
 }

--- a/src/services/referrals/ReferralServices.ts
+++ b/src/services/referrals/ReferralServices.ts
@@ -1,0 +1,52 @@
+import api from "../api";
+
+export interface ReferralRow {
+  id: string;
+  username: string;
+  profilePicture: string;
+  joinedAt: string;
+  wagered: number;
+  commission: number;
+  active: boolean;
+}
+
+export interface ReferralDashboard {
+  referralCode: string | null;
+  signupBonus: number;
+  commissionRate: number;
+  totals: {
+    earned: number;
+    claimed: number;
+    available: number;
+    totalWagered: number;
+    referralCount: number;
+    activeCount: number;
+  };
+  referrals: ReferralRow[];
+}
+
+export const getReferralDashboard = async (): Promise<ReferralDashboard> => {
+  const response = await api.get("/referrals/me");
+  return response.data;
+};
+
+export const createReferralCode = async (code: string): Promise<{ referralCode: string }> => {
+  const response = await api.post("/referrals/code", { code });
+  return response.data;
+};
+
+export const claimReferralEarnings = async (): Promise<{ claimed: number; walletBalance: number }> => {
+  const response = await api.post("/referrals/claim");
+  return response.data;
+};
+
+// the code captured from a /r/<code> visit, held until a registration consumes it
+const PENDING_KEY = "pendingReferralCode";
+
+export const setPendingReferralCode = (code: string) =>
+  localStorage.setItem(PENDING_KEY, code.toUpperCase());
+
+export const getPendingReferralCode = (): string =>
+  localStorage.getItem(PENDING_KEY) || "";
+
+export const clearPendingReferralCode = () => localStorage.removeItem(PENDING_KEY);


### PR DESCRIPTION
## The feature

- Any user creates a vanity code once (unique, 3-16 letters/numbers) and gets a shareable link: `/r/<code>`.
- The link remembers the code, opens the signup modal with it prefilled, and rides along through Google sign-in (a first Google login counts as registration).
- When someone registers with a code, **both sides get +100 KP**, minted like the other issuance bonuses. An unknown code never blocks a signup - it is silently ignored.
- The referrer then earns **1% of everything their referrals wager** (crash, coin flip, slots, case opens, battle entries), paid by the HOUSE account out of its edge - a real affiliate revenue share on the ledger.

## How commission stays honest

Commission is **derived from the ledger**, never accumulated by hooks: earned = 1% of each referee's stake rows, floored per referee. Available = earned - claimed. There is no per-bet write and no counter to drift; the numbers always agree with the transaction history. The claim pays out in one transaction: the claimed counter is the mutex, a failed credit rolls it back, concurrent claims pay exactly once.

## The page

`/affiliates` (navbar + sidebar): totals (earned, wagered by referrals, referral count, active this week), code creation / link copy, claimable earnings with a Claim button, and a per-referral table (joined, wagered, commission, active status).

## Tests

- 13 integration tests: code rules (format, once-only, uniqueness), both-sides bonus with MINT rows, unknown-code signup, dashboard math (only referred wagers count, wins do not), claim from HOUSE, claim-the-delta.
- 2 replica-set tests in the ledger atomicity suite: a failed commission credit rolls the counter back (retryable), concurrent claims pay once.
- Backend 286/286, frontend unit + build + e2e green.