### PR TITLE
Rewarded ads: watch a video, earn KP

### DIFF
--- a/backend/__tests__/integration/adRewards.test.js
+++ b/backend/__tests__/integration/adRewards.test.js
@@ -1,0 +1,146 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+// tests should not sit through a real watch window
+process.env.AD_REWARD_MIN_WATCH_MS = "50";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const AdWatch = require("../../models/AdWatch");
+const { TX } = require("../../utils/economy");
+const { MINT } = require("../../utils/accounts");
+const { AD_REWARD_AMOUNT, AD_REWARD_DAILY_CAP } = require("../../utils/adRewards");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 0,
+    ...overrides,
+  });
+}
+
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+const start = (user) => auth(request(app).post("/rewards/ads/start"), user);
+const claim = (user, token) => auth(request(app).post("/rewards/ads/claim"), user).send({ token });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// a full legitimate view: start, wait out the minimum, claim
+async function watchOne(user) {
+  const s = await start(user);
+  expect(s.status).toBe(200);
+  await sleep(80);
+  return claim(user, s.body.token);
+}
+
+describe("rewarded ads", () => {
+  test("requires auth", async () => {
+    expect((await request(app).get("/rewards/ads")).status).toBe(401);
+    expect((await request(app).post("/rewards/ads/start")).status).toBe(401);
+  });
+
+  test("status reports the offer and what is left today", async () => {
+    const u = await makeUser();
+    const res = await auth(request(app).get("/rewards/ads"), u);
+    expect(res.body).toMatchObject({
+      enabled: true,
+      provider: "mock",
+      amount: AD_REWARD_AMOUNT,
+      dailyCap: AD_REWARD_DAILY_CAP,
+      remainingToday: AD_REWARD_DAILY_CAP,
+    });
+  });
+
+  test("a completed view pays once, minted, and counts down the day", async () => {
+    const u = await makeUser();
+    const res = await watchOne(u);
+
+    expect(res.status).toBe(200);
+    expect(res.body.claimed).toBe(AD_REWARD_AMOUNT);
+    expect(res.body.walletBalance).toBe(AD_REWARD_AMOUNT);
+    expect(res.body.remainingToday).toBe(AD_REWARD_DAILY_CAP - 1);
+    expect(res.body.user).toBeUndefined(); // the raw doc stays server-side
+
+    const row = await Transaction.findOne({ userId: u._id, type: TX.AD_REWARD });
+    expect(row.amount).toBe(AD_REWARD_AMOUNT);
+    expect(String(row.counterparty)).toBe(String(MINT));
+  });
+
+  test("claiming faster than a video could play is refused", async () => {
+    const u = await makeUser();
+    const s = await start(u);
+    const res = await claim(u, s.body.token); // immediate
+    expect(res.status).toBe(400);
+    expect((await User.findById(u._id)).walletBalance).toBe(0);
+  });
+
+  test("a token pays exactly once and only for its owner", async () => {
+    const u = await makeUser();
+    const other = await makeUser();
+    const s = await start(u);
+    await sleep(80);
+
+    expect((await claim(other, s.body.token)).status).toBe(400); // not theirs
+    expect((await claim(u, s.body.token)).status).toBe(200);
+    expect((await claim(u, s.body.token)).status).toBe(400); // spent
+    expect((await claim(u, "no-such-token")).status).toBe(400);
+    expect((await User.findById(u._id)).walletBalance).toBe(AD_REWARD_AMOUNT);
+  });
+
+  test("the daily cap stops both new tokens and further claims", async () => {
+    const u = await makeUser();
+    // the ledger already shows a full day of rewards
+    for (let i = 0; i < AD_REWARD_DAILY_CAP; i++) {
+      await Transaction.create({ userId: u._id, type: TX.AD_REWARD, direction: "credit", amount: AD_REWARD_AMOUNT });
+    }
+
+    expect((await start(u)).status).not.toBe(200); // no fresh token either way
+    const status = await auth(request(app).get("/rewards/ads"), u);
+    expect(status.body.remainingToday).toBe(0);
+
+    // a token hoarded from earlier cannot beat the cap at claim time
+    const hoarded = await AdWatch.create({ userId: u._id, token: `t-${uniqueSuffix()}` });
+    await sleep(80);
+    expect((await claim(u, hoarded.token)).status).toBe(429);
+    expect((await User.findById(u._id)).walletBalance).toBe(0);
+  });
+
+  test("sequential starts stop issuing at the cap", async () => {
+    const u = await makeUser();
+    let ok = 0;
+    for (let i = 0; i < AD_REWARD_DAILY_CAP + 3; i++) {
+      if ((await start(u)).status === 200) ok += 1;
+    }
+    expect(ok).toBe(AD_REWARD_DAILY_CAP);
+    expect(await AdWatch.countDocuments({ userId: u._id })).toBe(AD_REWARD_DAILY_CAP);
+  });
+});
+
+describe("real-money mode turns ad rewards off", () => {
+  beforeEach(() => {
+    process.env.REAL_MONEY_MODE = "true";
+  });
+  afterEach(() => {
+    delete process.env.REAL_MONEY_MODE;
+  });
+
+  test("status reports disabled and both endpoints refuse", async () => {
+    const u = await makeUser();
+    expect((await auth(request(app).get("/rewards/ads"), u)).body).toEqual({ enabled: false });
+    expect((await start(u)).status).toBe(403);
+    expect((await claim(u, "any")).status).toBe(403);
+  });
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -10,6 +10,7 @@ const collectionsRoutes = require("../../routes/collectionsRoutes");
 const missionsRoutes = require("../../routes/missionsRoutes");
 const adminRoutes = require("../../routes/adminRoutes");
 const referralRoutes = require("../../routes/referralRoutes");
+const rewardRoutes = require("../../routes/rewardRoutes");
 
 // no-op socket.io stand-in
 const io = { emit: () => {}, to: () => ({ emit: () => {} }) };
@@ -26,6 +27,7 @@ function makeApp() {
   app.use("/missions", missionsRoutes(io));
   app.use("/admin", adminRoutes);
   app.use("/referrals", referralRoutes(io));
+  app.use("/rewards", rewardRoutes(io));
   return app;
 }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -84,6 +84,7 @@ const fairRoutes = require("./routes/fairRoutes");
 const collectionsRoutes = require("./routes/collectionsRoutes");
 const missionsRoutes = require("./routes/missionsRoutes")(io);
 const referralRoutes = require("./routes/referralRoutes")(io);
+const rewardRoutes = require("./routes/rewardRoutes")(io);
 
 // Connect to MongoDB
 mongoose
@@ -127,6 +128,7 @@ app.use("/fair", fairRoutes);
 app.use("/collections", collectionsRoutes);
 app.use("/missions", missionsRoutes);
 app.use("/referrals", referralRoutes);
+app.use("/rewards", rewardRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.

--- a/backend/models/AdWatch.js
+++ b/backend/models/AdWatch.js
@@ -1,0 +1,28 @@
+const mongoose = require("mongoose");
+
+// one issued watch-token per rewarded ad view; claimed once, then kept only long
+// enough to count against the day before the ttl sweeps it
+const AdWatchSchema = new mongoose.Schema({
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+    required: true,
+    index: true,
+  },
+  token: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  claimedAt: {
+    type: Date,
+    default: null,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    expires: 60 * 60 * 24, // a day covers the daily cap window, then self-cleans
+  },
+});
+
+module.exports = mongoose.model("AdWatch", AdWatchSchema);

--- a/backend/routes/rewardRoutes.js
+++ b/backend/routes/rewardRoutes.js
@@ -1,0 +1,49 @@
+const express = require("express");
+const { isAuthenticated } = require("../middleware/authMiddleware");
+const adRewards = require("../utils/adRewards");
+
+module.exports = (io) => {
+  const router = express.Router();
+
+  // GET /rewards/ads : whether rewarded ads are on, which player to use, what is left today
+  router.get("/ads", isAuthenticated, async (req, res) => {
+    try {
+      res.json(await adRewards.getStatus(req.user._id));
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  // POST /rewards/ads/start : issue the one-time watch token
+  router.post("/ads/start", isAuthenticated, async (req, res) => {
+    try {
+      const r = await adRewards.startWatch(req.user._id);
+      res.status(r.code).json(r.body);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  // POST /rewards/ads/claim : redeem the token once the view is plausible (atomic)
+  router.post("/ads/claim", isAuthenticated, async (req, res) => {
+    try {
+      const r = await adRewards.claimWatch(req.user._id, req.body.token);
+      if (r.code === 200 && io) {
+        io.to(req.user._id.toString()).emit("userDataUpdated", {
+          walletBalance: r.body.user.walletBalance,
+          xp: r.body.user.xp,
+          level: r.body.user.level,
+        });
+      }
+      const { user, ...pub } = r.body;
+      res.status(r.code).json(pub);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
+  return router;
+};

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -18,6 +18,8 @@ const COUNTERPARTY_FOR_TYPE = {
   mission_reward: MINT,
   referral_bonus: MINT,
   referral_milestone: MINT,
+  ad_reward: MINT, // KP printed against outside ad revenue
+
   referral_commission: HOUSE, // the house shares its edge with the affiliate
   admin_adjust: MINT,
   case_open: HOUSE,

--- a/backend/utils/adRewards.js
+++ b/backend/utils/adRewards.js
@@ -1,0 +1,112 @@
+const { v4: uuidv4 } = require("uuid");
+const AdWatch = require("../models/AdWatch");
+const Transaction = require("../models/Transaction");
+const { creditUser, runAtomic, TX } = require("./economy");
+const { isRealMoneyMode } = require("./mode");
+
+const AD_REWARD_AMOUNT = 500;
+const AD_REWARD_DAILY_CAP = 10;
+// a claim younger than this cannot have played a real video; env override for tests
+const minWatchMs = () => Number(process.env.AD_REWARD_MIN_WATCH_MS || 5000);
+// which player the frontend should use; "adsense" once h5 games ads is approved
+const provider = () => process.env.AD_REWARDS_PROVIDER || "mock";
+
+// paying users KP for ad views only makes sense while the KP is play money
+const adRewardsEnabled = () => !isRealMoneyMode();
+
+const startOfToday = () => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+// rows already paid today; the ledger is the counter, nothing to drift
+const paidToday = (userId) =>
+  Transaction.countDocuments({ userId, type: TX.AD_REWARD, createdAt: { $gte: startOfToday() } });
+
+async function getStatus(userId) {
+  if (!adRewardsEnabled()) return { enabled: false };
+  const paid = await paidToday(userId);
+  return {
+    enabled: true,
+    provider: provider(),
+    amount: AD_REWARD_AMOUNT,
+    dailyCap: AD_REWARD_DAILY_CAP,
+    remainingToday: Math.max(0, AD_REWARD_DAILY_CAP - paid),
+  };
+}
+
+// issue a one-time watch token. tokens issued today count against the cap too, so
+// hoarding players does not stack claims; under parallel starts the count check is
+// best-effort, which for a capped fake-coin faucet is exposure enough.
+async function startWatch(userId) {
+  if (!adRewardsEnabled()) return { code: 403, body: { message: "Ad rewards are disabled" } };
+  const [issuedToday, alreadyPaid] = await Promise.all([
+    AdWatch.countDocuments({ userId, createdAt: { $gte: startOfToday() } }),
+    paidToday(userId),
+  ]);
+  if (issuedToday >= AD_REWARD_DAILY_CAP || alreadyPaid >= AD_REWARD_DAILY_CAP) {
+    return { code: 429, body: { message: "No more rewarded ads today, come back tomorrow" } };
+  }
+  const watch = await AdWatch.create({ userId, token: uuidv4() });
+  return { code: 200, body: { token: watch.token, amount: AD_REWARD_AMOUNT, minWatchMs: minWatchMs() } };
+}
+
+// redeem a token exactly once, only after a plausible watch time, only under the cap
+async function claimWatch(userId, token) {
+  if (!adRewardsEnabled()) return { code: 403, body: { message: "Ad rewards are disabled" } };
+  if (await paidToday(userId) >= AD_REWARD_DAILY_CAP) {
+    return { code: 429, body: { message: "No more rewarded ads today, come back tomorrow" } };
+  }
+
+  // the claim filter is the mutex and it commits in one transaction with the credit,
+  // so a failed payout frees the token instead of burning it. too fast, already
+  // claimed or foreign tokens match nothing.
+  let credited;
+  try {
+    credited = await runAtomic(async (session) => {
+      const watch = await AdWatch.findOneAndUpdate(
+        {
+          token: String(token || ""),
+          userId,
+          claimedAt: null,
+          createdAt: { $lte: new Date(Date.now() - minWatchMs()) },
+        },
+        { $set: { claimedAt: new Date() } },
+        { session }
+      );
+      if (!watch) return null;
+      const paid = await creditUser(userId, AD_REWARD_AMOUNT, 0, {
+        type: TX.AD_REWARD,
+        meta: { provider: provider(), watchToken: watch.token },
+        session,
+      });
+      if (!paid) throw new Error("ad reward credit failed"); // abort, the token frees
+      return paid;
+    });
+  } catch (e) {
+    console.error("claimWatch failed:", e);
+    return { code: 500, body: { message: "Could not pay the reward, please try again" } };
+  }
+  if (credited === null) return { code: 400, body: { message: "Invalid or unfinished ad view" } };
+
+  const paid = await paidToday(userId);
+  return {
+    code: 200,
+    body: {
+      claimed: AD_REWARD_AMOUNT,
+      walletBalance: credited.walletBalance,
+      remainingToday: Math.max(0, AD_REWARD_DAILY_CAP - paid),
+      user: credited,
+    },
+  };
+}
+
+module.exports = {
+  AD_REWARD_AMOUNT,
+  AD_REWARD_DAILY_CAP,
+  adRewardsEnabled,
+  getStatus,
+  startWatch,
+  claimWatch,
+};

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -33,6 +33,7 @@ const TX = {
   REFERRAL_BONUS: "referral_bonus", // one-time signup bonus, both sides of a referral
   REFERRAL_COMMISSION: "referral_commission", // the referrer's cut of referred wagers
   REFERRAL_MILESTONE: "referral_milestone", // one-time payout when a referee reaches level 10
+  AD_REWARD: "ad_reward", // KP paid for a completed rewarded ad view
   OPENING: "opening_balance", // the pre-ledger balance, booked once against genesis
 };
 

--- a/src/components/header/Navbar/RightContent.tsx
+++ b/src/components/header/Navbar/RightContent.tsx
@@ -3,6 +3,7 @@ import Avatar from "../../Avatar";
 import { FaRegBell } from "react-icons/fa";
 import { FaRegBellSlash } from "react-icons/fa";
 import ClaimBonus from "../ClaimBonus";
+import WatchAdReward from "../WatchAdReward";
 import { IoMdExit } from "react-icons/io";
 import { BiWallet } from "react-icons/bi";
 import Monetary from "../../Monetary";
@@ -34,11 +35,14 @@ const RightContent: React.FC<RightContentProps> = ({ loading, userData, openNoti
 
     return (
         <div className="flex items-center gap-4">
-            <div className="hidden md:flex ">
+            <div className="hidden md:flex items-center gap-2">
                 {
                     !loading && (
-                        //button to claim bonus 
-                        <ClaimBonus bonusDate={userData?.nextBonus} userData={userData} />
+                        //button to claim bonus
+                        <>
+                            <WatchAdReward />
+                            <ClaimBonus bonusDate={userData?.nextBonus} userData={userData} />
+                        </>
                     )
                 }
             </div>

--- a/src/components/header/Sidebar.tsx
+++ b/src/components/header/Sidebar.tsx
@@ -6,6 +6,7 @@ import { FaHome } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { TbCat } from "react-icons/tb";
 import ClaimBonus from "../header/ClaimBonus";
+import WatchAdReward from "../header/WatchAdReward";
 import { useContext } from "react";
 import UserContext from "../../UserContext";
 import Monetary from "../Monetary";
@@ -91,7 +92,10 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
                             <Monetary value={Math.floor(userData?.walletBalance)} />
                         </div>
 
-                        <ClaimBonus bonusDate={userData?.nextBonus} userData={userData} />
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <WatchAdReward />
+                            <ClaimBonus bonusDate={userData?.nextBonus} userData={userData} />
+                        </div>
                     </div>
                     <div className="flex flex-col space-y-4 mt-6">
                         {links.map((link, index) => (

--- a/src/components/header/WatchAdReward.tsx
+++ b/src/components/header/WatchAdReward.tsx
@@ -1,0 +1,128 @@
+import { useContext, useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { BiMoviePlay } from "react-icons/bi";
+import Modal from "../Modal";
+import MainButton from "../MainButton";
+import UserContext from "../../UserContext";
+import {
+  getAdRewardStatus,
+  startAdWatch,
+  claimAdReward,
+  showRewardedAd,
+  AdRewardStatus,
+} from "../../services/rewards/AdRewardServices";
+
+// "watch an ad, earn KP": the server issues a one-time token, the ad plays, and the
+// claim is refused unless enough time passed for a real view
+const WatchAdReward = () => {
+  const { userData, toogleUserData } = useContext(UserContext);
+  const [status, setStatus] = useState<AdRewardStatus | null>(null);
+  const [open, setOpen] = useState(false);
+  const [watchToken, setWatchToken] = useState<string | null>(null);
+  const [canClaim, setCanClaim] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [progressOn, setProgressOn] = useState(false);
+  const [watchMs, setWatchMs] = useState(5000);
+
+  useEffect(() => {
+    if (!userData) return;
+    getAdRewardStatus()
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, [userData?.id]);
+
+  if (!userData || !status || !status.enabled || status.remainingToday < 1) return null;
+
+  const finishClaim = async (token: string) => {
+    try {
+      const res = await claimAdReward(token);
+      toast.success(`+${res.claimed} K₽ for watching`, { theme: "dark" });
+      toogleUserData({ ...userData, walletBalance: res.walletBalance });
+      setStatus({ ...status, remainingToday: res.remainingToday });
+    } catch (e: any) {
+      toast.error(e.response?.data?.message || "Could not pay the reward", { theme: "dark" });
+    }
+  };
+
+  const startMock = (token: string, minWatchMs: number) => {
+    setWatchToken(token);
+    setWatchMs(minWatchMs);
+    setCanClaim(false);
+    setProgressOn(false);
+    setOpen(true);
+    // both waits start next frame so the bar animates and the claim unlocks together
+    setTimeout(() => setProgressOn(true), 50);
+    setTimeout(() => setCanClaim(true), minWatchMs + 100);
+  };
+
+  const begin = async () => {
+    setBusy(true);
+    try {
+      const started = await startAdWatch();
+      if (status.provider === "adsense") {
+        showRewardedAd({
+          onGranted: () => finishClaim(started.token),
+          onDismissed: () => toast.info("Ad closed early, no reward", { theme: "dark" }),
+          onUnavailable: () => toast.info("No ad available right now, try later", { theme: "dark" }),
+        });
+      } else {
+        startMock(started.token, started.minWatchMs);
+      }
+    } catch (e: any) {
+      toast.error(e.response?.data?.message || "Could not start the ad", { theme: "dark" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const claimMock = async () => {
+    if (!watchToken) return;
+    setBusy(true);
+    await finishClaim(watchToken);
+    setBusy(false);
+    setOpen(false);
+    setWatchToken(null);
+  };
+
+  return (
+    <>
+      <MainButton
+        text={
+          <span className="flex items-center gap-2">
+            <BiMoviePlay className="text-xl" /> {`+${status.amount}`}
+          </span>
+        }
+        onClick={begin}
+        disabled={busy}
+      />
+      {open && (
+        <Modal open={open} setOpen={setOpen} width="420px">
+          <div className="flex flex-col items-center gap-4 p-6">
+            <div className="w-full aspect-video bg-surface-nav rounded-md flex items-center justify-center relative overflow-hidden">
+              <BiMoviePlay className="text-6xl text-ink-faint" />
+              <span className="absolute top-2 left-2 text-xs text-ink-muted uppercase">Ad</span>
+              <div
+                className="absolute bottom-0 left-0 h-1 bg-accent-gold"
+                style={{
+                  width: progressOn ? "100%" : "0%",
+                  transition: progressOn ? `width ${watchMs}ms linear` : "none",
+                }}
+              />
+            </div>
+            <p className="text-ink-soft text-sm text-center">
+              {canClaim ? "All done, enjoy your coins." : "Watching the ad..."}
+            </p>
+            <MainButton
+              text={`Claim +${status.amount} K₽`}
+              onClick={claimMock}
+              disabled={!canClaim || busy}
+              loading={busy}
+            />
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default WatchAdReward;

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -43,6 +43,7 @@ const LINE_LABELS: Record<string, string> = {
   referral_bonus: "Referral bonuses",
   referral_milestone: "Referral milestones",
   referral_commission: "Referral commission",
+  ad_reward: "Ad rewards",
   admin_adjust: "Admin adjustments",
 };
 const label = (type: string) => LINE_LABELS[type] || type.replace(/_/g, " ");

--- a/src/services/rewards/AdRewardServices.ts
+++ b/src/services/rewards/AdRewardServices.ts
@@ -1,0 +1,64 @@
+import api from "../api";
+
+// when disabled (real-money mode) the api returns only { enabled: false }
+export interface AdRewardStatus {
+  enabled: boolean;
+  provider: "mock" | "adsense";
+  amount: number;
+  dailyCap: number;
+  remainingToday: number;
+}
+
+export interface AdWatchStart {
+  token: string;
+  amount: number;
+  minWatchMs: number;
+}
+
+export interface AdRewardClaim {
+  claimed: number;
+  walletBalance: number;
+  remainingToday: number;
+}
+
+export const getAdRewardStatus = async (): Promise<AdRewardStatus> =>
+  (await api.get("/rewards/ads")).data;
+
+export const startAdWatch = async (): Promise<AdWatchStart> =>
+  (await api.post("/rewards/ads/start")).data;
+
+export const claimAdReward = async (token: string): Promise<AdRewardClaim> =>
+  (await api.post("/rewards/ads/claim", { token })).data;
+
+// google's ad placement api (h5 games ads). the page already loads adsbygoogle, so
+// adBreak is just the queued call; this only runs when the provider is "adsense".
+declare global {
+  interface Window {
+    adsbygoogle: unknown[];
+    adBreak?: (o: Record<string, unknown>) => void;
+  }
+}
+
+export const showRewardedAd = (handlers: {
+  onGranted: () => void;
+  onDismissed: () => void;
+  onUnavailable: () => void;
+}) => {
+  const adBreak =
+    window.adBreak || ((o: Record<string, unknown>) => (window.adsbygoogle = window.adsbygoogle || []).push(o));
+  let shown = false;
+  adBreak({
+    type: "reward",
+    name: "kp-reward",
+    beforeReward: (showAdFn: () => void) => {
+      shown = true;
+      showAdFn();
+    },
+    adViewed: () => handlers.onGranted(),
+    adDismissed: () => handlers.onDismissed(),
+    adBreakDone: () => {
+      // no fill: beforeReward never ran, so nothing was ever shown
+      if (!shown) handlers.onUnavailable();
+    },
+  });
+};


### PR DESCRIPTION
Stacked on #150 (base `feat/referral-tuning`); merge order #149 -> #150 -> this, each retargets automatically.

## The feature

"Watch this video, get **+500 KP**", capped at **10 a day**. The button sits next to the bonus claim in the header and mobile sidebar, shows the amount, and disappears when the day is used up.

## Why only the rewarded format

Rewarding users for viewing the **regular display ads is against AdSense policy** (incentivized traffic - account ban). The rewarded video format exists specifically for this trade, so only that format is wired.

## Server-authoritative flow

1. `POST /rewards/ads/start` issues a one-time watch token (`AdWatch` doc, TTL-swept after a day).
2. The ad plays.
3. `POST /rewards/ads/claim` pays only if the token is real, unspent, owned by the caller, and **old enough for a genuine view** (min-watch check). The token burn and the credit commit in **one transaction** - a failed payout frees the token instead of eating it.

The daily cap is **counted from the ledger rows** (nothing kept on the side) and gates both token issue and claim, so hoarded tokens die at the cap too. New `ad_reward` transaction type, minted against MINT - the first faucet backed by real outside revenue - and it appears in the backoffice faucet panel automatically. Fake-balance mode only, same gate as referrals.

## Pluggable provider

`AD_REWARDS_PROVIDER` env: `mock` (default) shows a simulated video player so the full flow works end-to-end today; `adsense` drives the H5 Games Ads rewarded `adBreak` (the page already loads adsbygoogle) once Google approves the site for the program - a config flip, no code change. The adBreak wiring should get a manual pass when the approval lands.

## Tests

8 integration tests: auth, status shape, happy path (minted row, countdown), too-fast claim refused, one-time/foreign/unknown tokens, cap stops both issue and claim, sequential issue stops at cap, real-money mode off. Backend 311/311 twice, frontend typecheck/lint/build/unit/e2e green.