### PR TITLE
Bug: periodic recovery sweep settles LIVE crash/coin-flip rounds (double-pays)

### DIFF
--- a/backend/__tests__/integration/battleRecovery.test.js
+++ b/backend/__tests__/integration/battleRecovery.test.js
@@ -52,7 +52,7 @@ test("a battle abandoned before its preroll refunds the players who paid", async
   await recordEntry(a._id, battle._id);
   await recordEntry(b._id, battle._id);
 
-  await engine.completeStuckBattles();
+  await engine.completeStuckBattles(undefined, { boot: true });
 
   const done = await Battle.findById(battle._id);
   // it never happened, so it must not be dressed up as a finished battle
@@ -70,7 +70,7 @@ test("a player the crash beat to the charge is not refunded money they never pai
   const battle = await abandonedBattle([paid, never]);
   await recordEntry(paid._id, battle._id); // only one of them was charged
 
-  await engine.completeStuckBattles();
+  await engine.completeStuckBattles(undefined, { boot: true });
 
   expect((await User.findById(paid._id)).walletBalance).toBe(1000);
   expect((await User.findById(never._id)).walletBalance).toBe(1000); // not 1100
@@ -81,8 +81,8 @@ test("voiding twice does not pay twice", async () => {
   const battle = await abandonedBattle([a]);
   await recordEntry(a._id, battle._id);
 
-  await engine.completeStuckBattles();
-  await engine.completeStuckBattles();
+  await engine.completeStuckBattles(undefined, { boot: true });
+  await engine.completeStuckBattles(undefined, { boot: true });
 
   expect((await User.findById(a._id)).walletBalance).toBe(1000);
 });
@@ -101,11 +101,25 @@ test("a battle interrupted mid-reveal still finishes from its preroll", async ()
   battle.rolls = [[item, null]]; // slot 0 won something, slot 1 got nothing
   await battle.save();
 
-  await engine.completeStuckBattles();
+  await engine.completeStuckBattles(undefined, { boot: true });
 
   const done = await Battle.findById(battle._id);
   expect(done.status).toBe("finished");
   expect(done.winningTeam).toBe(0);
   const winner = await User.findById(a._id);
   expect(winner.inventory.map((i) => i.name)).toContain("won");
+});
+
+test("the periodic sweep leaves a live in-progress battle for the engine to finish", async () => {
+  const a = await makePlayer(900);
+  const b = await makePlayer(900);
+  const battle = await abandonedBattle([a, b]); // in_progress, the engine is still playing it
+  await recordEntry(a._id, battle._id);
+  await recordEntry(b._id, battle._id);
+
+  await engine.completeStuckBattles(undefined, { boot: false });
+
+  const same = await Battle.findById(battle._id);
+  expect(same.status).toBe("in_progress"); // untouched, no early finish/void
+  expect((await User.findById(a._id)).walletBalance).toBe(900); // not refunded out from under it
 });

--- a/backend/__tests__/integration/refundResume.test.js
+++ b/backend/__tests__/integration/refundResume.test.js
@@ -55,7 +55,7 @@ const creditWorksAgain = () => {
   creditUser.mockImplementation((...args) => actual.creditUser(...args));
 };
 
-const recover = () => recoverStuckRounds(undefined, winPayout);
+const recover = () => recoverStuckRounds(undefined, winPayout, { boot: true });
 
 // a dead process leaves its lease behind. the next sweep only takes it over once the
 // lease has gone stale, so that is what a later boot actually sees.
@@ -130,10 +130,11 @@ test("a battle void interrupted mid-refund is finished on the next boot", async 
   }
 
   dieOnCredit(2);
-  await engine.completeStuckBattles().catch(() => {});
+  await engine.completeStuckBattles(undefined, { boot: true }).catch(() => {});
   creditWorksAgain();
   await expireLease(Battle, battle._id);
-  await engine.completeStuckBattles();
+  // the periodic sweep (not a boot) resumes the give-back loop that died holding the lease
+  await engine.completeStuckBattles(undefined, { boot: false });
 
   expect(await balanceOf(a)).toBe(1000);
   expect(await balanceOf(b)).toBe(1000);

--- a/backend/__tests__/integration/roundRecovery.test.js
+++ b/backend/__tests__/integration/roundRecovery.test.js
@@ -33,7 +33,10 @@ const paidRow = (user, round, amount, type) =>
     meta: { roundId: String(round._id) },
   });
 
