### PR TITLE
Backoffice: admin dashboard fed by the ledger

### DIFF
--- a/backend/__tests__/integration/adminStats.test.js
+++ b/backend/__tests__/integration/adminStats.test.js
@@ -1,0 +1,170 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Case = require("../../models/Case");
+const Transaction = require("../../models/Transaction");
+const { recordTransaction, TX } = require("../../utils/economy");
+const { HOUSE } = require("../../utils/accounts");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 1000,
+    ...overrides,
+  });
+}
+
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+const get = (path, user) => auth(request(app).get(path), user);
+
+// recordTransaction fills the counterparty from the type, like the live money paths do
+const row = (userId, type, direction, amount, meta = {}) =>
+  recordTransaction({ userId, type, direction, amount, meta });
+
+describe("access", () => {
+  const PATHS = ["/admin/stats/overview", "/admin/stats/games", "/admin/stats/cases", "/admin/stats/users"];
+
+  test("anonymous and non-admin callers are refused", async () => {
+    const pleb = await makeUser();
+    for (const p of PATHS) {
+      expect((await request(app).get(p)).status).toBe(401);
+      expect((await get(p, pleb)).status).toBe(403);
+    }
+  });
+
+  test("/users/me tells the caller their own admin flag", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const pleb = await makeUser();
+    expect((await get("/users/me", admin)).body.isAdmin).toBe(true);
+    expect((await get("/users/me", pleb)).body.isAdmin).toBe(false);
+  });
+});
+
+describe("GET /admin/stats/overview", () => {
+  test("counts users and derives the economy from the ledger", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const a = await makeUser();
+    await makeUser(); // registered but never played
+    await row(a._id, TX.BONUS, "credit", 500);
+    await row(a._id, TX.CRASH_BET, "debit", 300);
+    await row(a._id, TX.CRASH_CASHOUT, "credit", 100);
+
+    const res = await get("/admin/stats/overview", admin);
+    expect(res.status).toBe(200);
+    expect(res.body.users.total).toBe(3);
+    expect(res.body.users.active).toBe(1); // only a transacted
+    expect(res.body.economy.supply).toBe(500); // the bonus minted 500
+    expect(res.body.economy.houseBalance).toBe(200); // 300 staked, 100 paid back
+  });
+});
+
+describe("GET /admin/stats/games", () => {
+  test("nets each game and splits house lines from issuance", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const u = await makeUser();
+    await row(u._id, TX.CRASH_BET, "debit", 1000);
+    await row(u._id, TX.CRASH_CASHOUT, "credit", 400);
+    await row(u._id, TX.SLOT_BET, "debit", 200);
+    await row(u._id, TX.SLOT_WIN, "credit", 300);
+    await row(u._id, TX.CASE_OPEN, "debit", 500, { quantity: 5, caseId: new mongoose.Types.ObjectId() });
+    // the live fee writer books the fee with HOUSE as the row's owner, so mirror it
+    await recordTransaction({ userId: HOUSE, type: TX.MARKET_FEE, direction: "credit", amount: 25, counterparty: null });
+    await row(u._id, TX.ITEM_SELL, "credit", 80);
+    await row(u._id, TX.BONUS, "credit", 900);
+
+    const res = await get("/admin/stats/games", admin);
+    expect(res.status).toBe(200);
+
+    const byGame = Object.fromEntries(res.body.games.map((g) => [g.game, g]));
+    expect(byGame.crash).toMatchObject({ plays: 1, wagered: 1000, paidOut: 400, net: 600 });
+    expect(byGame.slots).toMatchObject({ plays: 1, wagered: 200, paidOut: 300, net: -100 }); // a deficit
+    expect(byGame.cases).toMatchObject({ plays: 5, wagered: 500, net: 500 }); // quantity, not row count
+    expect(res.body.games[0].game).toBe("crash"); // most profitable first
+    expect(res.body.games[res.body.games.length - 1].game).toBe("slots"); // biggest deficit last
+
+    const lines = Object.fromEntries(res.body.houseLines.map((l) => [l.type, l.net]));
+    expect(lines.market_fee).toBe(25);
+    expect(lines.item_sell).toBe(-80); // the house buying items back
+    const issued = Object.fromEntries(res.body.issuance.map((l) => [l.type, l.issued]));
+    expect(issued.bonus).toBe(900);
+  });
+});
+
+describe("GET /admin/stats/cases", () => {
+  test("ranks cases by opens, summing quantities, tolerating deleted cases", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const u = await makeUser();
+    const hot = await Case.create({ title: "Hot Case", image: "hot.png", price: 100, items: [] });
+    const goneId = new mongoose.Types.ObjectId();
+
+    await row(u._id, TX.CASE_OPEN, "debit", 300, { caseId: hot._id, caseTitle: "Hot Case", quantity: 3 });
+    await row(u._id, TX.CASE_OPEN, "debit", 200, { caseId: hot._id, caseTitle: "Hot Case", quantity: 2 });
+    await row(u._id, TX.CASE_OPEN, "debit", 50, { caseId: goneId, caseTitle: "Old Case", quantity: 1 });
+
+    const res = await get("/admin/stats/cases", admin);
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toMatchObject({ title: "Hot Case", opens: 5, spent: 500, image: "hot.png", price: 100 });
+    expect(res.body[1]).toMatchObject({ title: "Old Case", opens: 1, spent: 50, image: null, price: null });
+  });
+});
+
+describe("GET /admin/stats/users", () => {
+  test("paginates, searches safely and sums each user's wagers", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const whale = await makeUser({ username: `whale-${uniqueSuffix()}` });
+    for (let i = 0; i < 20; i++) await makeUser();
+    await row(whale._id, TX.SLOT_BET, "debit", 700);
+    await row(whale._id, TX.SLOT_WIN, "credit", 900); // a win is not a wager
+
+    const page2 = await get("/admin/stats/users?page=2", admin);
+    expect(page2.status).toBe(200);
+    expect(page2.body.total).toBe(22);
+    expect(page2.body.pages).toBe(2);
+    expect(page2.body.users).toHaveLength(2);
+
+    const found = await get("/admin/stats/users?search=whale", admin);
+    expect(found.body.users).toHaveLength(1);
+    expect(found.body.users[0].wagered).toBe(700);
+    expect(found.body.users[0].lastActive).not.toBeNull();
+    expect(found.body.users[0].joined).toBeTruthy();
+
+    // a regex metacharacter is treated as text, not as a pattern
+    expect((await get("/admin/stats/users?search=.*", admin)).body.users).toHaveLength(0);
+  });
+});
+
+describe("time windows", () => {
+  test("?days= excludes older activity", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const u = await makeUser();
+    await row(u._id, TX.CRASH_BET, "debit", 100);
+    await Transaction.create({
+      userId: u._id, type: TX.CRASH_BET, direction: "debit", amount: 900,
+      createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    });
+
+    const all = await get("/admin/stats/games", admin);
+    const week = await get("/admin/stats/games?days=7", admin);
+    const crashAll = all.body.games.find((g) => g.game === "crash");
+    const crashWeek = week.body.games.find((g) => g.game === "crash");
+    expect(crashAll.wagered).toBe(1000);
+    expect(crashWeek.wagered).toBe(100);
+  });
+});

