### PR TITLE
Cache the public case + item reads (cut Australia round-trips)

### DIFF
--- a/backend/__tests__/integration/cacheHeaders.test.js
+++ b/backend/__tests__/integration/cacheHeaders.test.js
@@ -1,0 +1,50 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+const Case = require("../../models/Case");
+const Item = require("../../models/Item");
+const User = require("../../models/User");
+
+let app;
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+// the public reads carry no user and change only on an admin edit, so they are cacheable;
+// personalised reads must never be, or one user would be served another's data from a cache.
+describe("public read cache headers", () => {
+  test("GET /cases is cacheable with a short ttl", async () => {
+    await Case.create({ title: "Box", image: "b.webp", price: 50, items: [] });
+    const res = await request(app).get("/cases");
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("public, max-age=60");
+  });
+
+  test("GET /cases/:id is cacheable", async () => {
+    const c = await Case.create({ title: "Box", image: "b.webp", price: 50, items: [] });
+    const res = await request(app).get(`/cases/${c._id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("public, max-age=120");
+  });
+
+  test("GET /items is cacheable", async () => {
+    await Item.create({ name: "Card", image: "c.webp", rarity: "1" });
+    const res = await request(app).get("/items");
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("public, max-age=300");
+  });
+
+  test("a personalised read is never cached", async () => {
+    // the public profile is per-user; it must not carry a public cache-control
+    const s = uniqueSuffix();
+    const u = await User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x" });
+    const res = await request(app).get(`/users/${u._id}`);
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBeUndefined();
+  });
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -11,6 +11,8 @@ const missionsRoutes = require("../../routes/missionsRoutes");
 const adminRoutes = require("../../routes/adminRoutes");
 const referralRoutes = require("../../routes/referralRoutes");
 const rewardRoutes = require("../../routes/rewardRoutes");
+const caseRoutes = require("../../routes/caseRoutes");
+const itemRoutes = require("../../routes/itemRoutes");
 
 // no-op socket.io stand-in
 const io = { emit: () => {}, to: () => ({ emit: () => {} }) };
@@ -28,6 +30,8 @@ function makeApp() {
   app.use("/admin", adminRoutes);
   app.use("/referrals", referralRoutes(io));
   app.use("/rewards", rewardRoutes(io));
+  app.use("/cases", caseRoutes);
+  app.use("/items", itemRoutes);
   return app;
 }
 

--- a/backend/routes/caseRoutes.js
+++ b/backend/routes/caseRoutes.js
@@ -4,6 +4,7 @@ const Case = require("../models/Case");
 const Item = require("../models/Item");
 const { isAuthenticated, isAdmin } = require("../middleware/authMiddleware");
 const { recomputeCaseValues } = require("../utils/itemValue");
+const { publicCache, TTL } = require("../utils/httpCache");
 
 router.get("/", async (req, res) => {
   try {
@@ -12,6 +13,7 @@ router.get("/", async (req, res) => {
     const safe = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const filter = q ? { title: { $regex: safe, $options: "i" } } : {};
     const cases = await Case.find(filter).select('-items');
+    publicCache(res, TTL.caseList);
     res.json(cases);
   } catch (err) {
     res.status(500).json({ message: err.message });
@@ -41,6 +43,7 @@ router.get("/:id", async (req, res) => {
       path: "items",
       options: { sort: { rarity: -1 } },
     });
+    publicCache(res, TTL.caseDetail);
     res.json(caseData);
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/backend/routes/itemRoutes.js
+++ b/backend/routes/itemRoutes.js
@@ -4,10 +4,12 @@ const Item = require("../models/Item");
 const Case = require("../models/Case");
 const { isAuthenticated, isAdmin } = require("../middleware/authMiddleware");
 const { recomputeCaseValues } = require("../utils/itemValue");
+const { publicCache, TTL } = require("../utils/httpCache");
 
 router.get("/", async (req, res) => {
   try {
     const items = await Item.find();
+    publicCache(res, TTL.itemList);
     res.json(items);
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/backend/utils/httpCache.js
+++ b/backend/utils/httpCache.js
@@ -1,0 +1,11 @@
+// cache-control for the public, non-personalised reads (case + item listings). the data is
+// the same for everyone and changes only when an admin edits it, so a short ttl lets
+// cloudflare serve most hits from its edge instead of crossing to the origin, while a new
+// case still shows up within the window. never use this on anything that carries a user.
+const publicCache = (res, seconds) => res.set("Cache-Control", `public, max-age=${seconds}`);
+
+// tuned per read: the listing is hit most and must reflect a new case fastest, a single
+// case's contents change less often, the full item catalogue least of all.
+const TTL = { caseList: 60, caseDetail: 120, itemList: 300 };
+
+module.exports = { publicCache, TTL };


### PR DESCRIPTION
Follow-up to the latency finding: the origin is in Australia, so every uncached read crosses the globe. The public listings had **no cache headers** (`cf-cache-status: DYNAMIC`), and the home page calls `/cases` on every visit.

## What changed (in-repo)

`Cache-Control: public, max-age=N` on the three public, non-personalised reads:

| Endpoint | TTL | why |
|---|---|---|
| `GET /cases` (listing) | 60s | hit most; a new case must show up fast |
| `GET /cases/:id` | 120s | a single case's contents change less often |
| `GET /items` | 300s | the full catalogue changes least |

Personalised reads (profile, inventory, missions, etc.) are untouched, so no user is ever served another's data from a cache. Opening a case still charges the server-side price, so a stale displayed price can't be exploited.

## Two things still on your side

1. **Cloudflare cache rule (the real win).** Headers alone only give *browser* caching. Cloudflare currently treats these paths as `DYNAMIC`. Add a **Cache Rule** for `kanicasino.cfhxo.com` matching `URI Path starts with /cases` or `/items` → **Eligible for cache**, respect origin `Cache-Control`. Then the first request per region is cached at the edge (near the user) and the rest skip the trip to Australia. This is what turns ~690ms into a near-instant edge hit for everyone.
2. **Images are already fine** - S3 sends a 7-day cache. If you want them effectively permanent (they never change), bump the S3 objects' `Cache-Control` to `public, max-age=31536000, immutable`.

## Tests

4 new tests: each listing sets its `Cache-Control`, and a personalised read sets none. Backend 322/322.

**Holding for your ok - not merging.**