### PR TITLE
SECURITY: crash & coin flip outcomes were derivable from the public commitment

### DIFF
--- a/backend/__tests__/unit/coinMath.test.js
+++ b/backend/__tests__/unit/coinMath.test.js
@@ -22,4 +22,20 @@ describe("coin result from seed", () => {
     expect(heads / N).toBeGreaterThan(0.48);
     expect(heads / N).toBeLessThan(0.52);
   });
+
+  // the guarantee the original bug broke: the round's commitment is sha256(seed), so the
+  // result must NOT be readable off it. deriving it that way must be no better than a toss.
+  test("result cannot be predicted from the published commitment", () => {
+    const N = 40000;
+    // the OLD, broken derivation applied to the broadcast commitment
+    const fromCommitment = (hash) => parseInt(hash.slice(0, 8), 16) % 2;
+    let matches = 0;
+    for (let i = 0; i < N; i++) {
+      const seed = sha256(`predict:${i}`);
+      if (fromCommitment(sha256(seed)) === coinResultFromSeed(seed)) matches += 1;
+    }
+    // chance is 50%; a broken scheme scored N/N here
+    expect(matches / N).toBeGreaterThan(0.47);
+    expect(matches / N).toBeLessThan(0.53);
+  });
 });

--- a/backend/__tests__/unit/crashMath.test.js
+++ b/backend/__tests__/unit/crashMath.test.js
@@ -1,4 +1,13 @@
-const { multiplierAt, crashPointFromRandom } = require("../../utils/crashMath");
+const { multiplierAt, crashPointFromRandom, crashPointFromSeed, INSTANT_CRASH_CHANCE } = require("../../utils/crashMath");
+const { sha256 } = require("../../utils/hashChain");
+
+// the OLD, broken derivation: read the outcome straight off sha256(seed). since sha256(seed)
+// is exactly the commitment broadcast at betting open, anything derivable this way was public.
+const crashFromCommitment = (hash) => {
+  const bust = parseInt(hash.slice(0, 8), 16) / 2 ** 32;
+  if (bust < INSTANT_CRASH_CHANCE) return 1.0;
+  return crashPointFromRandom(parseInt(hash.slice(8, 16), 16));
+};
 
 describe("crash math", () => {
   test("crash point is at least 1.0", () => {
@@ -7,6 +16,32 @@ describe("crash math", () => {
       const h = Math.floor((i / 1000) * 2 ** 32);
       expect(crashPointFromRandom(h)).toBeGreaterThanOrEqual(1);
     }
+  });
+
+  test("crash point is deterministic, with a stable small bust-to-1.0 rate", () => {
+    const seed = sha256("determinism");
+    expect(crashPointFromSeed(seed)).toBe(crashPointFromSeed(seed));
+    const N = 40000;
+    let atOne = 0;
+    for (let i = 0; i < N; i++) {
+      if (crashPointFromSeed(sha256(`crash:${i}`)) === 1.0) atOne += 1;
+    }
+    // the 3% instant bust plus the curve's lowest bucket that also rounds to 1.00
+    expect(atOne / N).toBeGreaterThan(0.03);
+    expect(atOne / N).toBeLessThan(0.055);
+  });
+
+  // the guarantee the original bug broke: the outcome must NOT be derivable from the
+  // published commitment sha256(seed). deriving it that way must be no better than luck.
+  test("crash point cannot be predicted from the published commitment", () => {
+    const N = 5000;
+    let matches = 0;
+    for (let i = 0; i < N; i++) {
+      const seed = sha256(`predict:${i}`);
+      if (crashFromCommitment(sha256(seed)) === crashPointFromSeed(seed)) matches += 1;
+    }
+    // exact-value coincidences only; the broken scheme scored N/N here
+    expect(matches / N).toBeLessThan(0.05);
   });
 
   test("multiplier starts at 1 and grows then caps at the crash point", () => {

--- a/backend/utils/coinMath.js
+++ b/backend/utils/coinMath.js
@@ -1,9 +1,12 @@
 const crypto = require("crypto");
 
-// the coin result derived from one seed so the round is verifiable: 0 (heads) or 1
-// (tails) from a word of sha256(seed), a fair 50/50.
+// the result is derived by an hmac KEYED with the seed, not by sha256(seed): the round's
+// published commitment is sha256(seed), so deriving the result from that same hash let
+// anyone read the winning side off the commitment before betting closed. hmac(seed,
+// "coinflip") needs the still-secret seed, so it stays unknowable until reveal while
+// sha256(seed) still verifies the chain link. 0 (heads) or 1 (tails), a fair 50/50.
 const coinResultFromSeed = (serverSeed) => {
-  const hash = crypto.createHash("sha256").update(serverSeed).digest("hex");
+  const hash = crypto.createHmac("sha256", serverSeed).update("coinflip").digest("hex");
   return parseInt(hash.slice(0, 8), 16) % 2;
 };
 

--- a/backend/utils/crashMath.js
+++ b/backend/utils/crashMath.js
@@ -13,10 +13,13 @@ const crashPointFromRandom = (h) => {
   return Math.floor((100 * e - h) / (e - h)) / 100;
 };
 
-// the outcome derived from one seed so the round is verifiable: two disjoint words of
-// sha256(seed) drive the instant bust and the curve, matching the old random distribution.
+// the outcome is derived by an hmac KEYED with the seed, not by sha256(seed): the round's
+// published commitment is sha256(seed), so deriving the outcome from that same hash let
+// anyone read the crash point off the commitment before betting closed. hmac(seed, "crash")
+// needs the still-secret seed, so it stays unknowable until reveal while sha256(seed) still
+// verifies the chain link. two disjoint words drive the instant bust and the curve.
 const crashPointFromSeed = (serverSeed) => {
-  const hash = crypto.createHash("sha256").update(serverSeed).digest("hex");
+  const hash = crypto.createHmac("sha256", serverSeed).update("crash").digest("hex");
   const bust = parseInt(hash.slice(0, 8), 16) / 2 ** 32; // uniform [0,1)
   if (bust < INSTANT_CRASH_CHANCE) return 1.0;
   return crashPointFromRandom(parseInt(hash.slice(8, 16), 16));


### PR DESCRIPTION
## Severity: critical (found in the branch audit; live on main)

Crash and Coin Flip published `serverSeedHash = sha256(seed)` when betting opened - and derived the **outcome from that same `sha256(seed)`**. So the commitment *was* the outcome-deriving hash: any logged-in client could read `serverSeedHash` off `crash:gameState` / `coinFlip:gameState` and compute the crash point / winning side before betting closed, then bet the winning side (or skip the 3% instant-bust rounds) every time.

**Proof of concept** (using the repo's own modules) predicted **20/20 crash points and 20/20 coin results** from the broadcast hash alone. After this change, the same PoC scores 0/20 (crash) and ~10/20 (coin, i.e. chance).

## The fix

Derive the outcome from `HMAC-SHA256(key = seed, msg = "crash" | "coinflip")` instead of `sha256(seed)`. The commitment stays `sha256(seed)`, but the outcome now needs the seed itself, which stays secret until reveal - so the commitment leaks nothing, while `sha256(seed)` still verifies the hash-chain link. This is exactly how the per-user case/upgrade/slot rolls already work (`provablyFair.js`); it brings the two live games in line.

- **Odds unchanged:** HMAC-SHA256 output is uniform, so the distribution (3% instant bust, curve, 50/50) and house edge are identical.
- **Verifiability unchanged:** at reveal the player still gets the seed, checks `sha256(seed) === serverSeedHash` (chain) and recomputes the outcome. `fairRoutes` verify endpoints recompute via the same functions, so they update automatically.

## Tests

The old `crashSecrecy`/`coinFlipSecrecy` tests only asserted the raw values weren't broadcast - they never checked the outcome couldn't be **derived** from the commitment, so CI was green on the broken scheme. Added regression tests (`crashMath.test.js`, `coinMath.test.js`) that recompute the outcome from the published commitment and assert the match rate is no better than chance (crash <5%, coin ~50%). Full backend suite 296/296.

## Note

This changes how past crash/coin rounds would recompute, so historical `serverSeed` reveals from before this deploy verify against the old formula. New rounds use the new one. (Per-user provably-fair rolls are untouched.)