### PR TITLE
Show every case on the home listing, newest first

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -89,7 +89,7 @@ const Home = () => {
         <CaseListing
           name="NEW CASES"
           loading={loading}
-          cases={loading ? [] : cases.length > 6 ? cases.slice(0, 6) : cases}
+          cases={loading ? [] : [...cases].sort((a: any, b: any) => (a._id < b._id ? 1 : -1))}
         />
 
         {discordURL && (


### PR DESCRIPTION
Problem: the home "NEW CASES" grid sliced to the first 6 cases in insertion order, so any case added after the original six never showed. The four new Blue Archive cases sat in positions 7 to 10 and were cut off, which is why they were live in the API but missing from the page.

Change: render the full case list sorted newest first. New cases lead the section (matching the heading), and none become unreachable, since this grid is the only case listing in the app.

Tests: `npm run build` passes; the prerender step now emits all 10 case pages.