### PR TITLE
Auto-expire notifications after 7 days (TTL index)

### DIFF
--- a/backend/__tests__/unit/notificationTtl.test.js
+++ b/backend/__tests__/unit/notificationTtl.test.js
@@ -1,0 +1,9 @@
+const Notification = require("../../models/Notification");
+
+// the collection was growing without bound (27k+ docs on prod); a ttl index expires each
+// notification a week after it is created so it stays flat.
+test("notifications carry a 7-day ttl index on createdAt", () => {
+  const ttl = Notification.schema.indexes().find(([keys]) => keys.createdAt === 1);
+  expect(ttl).toBeDefined();
+  expect(ttl[1].expireAfterSeconds).toBe(604800); // 7 days
+});

--- a/backend/models/Notification.js
+++ b/backend/models/Notification.js
@@ -26,4 +26,8 @@ const NotificationSchema = new mongoose.Schema({
     }
 });
 
+// notifications are ephemeral; drop them a week after creation so the collection does not
+// grow without bound (mongo's ttl monitor sweeps expired docs about once a minute)
+NotificationSchema.index({ createdAt: 1 }, { expireAfterSeconds: 60 * 60 * 24 * 7 });
+
 module.exports = mongoose.model("Notification", NotificationSchema);


### PR DESCRIPTION
Keeps the `notifications` collection from growing without bound — it's at **27K+ docs on prod** and was never pruned (the biggest of the "quiet bloat" collections on the free Mongo tier).

## Change

A TTL index on `Notification.createdAt` with `expireAfterSeconds: 604800` (7 days). Mongo's TTL monitor (runs ~once a minute) then deletes any notification older than 7 days automatically.

**On deploy** this also sweeps the existing backlog down to the last 7 days — a one-time cleanup, no migration needed. Notifications are ephemeral (friend requests, messages, alerts), so this is safe; nothing money- or audit-related is touched.

## Test

Verifies the schema carries the 7-day TTL index on `createdAt`. Backend 323/323.

**Holding for your ok — not merging.**