### PR TITLE
Flaky test: game-race suite could fail before betting opened (blocked a deploy)

### DIFF
--- a/backend/__tests__/integration/gameRaces.test.js
+++ b/backend/__tests__/integration/gameRaces.test.js
@@ -31,14 +31,19 @@ const start = (game, io) => {
   running.push(game(io));
 };
 
-// betting does not open until the round record exists, so wait for it rather than
-// assume. setImmediate is real here (the fake timers below leave it alone).
-async function untilBettingOpens(game) {
+// the game sets its in-memory bettingOpen flag and then broadcasts its opening state, so
+// that broadcast is the signal a bet will be accepted. waiting on the round doc alone raced
+// the flag: the doc could be visible a tick before bettingOpen flipped, and a bet placed in
+// that window was refused, so nothing was charged. the findOne is what actually paces this
+// loop (a real db round-trip lets openBetting's create finish); the emit is the gate.
+// setImmediate is real here (the fake timers below leave it alone).
+async function untilBettingOpens(emitted, event, game) {
   for (let i = 0; i < 500; i++) {
-    if (await Round.findOne({ game, status: "betting" })) return;
+    if (emitted.includes(event)) return;
+    await Round.findOne({ game, status: "betting" });
     await new Promise((r) => setImmediate(r));
   }
-  throw new Error(`no ${game} round opened`);
+  throw new Error(`no ${event} broadcast`);
 }
 
 afterEach(async () => {
@@ -51,14 +56,15 @@ afterAll(teardownDb);
 // handlers exactly that way, which is how the duplicate-charge races were found
 function fakeIo() {
   let onConnection;
+  const emitted = [];
   const io = {
     on: (event, cb) => {
       if (event === "connection") onConnection = cb;
     },
-    emit: () => {},
+    emit: (event) => emitted.push(event),
     to: () => ({ emit: () => {} }),
   };
-  return { io, connect: (socket) => onConnection(socket) };
+  return { io, emitted, connect: (socket) => onConnection(socket) };
 }
 
 function fakeSocket(userId) {
@@ -94,9 +100,9 @@ describe("crash", () => {
     jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
 
     const user = await makeUser(1000);
-    const { io, connect } = fakeIo();
+    const { io, emitted, connect } = fakeIo();
     start(crashGame, io);
-    await untilBettingOpens("crash");
+    await untilBettingOpens(emitted, "crash:gameState", "crash");
     const socket = fakeSocket(user._id);
     connect(socket);
 
@@ -117,9 +123,9 @@ describe("crash", () => {
   test("a bet emitted twice in one tick is only charged once", async () => {
     jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
     const user = await makeUser(1000);
-    const { io, connect } = fakeIo();
+    const { io, emitted, connect } = fakeIo();
     start(crashGame, io);
-    await untilBettingOpens("crash");
+    await untilBettingOpens(emitted, "crash:gameState", "crash");
     const socket = fakeSocket(user._id);
     connect(socket);
 
@@ -140,9 +146,9 @@ describe("coin flip", () => {
   test("two bets in one tick cannot back both sides", async () => {
     jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
     const user = await makeUser(1000);
-    const { io, connect } = fakeIo();
+    const { io, emitted, connect } = fakeIo();
     start(coinFlip, io);
-    await untilBettingOpens("coinflip");
+    await untilBettingOpens(emitted, "coinFlip:gameState", "coinflip");
     const socket = fakeSocket(user._id);
     connect(socket);
 


### PR DESCRIPTION
## The flake

`gameRaces.test.js` failed intermittently in CI and just **blocked a deploy**:

```
● crash › a cashout emitted twice in one tick is only paid once
  expect(received).toBe(expected)   Expected: 900  Received: 1000
  > 104 | expect((await User.findById(user._id)).walletBalance).toBe(900);
```

The bet wasn't charged. Root cause: the test waited on the **round doc** to appear, but the game sets its in-memory `bettingOpen` flag and *then* broadcasts its opening state a tick later (`bettingOpen = true` → `io.emit("...:gameState")`). The doc could be visible in the window before `bettingOpen` flipped, so a bet placed then was refused ("betting closed") and nothing was charged. Not a product bug — purely a test-harness timing race.

## The fix

The tests now wait for the game's **opening broadcast** (which the fake `io` records) instead of the round doc — that broadcast happens *after* `bettingOpen = true`, so the flag is guaranteed set before the first bet. The round-doc `findOne` stays as the loop's pacing (a real DB round-trip that gives `openBetting`'s create time to finish, rather than spinning through `setImmediate` faster than the DB write).

## Verification

Full backend suite **10×** and the race suite **10×** with zero failures (the pre-fix suite failed ~1 in 8 under load). No product code changed - test-only.

**Holding for your ok - not merging.**