### PR TITLE
Referrals: bigger rewards, level-10 milestone, profile tab

### DIFF
--- a/backend/__tests__/integration/ledgerAtomicity.test.js
+++ b/backend/__tests__/integration/ledgerAtomicity.test.js
@@ -244,3 +244,38 @@ test("concurrent commission claims pay exactly once", async () => {
   expect((await User.findById(me._id)).referralClaimed).toBe(10);
   expect(await Transaction.countDocuments({ userId: me._id, type: TX.REFERRAL_COMMISSION })).toBe(1);
 });
+
+const { maybePayReferralMilestone, MILESTONE_LEVEL, MILESTONE_BONUS } = require("../../utils/referrals");
+
+async function referredPair() {
+  const referrer = await makeUser(0);
+  const referee = await makeUser(1000);
+  await User.updateOne({ _id: referee._id }, { $set: { referredBy: referrer._id } });
+  return { referrer, referee };
+}
+
+test("a failed milestone credit rolls the paid flag back", async () => {
+  const { referrer, referee } = await referredPair();
+  jest.spyOn(Transaction, "create").mockRejectedValueOnce(new Error("row write failed"));
+
+  await maybePayReferralMilestone(referee._id, MILESTONE_LEVEL); // swallows the abort
+
+  expect((await User.findById(referee._id)).referralMilestonePaid).not.toBe(true); // still owed
+  expect((await User.findById(referrer._id)).walletBalance).toBe(0);
+  jest.restoreAllMocks();
+
+  await maybePayReferralMilestone(referee._id, MILESTONE_LEVEL); // the next level event pays
+  expect((await User.findById(referrer._id)).walletBalance).toBe(MILESTONE_BONUS);
+});
+
+test("concurrent milestone triggers pay exactly once", async () => {
+  const { referrer, referee } = await referredPair();
+
+  await Promise.all([
+    maybePayReferralMilestone(referee._id, MILESTONE_LEVEL),
+    maybePayReferralMilestone(referee._id, MILESTONE_LEVEL),
+  ]);
+
+  expect((await User.findById(referrer._id)).walletBalance).toBe(MILESTONE_BONUS);
+  expect(await Transaction.countDocuments({ userId: referrer._id, type: TX.REFERRAL_MILESTONE })).toBe(1);
+});

--- a/backend/__tests__/integration/referrals.test.js
+++ b/backend/__tests__/integration/referrals.test.js
@@ -1,14 +1,41 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
 
+// the google login path verifies a real token; stand in for google so a fake token
+// resolves to whatever payload the test sets
+let mockGooglePayload = null;
+jest.mock("google-auth-library", () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn().mockImplementation(() => Promise.resolve({ getPayload: () => mockGooglePayload })),
+  })),
+}));
+
 const request = require("supertest");
 const { setupDb, clearDb, teardownDb } = require("./db");
 const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
 
 const User = require("../../models/User");
 const Transaction = require("../../models/Transaction");
-const { TX } = require("../../utils/economy");
+const Notification = require("../../models/Notification");
+const { TX, awardXp, calculateXPForLevel } = require("../../utils/economy");
 const { HOUSE, MINT } = require("../../utils/accounts");