--- a/backend/models/Transaction.js
+++ b/backend/models/Transaction.js
@@ -44,5 +44,6 @@ const TransactionSchema = new mongoose.Schema({
 });
 
 TransactionSchema.index({ userId: 1, createdAt: -1 });
+TransactionSchema.index({ type: 1, createdAt: -1 });
 
 module.exports = mongoose.model("Transaction", TransactionSchema);

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -6,6 +6,45 @@ const Case = require("../models/Case");
 const Item = require("../models/Item");
 const { recomputeCaseValues } = require("../utils/itemValue");
 const { recordTransaction, runAtomic, TX } = require("../utils/economy");
+const adminStats = require("../utils/adminStats");
+
+// the backoffice dashboard: everything is derived from the ledger, ?days= windows it
+router.get("/stats/overview", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    res.json(await adminStats.overview(req.query.days));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.get("/stats/games", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    res.json(await adminStats.gameStats(req.query.days));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.get("/stats/cases", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    res.json(await adminStats.caseStats(req.query.days));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.get("/stats/users", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const { days, page, search, sort } = req.query;
+    res.json(await adminStats.userStats({ days, page, search, sort }));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
 
 router.get("/users", isAuthenticated, isAdmin, async (req, res) => {
   try {

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -250,14 +250,16 @@ router.get("/me", authMiddleware.isAuthenticated, async (req, res) => {
       xp,
       level,
       walletBalance,
-      nextBonus
+      nextBonus,
+      isAdmin
     } = req.user;
 
     // verify in Notification model if there are unread notifications for the user
     const unreadNotifications = await Notification.find({ receiverId: req.user._id, read: false });
     const hasUnreadNotifications = unreadNotifications.length > 0;
 
-    res.json({ id, username, profilePicture, xp, level, walletBalance, nextBonus, hasUnreadNotifications });
+    // isAdmin is the caller's own flag; the public /:id profile keeps hiding it
+    res.json({ id, username, profilePicture, xp, level, walletBalance, nextBonus, hasUnreadNotifications, isAdmin: !!isAdmin });
   } catch (err) {
     console.error(err.message);
     res.status(500).send("Server error");

--- a/backend/utils/adminStats.js
+++ b/backend/utils/adminStats.js
@@ -1,0 +1,204 @@
+const mongoose = require("mongoose");
+const User = require("../models/User");
+const Case = require("../models/Case");
+const Transaction = require("../models/Transaction");
+const { accountBalance, ledgerSupply, TX, STAKE_TYPES } = require("./economy");
+const { HOUSE, MINT, ESCROW } = require("./accounts");
+
+const PAGE_SIZE = 20;
+
+// window start, or null for all-time
+const sinceFor = (days) => {
+  const n = Number(days);
+  return Number.isFinite(n) && n > 0 ? new Date(Date.now() - n * 24 * 60 * 60 * 1000) : null;
+};
+const matchSince = (since) => (since ? { createdAt: { $gte: since } } : {});
+
+async function overview(days) {
+  const since = sinceFor(days);
+  const [totalUsers, newUsers, activeAgg, supply, house, escrow] = await Promise.all([
+    User.countDocuments({}),
+    since
+      ? User.countDocuments({ _id: { $gte: mongoose.Types.ObjectId.createFromTime(Math.floor(since.getTime() / 1000)) } })
+      : User.countDocuments({}),
+    Transaction.aggregate([{ $match: matchSince(since) }, { $group: { _id: "$userId" } }, { $count: "n" }]),
+    ledgerSupply(),
+    accountBalance(HOUSE),
+    accountBalance(ESCROW),
+  ]);
+  return {
+    users: { total: totalUsers, new: newUsers, active: activeAgg.length ? activeAgg[0].n : 0 },
+    economy: { supply, houseBalance: house, escrow },
+  };
+}
+
+// what each game charges and what it pays back in KP. cases and battles pay in items,
+// so their KP outflow shows up later as item_sell buybacks, listed with the house lines.
+const GAME_LINES = [
+  { game: "crash", bets: [TX.CRASH_BET], outs: [TX.CRASH_CASHOUT, TX.CRASH_REFUND] },
+  { game: "coinflip", bets: [TX.COINFLIP_BET], outs: [TX.COINFLIP_WIN, TX.COINFLIP_REFUND] },
+  { game: "slots", bets: [TX.SLOT_BET], outs: [TX.SLOT_WIN] },
+  { game: "cases", bets: [TX.CASE_OPEN], outs: [] },
+  { game: "battles", bets: [TX.BATTLE_ENTRY], outs: [TX.BATTLE_REFUND] },
+];
+
+async function gameStats(days) {
+  const since = sinceFor(days);
+  // a system account can sit on either side of a row (market fees are written with
+  // HOUSE as the userId), so keep which one without exploding the group by real users
+  const rows = await Transaction.aggregate([
+    { $match: matchSince(since) },
+    {
+      $group: {
+        _id: {
+          type: "$type",
+          direction: "$direction",
+          counterparty: "$counterparty",
+          sysUser: { $cond: [{ $in: ["$userId", [HOUSE, MINT]] }, "$userId", null] },
+        },
+        amount: { $sum: "$amount" },
+        count: { $sum: 1 },
+        qty: { $sum: { $ifNull: ["$meta.quantity", 0] } },
+      },
+    },
+  ]);
+
+  const byTypeDir = {};
+  for (const r of rows) {
+    const key = `${r._id.type}:${r._id.direction}`;
+    const slot = byTypeDir[key] || (byTypeDir[key] = { amount: 0, count: 0, qty: 0 });
+    slot.amount += r.amount;
+    slot.count += r.count;
+    slot.qty += r.qty;
+  }
+  const sumOf = (types, dir) =>
+    types.reduce((s, t) => s + ((byTypeDir[`${t}:${dir}`] || {}).amount || 0), 0);
+
+  const games = GAME_LINES.map(({ game, bets, outs }) => {
+    const betSlot = byTypeDir[`${bets[0]}:debit`] || { amount: 0, count: 0, qty: 0 };
+    const plays = game === "cases" ? betSlot.qty || betSlot.count : betSlot.count;
+    const wagered = sumOf(bets, "debit");
+    const paidOut = sumOf(outs, "credit");
+    return { game, plays, wagered, paidOut, net: wagered - paidOut };
+  }).sort((a, b) => b.net - a.net);
+
+  // everything else settling against the house or the mint, signed from the house's
+  // and the supply's point of view; grouped by type so new lines appear on their own
+  const gameTypes = new Set(GAME_LINES.flatMap((g) => [...g.bets, ...g.outs]));
+  const houseLines = [];
+  const issuance = [];
+  const acc = {};
+  for (const r of rows) {
+    const cp = String(r._id.counterparty || "");
+    const sys = String(r._id.sysUser || "");
+    const account = [String(HOUSE), String(MINT)].find((a) => a === cp || a === sys);
+    if (!account) continue;
+    if (account === String(HOUSE) && gameTypes.has(r._id.type)) continue;
+    // as counterparty the account gains what the user pays; as the row's owner it is
+    // the account itself being credited or debited
+    const gain = account === cp ? r._id.direction === "debit" : r._id.direction === "credit";
+    const key = `${account}:${r._id.type}`;
+    const slot = acc[key] || (acc[key] = { type: r._id.type, cp: account, net: 0, count: 0 });
+    slot.net += (gain ? 1 : -1) * r.amount;
+    slot.count += r.count;
+  }
+  for (const slot of Object.values(acc)) {
+    if (slot.cp === String(HOUSE)) houseLines.push({ type: slot.type, net: slot.net, count: slot.count });
+    else issuance.push({ type: slot.type, issued: -slot.net, count: slot.count });
+  }
+  houseLines.sort((a, b) => b.net - a.net);
+  issuance.sort((a, b) => b.issued - a.issued);
+
+  return { games, houseLines, issuance };
+}
+
+async function caseStats(days) {
+  const since = sinceFor(days);
+  const rows = await Transaction.aggregate([
+    { $match: { type: TX.CASE_OPEN, "meta.caseId": { $exists: true }, ...matchSince(since) } },
+    {
+      $group: {
+        _id: "$meta.caseId",
+        opens: { $sum: { $max: [{ $ifNull: ["$meta.quantity", 1] }, 1] } },
+        spent: { $sum: "$amount" },
+        title: { $last: "$meta.caseTitle" },
+        lastOpened: { $max: "$createdAt" },
+      },
+    },
+    { $sort: { opens: -1 } },
+    { $limit: 50 },
+  ]);
+
+  const cases = await Case.find({ _id: { $in: rows.map((r) => r._id) } }, { image: 1, price: 1 }).lean();
+  const byId = new Map(cases.map((c) => [String(c._id), c]));
+  return rows.map((r) => {
+    const live = byId.get(String(r._id));
+    return {
+      caseId: String(r._id),
+      title: r.title || "(deleted case)",
+      image: live ? live.image : null,
+      price: live ? live.price : null,
+      opens: r.opens,
+      spent: r.spent,
+      lastOpened: r.lastOpened,
+    };
+  });
+}
+
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const SORTS = { newest: { _id: -1 }, balance: { walletBalance: -1 }, level: { level: -1 } };
+
+async function userStats({ days, page = 1, search = "", sort = "newest" } = {}) {
+  const since = sinceFor(days);
+  const filter = search ? { username: { $regex: escapeRegex(String(search)), $options: "i" } } : {};
+  const p = Math.max(1, Math.floor(Number(page)) || 1);
+
+  const [total, users] = await Promise.all([
+    User.countDocuments(filter),
+    User.find(filter, { username: 1, profilePicture: 1, level: 1, walletBalance: 1, isAdmin: 1, referredBy: 1 })
+      .sort(SORTS[sort] || SORTS.newest)
+      .skip((p - 1) * PAGE_SIZE)
+      .limit(PAGE_SIZE)
+      .lean(),
+  ]);
+
+  const ids = users.map((u) => u._id);
+  const [activity, referrers] = await Promise.all([
+    Transaction.aggregate([
+      { $match: { userId: { $in: ids }, ...matchSince(since) } },
+      {
+        $group: {
+          _id: "$userId",
+          wagered: { $sum: { $cond: [{ $in: ["$type", STAKE_TYPES] }, "$amount", 0] } },
+          lastActive: { $max: "$createdAt" },
+        },
+      },
+    ]),
+    User.find({ _id: { $in: users.map((u) => u.referredBy).filter(Boolean) } }, { username: 1 }).lean(),
+  ]);
+  const act = new Map(activity.map((a) => [String(a._id), a]));
+  const refName = new Map(referrers.map((r) => [String(r._id), r.username]));
+
+  return {
+    total,
+    page: p,
+    pages: Math.max(1, Math.ceil(total / PAGE_SIZE)),
+    users: users.map((u) => {
+      const a = act.get(String(u._id)) || {};
+      return {
+        id: String(u._id),
+        username: u.username,
+        profilePicture: u.profilePicture || "",
+        level: u.level || 0,
+        walletBalance: u.walletBalance,
+        isAdmin: !!u.isAdmin,
+        joined: u._id.getTimestamp(),
+        wagered: a.wagered || 0,
+        lastActive: a.lastActive || null,
+        referredBy: u.referredBy ? refName.get(String(u.referredBy)) || null : null,
+      };
+    }),
+  };
+}
+
+module.exports = { overview, gameStats, caseStats, userStats, PAGE_SIZE };

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -14,6 +14,7 @@ import BattleRoom from "./pages/Battles/BattleRoom";
 import ProvablyFair from "./pages/ProvablyFair";
 import Affiliates from "./pages/Affiliates/Affiliates";
 import ReferralRedirect from "./pages/Affiliates/ReferralRedirect";
+import Backoffice from "./pages/Backoffice/Backoffice";
 
 const defaultRoutes = (
   <>
@@ -31,6 +32,7 @@ const defaultRoutes = (
     <Route path="/provably-fair" element={<ProvablyFair />} />
     <Route path="/affiliates" element={<Affiliates />} />
     <Route path="/r/:code" element={<ReferralRedirect />} />
+    <Route path="/backoffice" element={<Backoffice />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
   </>
 );

--- a/src/components/header/Navbar/Navbar.tsx
+++ b/src/components/header/Navbar/Navbar.tsx
@@ -7,7 +7,7 @@ import MainButton from "../../MainButton";
 import { clearTokens } from "../../../services/auth/authUtils";
 import { me } from "../../../services/auth/auth";
 import "react-loading-skeleton/dist/skeleton.css";
-import { MdOutlineSell } from "react-icons/md";
+import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { BsCoin } from "react-icons/bs";
 import { SlPlane } from "react-icons/sl";
 import { GiUpgrade, GiCrossedSwords } from 'react-icons/gi';
@@ -99,7 +99,13 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
       name: "Affiliates",
       path: "/affiliates",
       icon: <FaUserFriends className="text-2xl" />,
-    }
+    },
+    // only admins see the backoffice; the api refuses everyone else anyway
+    ...(userData?.isAdmin ? [{
+      name: "Backoffice",
+      path: "/backoffice",
+      icon: <MdOutlineAdminPanelSettings className="text-2xl" />,
+    }] : [])
   ];
 
 

--- a/src/components/header/Sidebar.tsx
+++ b/src/components/header/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { BsCoin } from "react-icons/bs";
 import { GiUpgrade, GiCrossedSwords } from "react-icons/gi";
-import { MdOutlineSell } from "react-icons/md";
+import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { SlPlane } from "react-icons/sl";
 import { FaHome, FaUserFriends } from "react-icons/fa";
 import { Link } from "react-router-dom";
@@ -58,7 +58,12 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
             name: "Affiliates",
             path: "/affiliates",
             icon: <FaUserFriends className="text-2xl" />,
-        }
+        },
+        ...(userData?.isAdmin ? [{
+            name: "Backoffice",
+            path: "/backoffice",
+            icon: <MdOutlineAdminPanelSettings className="text-2xl" />,
+        }] : [])
     ];
 
     return (

--- a/src/pages/Backoffice/Backoffice.services.ts
+++ b/src/pages/Backoffice/Backoffice.services.ts
@@ -1,0 +1,96 @@
+import { useContext, useEffect, useState } from "react";
+import {
+  getAdminOverview,
+  getAdminGameStats,
+  getAdminCaseStats,
+  getAdminUserStats,
+  AdminOverview,
+  AdminGameStats,
+  AdminCaseRow,
+  AdminUsersPage,
+} from "../../services/admin/AdminServices";
+import UserContext from "../../UserContext";
+
+export type Window = 7 | 30 | null;
+
+export const useBackofficeServices = () => {
+  const { userData } = useContext(UserContext);
+  const [days, setDays] = useState<Window>(null);
+  const [overview, setOverview] = useState<AdminOverview | null>(null);
+  const [games, setGames] = useState<AdminGameStats | null>(null);
+  const [cases, setCases] = useState<AdminCaseRow[] | null>(null);
+  const [usersPage, setUsersPage] = useState<AdminUsersPage | null>(null);
+  const [page, setPage] = useState<number>(1);
+  const [search, setSearch] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+
+  const isAdmin = !!userData?.isAdmin;
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    Promise.all([getAdminOverview(days), getAdminGameStats(days), getAdminCaseStats(days)])
+      .then(([o, g, c]) => {
+        if (!active) return;
+        setOverview(o);
+        setGames(g);
+        setCases(c);
+        setError(false);
+      })
+      .catch(() => {
+        if (active) setError(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isAdmin, days]);
+
+  // the user table follows its own paging and search, debounced against typing
+  useEffect(() => {
+    if (!isAdmin) return;
+    let active = true;
+    const t = setTimeout(() => {
+      getAdminUserStats(days, page, search)
+        .then((res) => {
+          if (active) setUsersPage(res);
+        })
+        .catch(() => {
+          if (active) setUsersPage(null);
+        });
+    }, search ? 300 : 0);
+    return () => {
+      active = false;
+      clearTimeout(t);
+    };
+  }, [isAdmin, days, page, search]);
+
+  const changeSearch = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
+
+  return {
+    userData,
+    isAdmin,
+    days,
+    setDays,
+    overview,
+    games,
+    cases,
+    usersPage,
+    page,
+    setPage,
+    search,
+    changeSearch,
+    loading,
+    error,
+  };
+};

--- a/src/pages/Backoffice/Backoffice.tsx
+++ b/src/pages/Backoffice/Backoffice.tsx
@@ -1,0 +1,6 @@
+import { useBackofficeServices } from "./Backoffice.services";
+import BackofficeView from "./Backoffice.view";
+
+const Backoffice = () => <BackofficeView {...useBackofficeServices()} />;
+
+export default Backoffice;

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -1,0 +1,303 @@
+import Skeleton from "react-loading-skeleton";
+import Avatar from "../../components/Avatar";
+import Monetary from "../../components/Monetary";
+import {
+  AdminOverview,
+  AdminGameStats,
+  AdminCaseRow,
+  AdminUsersPage,
+} from "../../services/admin/AdminServices";
+import { Window } from "./Backoffice.services";
+
+interface Props {
+  userData: any;
+  isAdmin: boolean;
+  days: Window;
+  setDays: (d: Window) => void;
+  overview: AdminOverview | null;
+  games: AdminGameStats | null;
+  cases: AdminCaseRow[] | null;
+  usersPage: AdminUsersPage | null;
+  page: number;
+  setPage: (p: number) => void;
+  search: string;
+  changeSearch: (s: string) => void;
+  loading: boolean;
+  error: boolean;
+}
+
+const GAME_LABELS: Record<string, string> = {
+  crash: "Crash",
+  coinflip: "Coin Flip",
+  slots: "Slots",
+  cases: "Case openings",
+  battles: "Case battles",
+};
+
+const LINE_LABELS: Record<string, string> = {
+  market_fee: "Market fees",
+  item_sell: "Item buybacks",
+  bonus: "Claimable bonus",
+  signup: "Signup balance",
+  mission_reward: "Mission rewards",
+  referral_bonus: "Referral bonuses",
+  referral_commission: "Referral commission",
+  admin_adjust: "Admin adjustments",
+};
+const label = (type: string) => LINE_LABELS[type] || type.replace(/_/g, " ");
+
+const netClass = (n: number) => (n > 0 ? "text-green-400" : n < 0 ? "text-red-400" : "text-ink-soft");
+
+const StatCard = ({ title, children, sub }: { title: string; children: React.ReactNode; sub?: React.ReactNode }) => (
+  <div className="bg-surface rounded-lg p-4 flex flex-col gap-1">
+    <span className="text-sm text-ink-muted">{title}</span>
+    <span className="text-xl font-semibold text-ink">{children}</span>
+    {sub && <span className="text-xs text-ink-muted">{sub}</span>}
+  </div>
+);
+
+const Panel = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div className="bg-surface rounded-lg p-5">
+    <h2 className="text-ink font-semibold mb-3">{title}</h2>
+    {children}
+  </div>
+);
+
+const WINDOWS: { value: Window; text: string }[] = [
+  { value: null, text: "All time" },
+  { value: 30, text: "30 days" },
+  { value: 7, text: "7 days" },
+];
+
+const BackofficeView: React.FC<Props> = ({
+  userData, isAdmin, days, setDays, overview, games, cases, usersPage,
+  page, setPage, search, changeSearch, loading, error,
+}) => {
+  if (!userData || !isAdmin) {
+    return <div className="w-full flex justify-center py-16 text-ink-soft">Nothing to see here.</div>;
+  }
+  if (loading) {
+    return (
+      <div className="w-full flex justify-center">
+        <div className="w-full max-w-[1200px] px-4 py-8">
+          <Skeleton height={420} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />
+        </div>
+      </div>
+    );
+  }
+  if (error || !overview || !games || !cases) {
+    return <div className="w-full flex justify-center py-16 text-ink-muted">Could not load the numbers.</div>;
+  }
+
+  const windowText = days ? `last ${days} days` : "all time";
+
+  return (
+    <div className="w-full flex justify-center">
+      <div className="w-full max-w-[1200px] px-4 py-8 flex flex-col gap-6">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <h1 className="text-2xl font-semibold text-ink">Backoffice</h1>
+          <div className="flex gap-1 bg-surface rounded-lg p-1">
+            {WINDOWS.map((w) => (
+              <button
+                key={w.text}
+                onClick={() => setDays(w.value)}
+                className={`px-3 py-1.5 rounded-md text-sm transition-all ${
+                  days === w.value ? "bg-surface-raised text-ink" : "text-ink-muted hover:text-ink"
+                }`}
+              >
+                {w.text}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <StatCard title="Users" sub={days ? `+${overview.users.new} new in the window` : undefined}>
+            {overview.users.total.toLocaleString()}
+          </StatCard>
+          <StatCard title={`Players active (${windowText})`}>{overview.users.active.toLocaleString()}</StatCard>
+          <StatCard title="KP in circulation" sub="minted minus reclaimed, all time">
+            <Monetary value={overview.economy.supply} />
+          </StatCard>
+          <StatCard title="House balance" sub="lifetime edge minus payouts">
+            <span className={netClass(overview.economy.houseBalance)}>
+              <Monetary value={overview.economy.houseBalance} />
+            </span>
+          </StatCard>
+        </div>
+
+        <Panel title={`Games (${windowText}, most profitable first)`}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="text-ink-muted">
+                  <th className="font-medium py-2 pr-4">Game</th>
+                  <th className="font-medium py-2 pr-4">Plays</th>
+                  <th className="font-medium py-2 pr-4">Wagered</th>
+                  <th className="font-medium py-2 pr-4">Paid out</th>
+                  <th className="font-medium py-2">House net</th>
+                </tr>
+              </thead>
+              <tbody>
+                {games.games.map((g) => (
+                  <tr key={g.game} className="border-t border-line">
+                    <td className="py-3 pr-4 text-ink">{GAME_LABELS[g.game] || g.game}</td>
+                    <td className="py-3 pr-4 text-ink-soft">{g.plays.toLocaleString()}</td>
+                    <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.wagered} /></td>
+                    <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.paidOut} /></td>
+                    <td className={`py-3 font-semibold ${netClass(g.net)}`}><Monetary value={g.net} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-xs text-ink-muted mt-2">
+            Cases and battles pay winners in items, so their buybacks appear under item buybacks below.
+          </p>
+        </Panel>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <Panel title="Other house lines">
+            {games.houseLines.length === 0 ? (
+              <p className="text-ink-muted text-sm">Nothing in this window.</p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {games.houseLines.map((l) => (
+                  <div key={l.type} className="flex items-center justify-between text-sm">
+                    <span className="text-ink-soft">{label(l.type)} ({l.count.toLocaleString()})</span>
+                    <span className={`font-semibold ${netClass(l.net)}`}><Monetary value={l.net} /></span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Panel>
+          <Panel title="KP printed (faucets)">
+            {games.issuance.length === 0 ? (
+              <p className="text-ink-muted text-sm">Nothing in this window.</p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {games.issuance.map((l) => (
+                  <div key={l.type} className="flex items-center justify-between text-sm">
+                    <span className="text-ink-soft">{label(l.type)} ({l.count.toLocaleString()})</span>
+                    <span className="text-ink font-semibold"><Monetary value={l.issued} /></span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Panel>
+        </div>
+
+        <Panel title={`Cases (${windowText}, most opened first)`}>
+          {cases.length === 0 ? (
+            <p className="text-ink-muted text-sm py-4 text-center">No cases opened in this window.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="text-ink-muted">
+                    <th className="font-medium py-2 pr-4">Case</th>
+                    <th className="font-medium py-2 pr-4">Opens</th>
+                    <th className="font-medium py-2 pr-4">Spent on opens</th>
+                    <th className="font-medium py-2 pr-4">Price</th>
+                    <th className="font-medium py-2">Last opened</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {cases.map((c) => (
+                    <tr key={c.caseId} className="border-t border-line">
+                      <td className="py-3 pr-4">
+                        <div className="flex items-center gap-3">
+                          {c.image && <img src={c.image} alt={c.title} className="w-10 h-8 object-contain" />}
+                          <span className="text-ink">{c.title}</span>
+                        </div>
+                      </td>
+                      <td className="py-3 pr-4 text-ink font-semibold">{c.opens.toLocaleString()}</td>
+                      <td className="py-3 pr-4 text-ink-soft"><Monetary value={c.spent} /></td>
+                      <td className="py-3 pr-4 text-ink-soft">{c.price !== null ? <Monetary value={c.price} /> : "-"}</td>
+                      <td className="py-3 text-ink-muted">{new Date(c.lastOpened).toLocaleDateString()}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Panel>
+
+        <Panel title="Users">
+          <input
+            value={search}
+            onChange={(e) => changeSearch(e.target.value)}
+            placeholder="Search by username"
+            className="w-full md:w-72 bg-surface-nav rounded-md px-3 py-2 text-ink text-sm focus:outline-none mb-3"
+          />
+          {!usersPage ? (
+            <Skeleton height={200} borderRadius={8} highlightColor="#161427" baseColor="#1c1a31" />
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead>
+                    <tr className="text-ink-muted">
+                      <th className="font-medium py-2 pr-4">User</th>
+                      <th className="font-medium py-2 pr-4">Level</th>
+                      <th className="font-medium py-2 pr-4">Balance</th>
+                      <th className="font-medium py-2 pr-4">Wagered ({windowText})</th>
+                      <th className="font-medium py-2 pr-4">Joined</th>
+                      <th className="font-medium py-2 pr-4">Last active</th>
+                      <th className="font-medium py-2">Referred by</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {usersPage.users.map((u) => (
+                      <tr key={u.id} className="border-t border-line">
+                        <td className="py-3 pr-4">
+                          <div className="flex items-center gap-3">
+                            <Avatar image={u.profilePicture} loading={false} id={u.id} size="small" level={0} />
+                            <span className="text-ink">{u.username}</span>
+                            {u.isAdmin && (
+                              <span className="text-xs px-1.5 py-0.5 rounded bg-accent/20 text-accent-light">admin</span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="py-3 pr-4 text-ink-soft">{u.level}</td>
+                        <td className="py-3 pr-4 text-ink-soft"><Monetary value={Math.floor(u.walletBalance)} /></td>
+                        <td className="py-3 pr-4 text-ink-soft"><Monetary value={u.wagered} /></td>
+                        <td className="py-3 pr-4 text-ink-muted">{new Date(u.joined).toLocaleDateString()}</td>
+                        <td className="py-3 pr-4 text-ink-muted">
+                          {u.lastActive ? new Date(u.lastActive).toLocaleDateString() : "-"}
+                        </td>
+                        <td className="py-3 text-ink-muted">{u.referredBy || "-"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="flex items-center justify-between mt-3 text-sm text-ink-muted">
+                <span>{usersPage.total.toLocaleString()} users</span>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setPage(page - 1)}
+                    disabled={page <= 1}
+                    className="px-3 py-1.5 rounded-md bg-surface-raised disabled:opacity-40 text-ink"
+                  >
+                    Prev
+                  </button>
+                  <span>{usersPage.page} / {usersPage.pages}</span>
+                  <button
+                    onClick={() => setPage(page + 1)}
+                    disabled={page >= usersPage.pages}
+                    className="px-3 py-1.5 rounded-md bg-surface-raised disabled:opacity-40 text-ink"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+};
+
+export default BackofficeView;

--- a/src/services/admin/AdminServices.ts
+++ b/src/services/admin/AdminServices.ts
@@ -1,0 +1,68 @@
+import api from "../api";
+
+export interface AdminOverview {
+  users: { total: number; new: number; active: number };
+  economy: { supply: number; houseBalance: number; escrow: number };
+}
+
+export interface GameLine {
+  game: string;
+  plays: number;
+  wagered: number;
+  paidOut: number;
+  net: number;
+}
+
+export interface AdminGameStats {
+  games: GameLine[];
+  houseLines: { type: string; net: number; count: number }[];
+  issuance: { type: string; issued: number; count: number }[];
+}
+
+export interface AdminCaseRow {
+  caseId: string;
+  title: string;
+  image: string | null;
+  price: number | null;
+  opens: number;
+  spent: number;
+  lastOpened: string;
+}
+
+export interface AdminUserRow {
+  id: string;
+  username: string;
+  profilePicture: string;
+  level: number;
+  walletBalance: number;
+  isAdmin: boolean;
+  joined: string;
+  wagered: number;
+  lastActive: string | null;
+  referredBy: string | null;
+}
+
+export interface AdminUsersPage {
+  total: number;
+  page: number;
+  pages: number;
+  users: AdminUserRow[];
+}
+
+const withDays = (days: number | null) => (days ? { days } : {});
+
+export const getAdminOverview = async (days: number | null): Promise<AdminOverview> =>
+  (await api.get("/admin/stats/overview", { params: withDays(days) })).data;
+
+export const getAdminGameStats = async (days: number | null): Promise<AdminGameStats> =>
+  (await api.get("/admin/stats/games", { params: withDays(days) })).data;
+
+export const getAdminCaseStats = async (days: number | null): Promise<AdminCaseRow[]> =>
+  (await api.get("/admin/stats/cases", { params: withDays(days) })).data;
+
+export const getAdminUserStats = async (
+  days: number | null,
+  page: number,
+  search: string
+): Promise<AdminUsersPage> =>
+  (await api.get("/admin/stats/users", { params: { ...withDays(days), page, search } })).data;


### PR DESCRIPTION
## The feature

An admin-only `/backoffice` page (nav entry appears only for admins; the API refuses everyone else) answering:

- **Users**: total, new in the window, how many actually played, plus a paginated, searchable user table with balance, level, wagered total, join date, last activity and who referred them.
- **Most opened case**: ranking from the `case_open` rows, summing quantities, spend per case, tolerant of deleted cases.
- **Most played games / profit and deficit**: per-game table (plays, wagered, paid out, house net) sorted most-profitable first; a game paying out more than it takes shows red.
- **Where the coins go**: other house lines (market fees in, item buybacks out) and the faucets (signup, bonus, missions, referrals) grouped dynamically by type, so any future money line appears without code changes.
- Headline economy: KP in circulation, house balance, all from the same source.

Every number is **derived from the transaction ledger at read time** - no side counters to drift. All endpoints take `?days=7|30` (all-time default). One quirk handled: market fees are booked with HOUSE as the row's owner, so the house breakdown reads both sides of a row, same as `accountBalance`.

## API

`GET /admin/stats/overview | games | cases | users` (all `isAuthenticated, isAdmin`), logic in `utils/adminStats.js`. `/users/me` now returns the caller's own `isAdmin` so the frontend can gate the page - the public `/users/:id` keeps hiding it (existing test still enforces that). A `{type, createdAt}` index backs the aggregations.

## Tests

7 new integration tests: auth gate on every endpoint, `/me` admin flag, overview counts and economy derivation, per-game nets and house/issuance split, case ranking with quantities and deleted cases, user paging + regex-safe search + wager sums, and the `?days=` window. Backend 293/293, frontend typecheck/lint/build/unit/e2e green.