-const recover = () => recoverStuckRounds(undefined, winPayout);
+// the boot recovery: at restart every betting/running round is genuinely orphaned
+const recover = () => recoverStuckRounds(undefined, winPayout, { boot: true });
+// the periodic sweep: the live loops are still playing, so it must skip their rounds
+const sweep = () => recoverStuckRounds(undefined, winPayout, { boot: false });
 
 describe("rounds a restart left in flight", () => {
   test("a crash round caught during betting gives every stake back", async () => {
@@ -155,5 +158,45 @@ describe("rounds a restart left in flight", () => {
 
     // the ledger knows, which is the whole reason the refund reads from it
     expect(await balanceOf(a)).toBe(1000);
+  });
+});
+
+describe("the periodic sweep leaves the live loops' rounds alone", () => {
+  test("a live betting round is not voided out from under the loop", async () => {
+    const a = await makeUser(900);
+    const round = await Round.create({
+      game: "crash", status: "betting", bets: [{ userId: a._id, amount: 100 }],
+    });
+    await stakeRow(a, round, 100, TX.CRASH_BET);
+
+    expect(await sweep()).toEqual({ voided: 0, settled: 0 });
+    expect((await Round.findById(round._id)).status).toBe("betting");
+    expect(await balanceOf(a)).toBe(900); // stake not refunded mid-round
+  });
+
+  test("a live running coin flip is not settled early", async () => {
+    const winner = await makeUser(900);
+    const round = await Round.create({
+      game: "coinflip", status: "running", outcome: { result: 0, winningSide: "heads" },
+      bets: [{ userId: winner._id, amount: 100, side: "heads" }],
+    });
+    await stakeRow(winner, round, 100, TX.COINFLIP_BET);
+
+    expect(await sweep()).toEqual({ voided: 0, settled: 0 });
+    expect(await balanceOf(winner)).toBe(900); // the live loop pays it, not the sweep
+  });
+
+  test("but it still resumes a give-back loop that died holding a stale lease", async () => {
+    const a = await makeUser(900);
+    const round = await Round.create({
+      game: "crash", status: "voided",
+      settlementStartedAt: new Date(Date.now() - 120000), // older than the 60s lease
+      bets: [{ userId: a._id, amount: 100 }],
+    });
+    await stakeRow(a, round, 100, TX.CRASH_BET);
+
+    expect(await sweep()).toEqual({ voided: 1, settled: 0 });
+    expect(await balanceOf(a)).toBe(1000);
+    expect((await Round.findById(round._id)).settlementDone).toBe(true);
   });
 });

--- a/backend/games/battleEngine.js
+++ b/backend/games/battleEngine.js
@@ -285,22 +285,23 @@ async function voidBattle(battle, io = noopIo) {
   return claimed;
 }
 
-// on boot, settle any battle a restart interrupted so none are left stuck. one that
-// never committed a preroll has nothing to reveal, so it is voided rather than finished.
-// the second arm picks up a void whose own refund loop died partway: it keys on
-// settlementStartedAt, which only exists once that loop has claimed the battle, so
-// battles cancelled before this existed are left alone.
-async function completeStuckBattles(io = noopIo) {
-  const stuck = await Battle.find({
-    $or: [
-      { status: "in_progress" },
-      {
-        status: "cancelled",
-        settlementStartedAt: { $exists: true },
-        settlementDone: { $ne: true },
-      },
-    ],
-  });
+// settle any battle a restart interrupted so none are left stuck. the first arm (live
+// in_progress battles) only runs at boot: then they are genuinely orphaned, but on the
+// periodic sweep the engine is still playing them, and finishing/voiding one early cuts
+// its reveal short. the second arm picks up a void whose own refund loop died partway: it
+// keys on settlementStartedAt, which only exists once that loop has claimed the battle, so
+// it resumes a dead loop without touching a live battle. battles cancelled before this
+// existed have no marker and are left alone.
+async function completeStuckBattles(io = noopIo, { boot = false } = {}) {
+  const arms = [
+    {
+      status: "cancelled",
+      settlementStartedAt: { $exists: true },
+      settlementDone: { $ne: true },
+    },
+  ];
+  if (boot) arms.unshift({ status: "in_progress" });
+  const stuck = await Battle.find({ $or: arms });
   for (const b of stuck) {
     try {
       if (b.pfServerSeed && b.rolls && b.rolls.length) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -132,12 +132,15 @@ app.use("/referrals", referralRoutes);
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.
 // it repeats because a give-back loop that dies holds its lease until that goes stale,
 // and a boot-only sweep would leave the money it still owes until the next restart.
-const sweepRounds = () => {
-  recoverStuckRounds(io, coinFlip.winPayout).catch((e) => console.log(e));
-  completeStuckBattles(io).catch((e) => console.log(e));
+// boot recovers live-looking rounds/battles the restart orphaned; the interval only
+// resumes a give-back loop that died holding a stale lease, so it never touches the
+// rounds the running game loops are still playing.
+const sweepRounds = ({ boot = false } = {}) => {
+  recoverStuckRounds(io, coinFlip.winPayout, { boot }).catch((e) => console.log(e));
+  completeStuckBattles(io, { boot }).catch((e) => console.log(e));
 };
-sweepRounds();
-setInterval(sweepRounds, 5 * 60 * 1000);
+sweepRounds({ boot: true });
+setInterval(() => sweepRounds({ boot: false }), 5 * 60 * 1000);
 
 // Start the games
 coinFlip(io);

--- a/backend/utils/rounds.js
+++ b/backend/utils/rounds.js
@@ -120,21 +120,24 @@ async function settleInterruptedCoinFlip(round, io = noopIo, payoutFor) {
 // happened and its stakes go back; a coin flip that already landed is finished properly.
 // a round whose own give-back loop was interrupted is picked up again: it is terminal
 // but not done with, and the money it still owes is the whole reason this runs.
-async function recoverStuckRounds(io = noopIo, payoutFor) {
-  // the second arm keys on settlementStartedAt, which only exists once a give-back loop
-  // has actually claimed the round. every round that finished normally, and every round
-  // that predates this, has no such marker and is left alone: without that, the first
-  // boot would sweep every settled round ever and refund the losers.
-  const stuck = await Round.find({
-    $or: [
-      { status: { $in: ["betting", "running"] } },
-      {
-        status: { $in: ["voided", "settled"] },
-        settlementStartedAt: { $exists: true },
-        settlementDone: { $ne: true },
-      },
-    ],
-  });
+async function recoverStuckRounds(io = noopIo, payoutFor, { boot = false } = {}) {
+  // the first arm (fresh betting/running rounds) only runs at boot: then every such round
+  // is genuinely orphaned by the restart. on the periodic sweep the live game loop is still
+  // playing those rounds, and voiding one out from under it refunds its stakes and lets the
+  // loop pay on top, so the interval runs only the second arm.
+  // the second arm keys on settlementStartedAt, which only exists once a give-back loop has
+  // actually claimed the round, so it resumes a loop that died mid-settlement without
+  // touching a live round. every round that finished normally, and every round that predates
+  // this, has no such marker and is left alone.
+  const arms = [
+    {
+      status: { $in: ["voided", "settled"] },
+      settlementStartedAt: { $exists: true },
+      settlementDone: { $ne: true },
+    },
+  ];
+  if (boot) arms.unshift({ status: { $in: ["betting", "running"] } });
+  const stuck = await Round.find({ $or: arms });
   let voided = 0;
   let settled = 0;
 


### PR DESCRIPTION
## Severity: high (found in the branch audit; live on main)

`sweepRounds` runs at boot **and every 5 minutes** (`index.js`). `recoverStuckRounds` (and `completeStuckBattles`) have a first query arm matching any round in `betting`/`running` (battle `in_progress`) with **no age or lease guard**. At boot that's correct - every such round was orphaned by the restart. On the *interval* it isn't: the live game loops are still playing those rounds. Crash/coin-flip are almost always mid-round, so every ~5 minutes the sweep voids the live round out from under the loop - refunding every staker - while the loop goes on to pay the winners too. It's ledger-atomic each time, so `reconcile.js` won't flag it; the only symptom is HOUSE trending negative.

Battles were less exposed: `finishBattle`/`voidBattle` compare-and-set on `status`, so a live battle caught by the sweep at worst finishes early (reveal cut short), not a double-pay - but it's the same root cause, so it's fixed the same way.

## The fix

The first arm (fresh `betting`/`running` / `in_progress`) now runs **at boot only**. The interval runs only the second arm - resuming a give-back loop that died holding a stale lease, which is the only thing the interval was ever for (per its own comment). That arm is already lease-guarded (`SETTLEMENT_LEASE_MS = 60s`), so two runners can't both settle the same round.

- `recoverStuckRounds(io, payoutFor, { boot })` / `completeStuckBattles(io, { boot })`; boot call passes `{ boot: true }`, the interval passes `{ boot: false }`.

## Tests

- Existing recovery tests now pass `{ boot: true }` (they all simulate a restart).
- Added: the periodic sweep (`boot: false`) leaves a live betting round and a live running coin flip **untouched** (not voided/settled, stakes not refunded), and leaves a live `in_progress` battle for the engine - **but still resumes** a give-back loop that died holding a stale lease. Full backend suite 297/297.