-const { REFERRAL_SIGNUP_BONUS, COMMISSION_RATE } = require("../../utils/referrals");
+const {
+  REFERRER_SIGNUP_BONUS,
+  REFEREE_SIGNUP_BONUS,
+  MILESTONE_LEVEL,
+  MILESTONE_BONUS,
+  COMMISSION_RATE,
+  maybePayReferralMilestone,
+} = require("../../utils/referrals");
+
+// the level hooks fire and forget, so tests wait for the money to land
+async function waitFor(check, ms = 2000) {
+  const start = Date.now();
+  for (;;) {
+    if (await check()) return true;
+    if (Date.now() - start > ms) return false;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
 
 let app;
 
@@ -90,7 +117,7 @@ describe("POST /referrals/code", () => {
 });
 
 describe("registering through a referral link", () => {
-  test("both sides get the signup bonus and a minted ledger row", async () => {
+  test("the referee gets 500, the referrer 1000, both minted and both notified", async () => {
     const referrer = await makeUser({ referralCode: "FRIEND", walletBalance: 0 });
 
     const res = await registerWith("friend"); // lowercase on purpose
@@ -98,15 +125,17 @@ describe("registering through a referral link", () => {
 
     const referee = await User.findOne({ referredBy: referrer._id });
     expect(referee).not.toBeNull();
-    expect(referee.walletBalance).toBe(200 + REFERRAL_SIGNUP_BONUS);
-    expect((await User.findById(referrer._id)).walletBalance).toBe(REFERRAL_SIGNUP_BONUS);
+    expect(referee.walletBalance).toBe(200 + REFEREE_SIGNUP_BONUS);
+    expect((await User.findById(referrer._id)).walletBalance).toBe(REFERRER_SIGNUP_BONUS);
 
     const rows = await Transaction.find({ type: TX.REFERRAL_BONUS }).lean();
     expect(rows).toHaveLength(2);
-    expect(rows.every((r) => r.direction === "credit" && r.amount === REFERRAL_SIGNUP_BONUS)).toBe(true);
-    expect(rows.every((r) => String(r.counterparty) === String(MINT))).toBe(true);
-    const roles = rows.map((r) => r.meta.role).sort();
-    expect(roles).toEqual(["referee", "referrer"]);
+    expect(rows.every((r) => r.direction === "credit" && String(r.counterparty) === String(MINT))).toBe(true);
+    const byRole = Object.fromEntries(rows.map((r) => [r.meta.role, r.amount]));
+    expect(byRole).toEqual({ referee: REFEREE_SIGNUP_BONUS, referrer: REFERRER_SIGNUP_BONUS });
+
+    expect(await Notification.countDocuments({ receiverId: referee._id, title: "Referral bonus" })).toBe(1);
+    expect(await Notification.countDocuments({ receiverId: referrer._id, title: "Referral bonus" })).toBe(1);
   });
 
   test("an unknown code is ignored and the signup still succeeds", async () => {
@@ -116,6 +145,119 @@ describe("registering through a referral link", () => {
     const created = await User.findOne({ email: /new-/ });
     expect(created.referredBy).toBeUndefined();
     expect(created.walletBalance).toBe(200);
+  });
+});
+
+describe("google sign-in with a referral code", () => {
+  const googleLogin = (referralCode) =>
+    request(app).post("/users/googlelogin").send({ token: "fake", referralCode });
+
+  test("a first google sign-in is a registration: both bonuses land", async () => {
+    const referrer = await makeUser({ referralCode: "GFRIEND", walletBalance: 0 });
+    const s = uniqueSuffix();
+    mockGooglePayload = { email: `g-${s}@x.com`, name: `g-${s}`, picture: "p.png" };
+
+    const res = await googleLogin("GFRIEND");
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeTruthy();
+
+    const referee = await User.findOne({ email: mockGooglePayload.email });
+    expect(String(referee.referredBy)).toBe(String(referrer._id));
+    expect(referee.walletBalance).toBe(200 + REFEREE_SIGNUP_BONUS);
+    expect((await User.findById(referrer._id)).walletBalance).toBe(REFERRER_SIGNUP_BONUS);
+  });
+
+  test("an existing account logging in with a code gets and changes nothing", async () => {
+    const referrer = await makeUser({ referralCode: "GFRIEND2", walletBalance: 0 });
+    const existing = await makeUser({ walletBalance: 777 });
+    mockGooglePayload = { email: existing.email, name: existing.username, picture: "p.png" };
+
+    const res = await googleLogin("GFRIEND2");
+    expect(res.status).toBe(200);
+
+    const after = await User.findById(existing._id);
+    expect(after.referredBy).toBeUndefined();
+    expect(after.walletBalance).toBe(777);
+    expect((await User.findById(referrer._id)).walletBalance).toBe(0);
+    expect(await Transaction.countDocuments({ type: TX.REFERRAL_BONUS })).toBe(0);
+  });
+});
+
+describe("the level milestone", () => {
+  test("a referee reaching the level pays the referrer once, with notifications", async () => {
+    const referrer = await makeUser({ walletBalance: 0 });
+    const referee = await makeUser({ referredBy: referrer._id });
+
+    await maybePayReferralMilestone(referee._id, MILESTONE_LEVEL);
+
+    expect((await User.findById(referrer._id)).walletBalance).toBe(MILESTONE_BONUS);
+    expect((await User.findById(referee._id)).referralMilestonePaid).toBe(true);
+    const row = await Transaction.findOne({ userId: referrer._id, type: TX.REFERRAL_MILESTONE });
+    expect(row.amount).toBe(MILESTONE_BONUS);
+    expect(String(row.counterparty)).toBe(String(MINT));
+    expect(await Notification.countDocuments({ title: "Referral milestone" })).toBe(2);
+
+    // reaching further levels never pays again
+    await maybePayReferralMilestone(referee._id, MILESTONE_LEVEL + 3);
+    expect((await User.findById(referrer._id)).walletBalance).toBe(MILESTONE_BONUS);
+    expect(await Transaction.countDocuments({ type: TX.REFERRAL_MILESTONE })).toBe(1);
+  });
+
+  test("below the level, or with no referrer, nothing happens", async () => {
+    const referrer = await makeUser({ walletBalance: 0 });
+    const referee = await makeUser({ referredBy: referrer._id });
+    const loner = await makeUser();
+
+    await maybePayReferralMilestone(referee._id, MILESTONE_LEVEL - 1);
+    await maybePayReferralMilestone(loner._id, MILESTONE_LEVEL);
+
+    expect((await User.findById(referrer._id)).walletBalance).toBe(0);
+    expect(await Transaction.countDocuments({ type: TX.REFERRAL_MILESTONE })).toBe(0);
+  });
+
+  test("levelling up through play triggers the payout by itself", async () => {
+    const referrer = await makeUser({ walletBalance: 0 });
+    const referee = await makeUser({ referredBy: referrer._id });
+
+    await awardXp(referee._id, calculateXPForLevel(MILESTONE_LEVEL));
+
+    const paid = await waitFor(async () =>
+      (await User.findById(referrer._id)).walletBalance === MILESTONE_BONUS
+    );
+    expect(paid).toBe(true);
+    expect((await User.findById(referee._id)).level).toBeGreaterThanOrEqual(MILESTONE_LEVEL);
+  });
+});
+
+describe("real-money mode turns referrals off", () => {
+  beforeEach(() => {
+    process.env.REAL_MONEY_MODE = "true";
+  });
+  afterEach(() => {
+    delete process.env.REAL_MONEY_MODE;
+  });
+
+  test("registration ignores codes entirely", async () => {
+    const referrer = await makeUser({ referralCode: "OFFMODE", walletBalance: 0 });
+    const res = await registerWith("OFFMODE");
+    expect(res.status).toBe(200);
+    expect(await User.findOne({ referredBy: referrer._id })).toBeNull();
+    expect(await Transaction.countDocuments({ type: TX.REFERRAL_BONUS })).toBe(0);
+  });
+
+  test("the dashboard reports disabled and the write endpoints refuse", async () => {
+    const u = await makeUser();
+    const me = await auth(request(app).get("/referrals/me"), u);
+    expect(me.body).toEqual({ enabled: false });
+    expect((await auth(request(app).post("/referrals/code"), u).send({ code: "ABC" })).status).toBe(403);
+    expect((await auth(request(app).post("/referrals/claim"), u)).status).toBe(403);
+  });
+
+  test("the milestone does not pay", async () => {
+    const referrer = await makeUser({ walletBalance: 0 });
+    const referee = await makeUser({ referredBy: referrer._id });
+    await maybePayReferralMilestone(referee._id, MILESTONE_LEVEL);
+    expect((await User.findById(referrer._id)).walletBalance).toBe(0);
   });
 });
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -107,6 +107,11 @@ const UserSchema = new mongoose.Schema({
     type: Number,
     default: 0,
   },
+  // the level-10 reward went to this user's referrer; set once, never unset
+  referralMilestonePaid: {
+    type: Boolean,
+    default: false,
+  },
 
 });
 

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -8,6 +8,7 @@ const Round = require("../models/Round");
 const upgradeItems = require("../games/upgrade");
 const SlotGameController = require("../games/slot");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
+const referrals = require("../utils/referrals");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
 const { buildRangeTable } = require("../utils/caseRanges");
 const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
@@ -134,6 +135,7 @@ module.exports = (io) => {
       if (newLevel !== updatedUser.level) {
         updatedUser.level = newLevel;
         await User.updateOne({ _id: user._id }, { $set: { level: newLevel } });
+        referrals.maybePayReferralMilestone(user._id, newLevel).catch(() => {});
       }
 
       const winnerUser = {

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -17,6 +17,7 @@ const COUNTERPARTY_FOR_TYPE = {
   bonus: MINT,
   mission_reward: MINT,
   referral_bonus: MINT,
+  referral_milestone: MINT,
   referral_commission: HOUSE, // the house shares its edge with the affiliate
   admin_adjust: MINT,
   case_open: HOUSE,

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -32,6 +32,7 @@ const TX = {
   MISSION_REWARD: "mission_reward",
   REFERRAL_BONUS: "referral_bonus", // one-time signup bonus, both sides of a referral
   REFERRAL_COMMISSION: "referral_commission", // the referrer's cut of referred wagers
+  REFERRAL_MILESTONE: "referral_milestone", // one-time payout when a referee reaches level 10
   OPENING: "opening_balance", // the pre-ledger balance, booked once against genesis
 };
 
@@ -171,7 +172,12 @@ async function chargeUser(userId, cost, { awardXp = true, type, meta, counterpar
   // joining a caller's transaction: let a failure propagate so their whole op aborts
   if (session) return body(session);
   try {
-    return await runAtomic(body);
+    const user = await runAtomic(body);
+    // the level may have crossed the referral milestone; lazy require breaks the cycle
+    if (user && awardXp) {
+      require("./referrals").maybePayReferralMilestone(userId, user.level).catch(() => {});
+    }
+    return user;
   } catch (err) {
     console.error("chargeUser rolled back:", err);
     return null;
@@ -222,6 +228,7 @@ async function awardXp(userId, xpAmount) {
   if (newLevel !== user.level) {
     user.level = newLevel;
     await User.updateOne({ _id: userId }, { $set: { level: newLevel } });
+    require("./referrals").maybePayReferralMilestone(userId, newLevel).catch(() => {});
   }
   return user;
 }

--- a/backend/utils/referrals.js
+++ b/backend/utils/referrals.js
@@ -1,19 +1,37 @@
 const User = require("../models/User");
 const Transaction = require("../models/Transaction");
+const Notification = require("../models/Notification");
 const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
+const { isRealMoneyMode } = require("./mode");
 
-// both sides of a referral get this once, at the referee's registration
-const REFERRAL_SIGNUP_BONUS = 100;
+// what each side gets when the referee registers
+const REFERRER_SIGNUP_BONUS = 1000;
+const REFEREE_SIGNUP_BONUS = 500;
+// paid to the referrer once, when the referee proves real by reaching this level
+const MILESTONE_LEVEL = 10;
+const MILESTONE_BONUS = 10000;
 // the referrer's ongoing cut of everything their referees wager, paid by the house
 const COMMISSION_RATE = 0.01;
 // a referee counts as active if they wagered within this window
 const ACTIVE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
+// referrals mint marketing KP, which only makes sense while balances are play money
+const referralsEnabled = () => !isRealMoneyMode();
+
 const CODE_PATTERN = /^[A-Z0-9]{3,16}$/;
 const normalizeCode = (raw) => String(raw || "").trim().toUpperCase();
 
+// in-app notification; the bell picks it up on the next fetch, no socket needed here
+const notify = (receiverId, senderId, title, content) =>
+  Notification.create({ receiverId, senderId, type: "message", title, content }).catch((err) =>
+    console.error("referral notify failed:", err)
+  );
+
 // set the user's vanity code once; it never changes so shared links never rot
 async function setReferralCode(userId, raw) {
+  if (!referralsEnabled()) {
+    return { code: 403, body: { message: "Referrals are disabled" } };
+  }
   const code = normalizeCode(raw);
   if (!CODE_PATTERN.test(code)) {
     return { code: 400, body: { message: "Codes are 3-16 letters or numbers" } };
@@ -36,6 +54,7 @@ async function setReferralCode(userId, raw) {
 }
 
 const findReferrer = (raw) => {
+  if (!referralsEnabled()) return null;
   const code = normalizeCode(raw);
   if (!CODE_PATTERN.test(code)) return null;
   return User.findOne({ referralCode: code }, { _id: 1, username: 1 });
@@ -44,14 +63,65 @@ const findReferrer = (raw) => {
 // the one-time signup bonuses. issuance (minted), so a failed leg is just a lost gift,
 // never a corrupt ledger; registration must not fail over it
 async function payReferralBonuses(referee, referrer) {
-  await creditUser(referee._id, REFERRAL_SIGNUP_BONUS, 0, {
+  await creditUser(referee._id, REFEREE_SIGNUP_BONUS, 0, {
     type: TX.REFERRAL_BONUS,
     meta: { role: "referee", referrerId: String(referrer._id), referrerUsername: referrer.username },
   });
-  await creditUser(referrer._id, REFERRAL_SIGNUP_BONUS, 0, {
+  await creditUser(referrer._id, REFERRER_SIGNUP_BONUS, 0, {
     type: TX.REFERRAL_BONUS,
     meta: { role: "referrer", referredUserId: String(referee._id), referredUsername: referee.username },
   });
+  await notify(
+    referee._id, referrer._id, "Referral bonus",
+    `Welcome! Signing up with ${referrer.username}'s code paid you K₽${REFEREE_SIGNUP_BONUS}.`
+  );
+  await notify(
+    referrer._id, referee._id, "Referral bonus",
+    `${referee.username} joined with your code: +K₽${REFERRER_SIGNUP_BONUS}. If they reach level ${MILESTONE_LEVEL} you earn K₽${MILESTONE_BONUS} more.`
+  );
+}
+
+// pay the level milestone once per referee. the paid flag is the mutex and commits in
+// one transaction with the credit, so a failed payout rolls it back and retries later.
+async function maybePayReferralMilestone(userId, level) {
+  if (!referralsEnabled() || level < MILESTONE_LEVEL) return;
+  const referee = await User.findOne(
+    { _id: userId, referredBy: { $ne: null }, referralMilestonePaid: { $ne: true } },
+    { username: 1, referredBy: 1 }
+  );
+  if (!referee) return;
+
+  try {
+    const paid = await runAtomic(async (session) => {
+      const res = await User.updateOne(
+        { _id: userId, referralMilestonePaid: { $ne: true } },
+        { $set: { referralMilestonePaid: true } },
+        { session }
+      );
+      if (res.modifiedCount !== 1) return null; // a concurrent level-up already paid it
+      const credited = await creditUser(referee.referredBy, MILESTONE_BONUS, 0, {
+        type: TX.REFERRAL_MILESTONE,
+        meta: { referredUserId: String(userId), referredUsername: referee.username, level: MILESTONE_LEVEL },
+        session,
+      });
+      if (!credited) throw new Error("milestone credit failed"); // abort, flag rolls back
+      return credited;
+    });
+    if (paid === null) return;
+  } catch (e) {
+    console.error("referral milestone failed:", e);
+    return;
+  }
+
+  const referrer = await User.findById(referee.referredBy, { username: 1 });
+  await notify(
+    referee.referredBy, userId, "Referral milestone",
+    `${referee.username} reached level ${MILESTONE_LEVEL}: +K₽${MILESTONE_BONUS}.`
+  );
+  await notify(
+    userId, referee.referredBy, "Referral milestone",
+    `You reached level ${MILESTONE_LEVEL} and ${referrer ? referrer.username : "your referrer"} earned K₽${MILESTONE_BONUS}.`
+  );
 }
 
 // per-referee wagered totals from the ledger; commission is derived, never accumulated,
@@ -59,7 +129,7 @@ async function payReferralBonuses(referee, referrer) {
 async function refereeStats(userId) {
   const referees = await User.find(
     { referredBy: userId },
-    { username: 1, profilePicture: 1 }
+    { username: 1, profilePicture: 1, level: 1, referralMilestonePaid: 1 }
   ).lean();
   if (!referees.length) return [];
 
@@ -79,6 +149,8 @@ async function refereeStats(userId) {
       username: r.username,
       profilePicture: r.profilePicture || "",
       joinedAt: r._id.getTimestamp(),
+      level: r.level || 0,
+      milestonePaid: !!r.referralMilestonePaid,
       wagered,
       commission: Math.floor(wagered * COMMISSION_RATE),
       active: !!row && now - new Date(row.lastAt).getTime() < ACTIVE_WINDOW_MS,
@@ -90,6 +162,7 @@ async function refereeStats(userId) {
 const earnedFrom = (referrals) => referrals.reduce((s, r) => s + r.commission, 0);
 
 async function getDashboard(userId) {
+  if (!referralsEnabled()) return { enabled: false };
   const [me, referrals] = await Promise.all([
     User.findById(userId, { referralCode: 1, referralClaimed: 1 }),
     refereeStats(userId),
@@ -99,8 +172,12 @@ async function getDashboard(userId) {
   const earned = earnedFrom(referrals);
   const claimed = me.referralClaimed || 0;
   return {
+    enabled: true,
     referralCode: me.referralCode || null,
-    signupBonus: REFERRAL_SIGNUP_BONUS,
+    referrerBonus: REFERRER_SIGNUP_BONUS,
+    refereeBonus: REFEREE_SIGNUP_BONUS,
+    milestoneLevel: MILESTONE_LEVEL,
+    milestoneBonus: MILESTONE_BONUS,
     commissionRate: COMMISSION_RATE,
     totals: {
       earned,
@@ -117,6 +194,7 @@ async function getDashboard(userId) {
 // pay out everything earned but not yet claimed. the claimed-counter update is the
 // mutex and commits in one transaction with the credit, like a mission claim.
 async function claimCommission(userId) {
+  if (!referralsEnabled()) return { code: 403, body: { message: "Referrals are disabled" } };
   const me = await User.findById(userId, { referralClaimed: 1 });
   if (!me) return { code: 404, body: { message: "User not found" } };
 
@@ -156,12 +234,17 @@ async function claimCommission(userId) {
 }
 
 module.exports = {
-  REFERRAL_SIGNUP_BONUS,
+  REFERRER_SIGNUP_BONUS,
+  REFEREE_SIGNUP_BONUS,
+  MILESTONE_LEVEL,
+  MILESTONE_BONUS,
   COMMISSION_RATE,
+  referralsEnabled,
   normalizeCode,
   setReferralCode,
   findReferrer,
   payReferralBonuses,
+  maybePayReferralMilestone,
   getDashboard,
   claimCommission,
 };

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -12,7 +12,6 @@ import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
 import BattleRoom from "./pages/Battles/BattleRoom";
 import ProvablyFair from "./pages/ProvablyFair";
-import Affiliates from "./pages/Affiliates/Affiliates";
 import ReferralRedirect from "./pages/Affiliates/ReferralRedirect";
 import Backoffice from "./pages/Backoffice/Backoffice";
 
@@ -30,7 +29,6 @@ const defaultRoutes = (
     <Route path="/battles" element={<Battles />} />
     <Route path="/battles/:id" element={<BattleRoom />} />
     <Route path="/provably-fair" element={<ProvablyFair />} />
-    <Route path="/affiliates" element={<Affiliates />} />
     <Route path="/r/:code" element={<ReferralRedirect />} />
     <Route path="/backoffice" element={<Backoffice />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />

--- a/src/components/header/Navbar/Navbar.tsx
+++ b/src/components/header/Navbar/Navbar.tsx
@@ -13,7 +13,7 @@ import { SlPlane } from "react-icons/sl";
 import { GiUpgrade, GiCrossedSwords } from 'react-icons/gi';
 import { TbCat } from "react-icons/tb";
 import { toast } from "react-toastify";
-import { FaBars, FaUserFriends } from 'react-icons/fa';
+import { FaBars } from 'react-icons/fa';
 import RightContent from "./RightContent";
 
 interface Navbar {
@@ -94,11 +94,6 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
       name: "Case Battles",
       path: "/battles",
       icon: <GiCrossedSwords className="text-2xl" />,
-    },
-    {
-      name: "Affiliates",
-      path: "/affiliates",
-      icon: <FaUserFriends className="text-2xl" />,
     },
     // only admins see the backoffice; the api refuses everyone else anyway
     ...(userData?.isAdmin ? [{

--- a/src/components/header/Sidebar.tsx
+++ b/src/components/header/Sidebar.tsx
@@ -2,7 +2,7 @@ import { BsCoin } from "react-icons/bs";
 import { GiUpgrade, GiCrossedSwords } from "react-icons/gi";
 import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { SlPlane } from "react-icons/sl";
-import { FaHome, FaUserFriends } from "react-icons/fa";
+import { FaHome } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { TbCat } from "react-icons/tb";
 import ClaimBonus from "../header/ClaimBonus";
@@ -53,11 +53,6 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
             name: "Case Battles",
             path: "/battles",
             icon: <GiCrossedSwords className="text-2xl" />,
-        },
-        {
-            name: "Affiliates",
-            path: "/affiliates",
-            icon: <FaUserFriends className="text-2xl" />,
         },
         ...(userData?.isAdmin ? [{
             name: "Backoffice",

--- a/src/pages/Affiliates/Affiliates.tsx
+++ b/src/pages/Affiliates/Affiliates.tsx
@@ -1,6 +1,0 @@
-import { useAffiliatesServices } from "./Affiliates.services";
-import AffiliatesView from "./Affiliates.view";
-
-const Affiliates = () => <AffiliatesView {...useAffiliatesServices()} />;
-
-export default Affiliates;

--- a/src/pages/Affiliates/Affiliates.view.tsx
+++ b/src/pages/Affiliates/Affiliates.view.tsx
@@ -26,13 +26,14 @@ const StatCard = ({ label, children }: { label: string; children: React.ReactNod
   </div>
 );
 
-const ReferralTable = ({ referrals }: { referrals: ReferralRow[] }) => (
+const ReferralTable = ({ referrals, milestoneLevel }: { referrals: ReferralRow[]; milestoneLevel: number }) => (
   <div className="overflow-x-auto">
     <table className="w-full text-left text-sm">
       <thead>
         <tr className="text-ink-muted">
           <th className="font-medium py-2 pr-4">User</th>
           <th className="font-medium py-2 pr-4">Joined</th>
+          <th className="font-medium py-2 pr-4">Level</th>
           <th className="font-medium py-2 pr-4">Total wagered</th>
           <th className="font-medium py-2 pr-4">Commission earned</th>
           <th className="font-medium py-2">Status</th>
@@ -48,6 +49,17 @@ const ReferralTable = ({ referrals }: { referrals: ReferralRow[] }) => (
               </div>
             </td>
             <td className="py-3 pr-4 text-ink-soft">{new Date(r.joinedAt).toLocaleDateString()}</td>
+            <td className="py-3 pr-4 text-ink-soft">
+              {r.level}
+              {r.milestonePaid && (
+                <span
+                  className="ml-2 text-xs px-1.5 py-0.5 rounded bg-accent-gold/15 text-accent-gold"
+                  title={`Reached level ${milestoneLevel}, milestone paid`}
+                >
+                  paid
+                </span>
+              )}
+            </td>
             <td className="py-3 pr-4 text-ink-soft">
               <Monetary value={r.wagered} />
             </td>
@@ -74,30 +86,29 @@ const AffiliatesView: React.FC<Props> = ({
   }
   if (loading) {
     return (
-      <div className="w-full flex justify-center">
-        <div className="w-full max-w-[1100px] px-4 py-8">
-          <Skeleton height={320} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />
-        </div>
+      <div className="w-full max-w-[1100px]">
+        <Skeleton height={320} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />
       </div>
     );
   }
   if (error || !data) {
     return <div className="w-full flex justify-center py-16 text-ink-muted">Could not load your referrals.</div>;
   }
+  if (!data.enabled) {
+    return <div className="w-full flex justify-center py-16 text-ink-muted">Referrals are turned off right now.</div>;
+  }
 
   const { totals } = data;
 
   return (
-    <div className="w-full flex justify-center">
-      <div className="w-full max-w-[1100px] px-4 py-8 flex flex-col gap-6">
-        <div>
-          <h1 className="text-2xl font-semibold text-ink">Refer friends</h1>
-          <p className="text-ink-muted mt-1">
-            You both get <span className="text-accent-gold">+{data.signupBonus} K₽</span> when a friend signs up
-            with your link, and you keep earning{" "}
-            <span className="text-accent-gold">{Math.round(data.commissionRate * 100)}%</span> of everything they wager.
-          </p>
-        </div>
+    <div className="w-full max-w-[1100px] flex flex-col gap-6">
+        <p className="text-ink-muted">
+          Bring a friend: they start with <span className="text-accent-gold">+{data.refereeBonus} K₽</span>, you
+          get <span className="text-accent-gold">+{data.referrerBonus} K₽</span>, and when they reach level{" "}
+          {data.milestoneLevel} you earn <span className="text-accent-gold">+{data.milestoneBonus.toLocaleString()} K₽</span> more.
+          On top, <span className="text-accent-gold">{Math.round(data.commissionRate * 100)}%</span> of everything
+          they wager is yours to claim.
+        </p>
 
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
           <StatCard label="Total earned">
@@ -167,10 +178,9 @@ const AffiliatesView: React.FC<Props> = ({
               No one yet. Share your link and both of you get paid.
             </p>
           ) : (
-            <ReferralTable referrals={data.referrals} />
+            <ReferralTable referrals={data.referrals} milestoneLevel={data.milestoneLevel} />
           )}
         </div>
-      </div>
     </div>
   );
 };

--- a/src/pages/Affiliates/AffiliatesPanel.tsx
+++ b/src/pages/Affiliates/AffiliatesPanel.tsx
@@ -1,0 +1,22 @@
+import { useAffiliatesServices } from "./Affiliates.services";
+import AffiliatesView from "./Affiliates.view";
+
+interface Props {
+  isOwner: boolean;
+}
+
+// the affiliates tab. referrals are always the logged-in user's own program, so the
+// tab only renders on your own profile.
+const AffiliatesPanel: React.FC<Props> = ({ isOwner }) => {
+  const service = useAffiliatesServices();
+  if (!isOwner) {
+    return <p className="text-ink-muted py-8 text-center">Referrals are private.</p>;
+  }
+  return (
+    <div className="w-full flex justify-center">
+      <AffiliatesView {...service} />
+    </div>
+  );
+};
+
+export default AffiliatesPanel;

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -41,6 +41,7 @@ const LINE_LABELS: Record<string, string> = {
   signup: "Signup balance",
   mission_reward: "Mission rewards",
   referral_bonus: "Referral bonuses",
+  referral_milestone: "Referral milestones",
   referral_commission: "Referral commission",
   admin_adjust: "Admin adjustments",
 };

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -12,6 +12,7 @@ import Pagination from "../../components/Pagination";
 import BalanceHistory from "./BalanceHistory";
 import CollectionsPanel from "../Collections/CollectionsPanel";
 import MissionsPanel from "../Missions/MissionsPanel";
+import AffiliatesPanel from "../Affiliates/AffiliatesPanel";
 import { resolveTab, Tab } from "./tabs";
 import { User } from '../../components/Types'
 
@@ -22,7 +23,7 @@ interface Inventory {
 }
 
 // tabs that show a "NEW!" badge until the owner opens them for the first time
-const NEW_TABS = ["collections", "missions"];
+const NEW_TABS = ["collections", "missions", "affiliates"];
 
 const Profile = () => {
   const { id } = useParams();
@@ -147,6 +148,7 @@ const Profile = () => {
     ...(isSameUser
       ? [
           { key: "missions" as const, label: "Missions" },
+          { key: "affiliates" as const, label: "Affiliates" },
           { key: "history" as const, label: "Balance history" },
         ]
       : []),
@@ -224,6 +226,8 @@ const Profile = () => {
             <BalanceHistory />
           ) : activeTab === "missions" ? (
             <MissionsPanel userId={id as string} isOwner={isSameUser} />
+          ) : activeTab === "affiliates" ? (
+            <AffiliatesPanel isOwner={isSameUser} />
           ) : activeTab === "collections" ? (
             <CollectionsPanel userId={id as string} isOwner={isSameUser} />
           ) : (

--- a/src/pages/Profile/tabs.ts
+++ b/src/pages/Profile/tabs.ts
@@ -1,4 +1,4 @@
-export type Tab = "inventory" | "collections" | "history" | "missions";
+export type Tab = "inventory" | "collections" | "history" | "missions" | "affiliates";
 
 // the url is the source of truth for the tab. owner-only tabs collapse to inventory
 // whenever isOwner is false, which covers both "not the owner" and "ownership not
@@ -6,6 +6,6 @@ export type Tab = "inventory" | "collections" | "history" | "missions";
 export const resolveTab = (param: string | null, isOwner: boolean): Tab =>
   param === "collections"
     ? "collections"
-    : (param === "missions" || param === "history") && isOwner
+    : (param === "missions" || param === "history" || param === "affiliates") && isOwner
     ? param
     : "inventory";

--- a/src/services/referrals/ReferralServices.ts
+++ b/src/services/referrals/ReferralServices.ts
@@ -5,14 +5,21 @@ export interface ReferralRow {
   username: string;
   profilePicture: string;
   joinedAt: string;
+  level: number;
+  milestonePaid: boolean;
   wagered: number;
   commission: number;
   active: boolean;
 }
 
+// when referrals are disabled (real-money mode) the api returns only { enabled: false }
 export interface ReferralDashboard {
+  enabled: boolean;
   referralCode: string | null;
-  signupBonus: number;
+  referrerBonus: number;
+  refereeBonus: number;
+  milestoneLevel: number;
+  milestoneBonus: number;
   commissionRate: number;
   totals: {
     earned: number;


### PR DESCRIPTION
Stacked on #149 (branch base is `feat/backoffice`; merge that first and this retargets to `main` automatically).

## New reward structure

- Referrer: **+1,000 KP** when someone signs up with their code.
- New player: **+500 KP** on top of the normal starting balance.
- Referrer again: **+10,000 KP** when that player reaches **level 10**.
- The 1% wager commission stays as-is.

The milestone pays once per referee: a paid flag on the referee is the mutex, committed in one transaction with the credit (failed payout rolls back, the next level-up retries; concurrent level-ups pay once - both proven on the replica-set suite). It hooks every site where a level can change (bets, battle XP, case opens). **Both sides get in-app notifications** for the signup bonuses and the milestone.

## Fake-balance only

With `REAL_MONEY_MODE=true` the whole program shuts off: codes stop resolving at registration, the write endpoints refuse, the dashboard reports `enabled: false` (the tab shows it's off), and the milestone never pays.

## Placement

The affiliates screen moves out of the navbar into a **Profile tab** (like Missions, with the NEW badge); only the `/r/<code>` landing route remains. The referrals table now also shows each referee's level and whether their milestone paid.

## Google sign-in, now proven by tests

- A **first** Google login with a referral code counts as registration: both bonuses land, `referredBy` is set.
- An **existing** account logging in via Google with a code in hand: nothing happens - no bonus, no link, balance untouched.

## Tests

21 referral integration tests (amounts, notifications, google both ways, milestone once-only and threshold, mode gate) + 2 replica-set milestone atomicity tests. Backend 303/303 twice, frontend typecheck/lint/build/unit/e2e green.