### PR TITLE
Animate new live drops into the row

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,6 +90,8 @@ function App() {
 
     socket.on("caseOpened", (data) => {
       data.timestamp = Date.now();
+      // stable key so the live drop row can animate new entries in
+      data.id = crypto.randomUUID();
 
       // Wait 7.5 seconds to show the notification
       setTimeout(() => {

--- a/src/components/header/CaseOpenedNotification.tsx
+++ b/src/components/header/CaseOpenedNotification.tsx
@@ -31,9 +31,12 @@ const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
 
 
   return (
+    // the wrapper opens a gap in the row first, pushing older drops right, then the
+    // card falls into it from above (the row's overflow-hidden clips it until then)
+    <div className={`h-28 shrink-0 transition-[width] duration-200 ease-out ${transition ? "w-40" : "w-0"}`}>
     <div
-      className={`flex flex-col min-w-[160px] h-28 items-center transition-all duration-500 border bg-[#141225] 
-      ${transition ? "opacity-100" : "opacity-0 "}`}
+      className={`flex flex-col min-w-[160px] h-28 items-center transition-all duration-300 ease-out delay-200 border bg-[#141225]
+      ${transition ? "translate-y-0 opacity-100" : "-translate-y-[120%] opacity-0"}`}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       style={{
@@ -93,6 +96,7 @@ const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
         </div>
 
       </div>
+    </div>
     </div>
   );
 };

--- a/src/components/header/CaseOpenedNotification.tsx
+++ b/src/components/header/CaseOpenedNotification.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Rarities from "../Rarities";
 import { Link } from "react-router-dom";
 import { BasicItem } from "../Types";
@@ -17,13 +17,7 @@ interface CaseOpenedNotificationProps {
 const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
   user, item, caseImage
 }) => {
-  const [transition, setTransition] = useState<boolean>(false);
   const [isHovering, setIsHovering] = useState<boolean>(false);
-
-
-  useEffect(() => {
-    setTransition(true);
-  }, []);
 
   const getColor = (e: number) => {
     return Rarities.find((rarity) => rarity.id == e)?.color;
@@ -31,12 +25,11 @@ const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
 
 
   return (
-    // the wrapper opens a gap in the row first, pushing older drops right, then the
-    // card falls into it from above (the row's overflow-hidden clips it until then)
-    <div className={`h-28 shrink-0 transition-[width] duration-200 ease-out ${transition ? "w-40" : "w-0"}`}>
+    // css keyframes, not react-driven transitions: they run on dom insertion, so the entry
+    // can't be skipped when react batches the mount and the state flip into one paint
+    <div className="h-28 w-40 shrink-0 animate-livedrop-gap">
     <div
-      className={`flex flex-col min-w-[160px] h-28 items-center transition-all duration-300 ease-out delay-200 border bg-[#141225]
-      ${transition ? "translate-y-0 opacity-100" : "-translate-y-[120%] opacity-0"}`}
+      className="flex flex-col min-w-[160px] h-28 items-center animate-livedrop-fall border bg-[#141225]"
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       style={{

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -12,6 +12,7 @@ import Sidebar from "./Sidebar";
 import { BasicItem } from "../Types";
 
 interface CaseOpeningItem {
+  id: string;
   caseImage: string;
   timestamp: number;
   user: {
@@ -30,6 +31,7 @@ interface Header {
 }
 
 interface ItemsQueue {
+  id: string;
   items: BasicItem[];
   caseImages: string[];
   user: {
@@ -82,6 +84,7 @@ const Header: React.FC<Header> = ({ onlineUsers, recentCaseOpenings, notificatio
       const newQueue = [];
       const newItems = recentCaseOpenings.map((opening) => {
         return {
+          id: opening.id,
           items: opening.winningItems,
           caseImages: [opening.caseImage],
           user: opening.user,
@@ -136,9 +139,9 @@ const Header: React.FC<Header> = ({ onlineUsers, recentCaseOpenings, notificatio
 
             <div className="flex h-28 bg-[#141225] ">
               <div className="flex overflow-hidden justify-start transition-all">
-                {ItemsQueue.map((opening, index) => (
+                {ItemsQueue.map((opening) => (
                   <CaseOpenedNotification
-                    key={index}
+                    key={opening.id}
                     item={opening.items[0]}
                     caseImage={opening.caseImages[0]}
                     user={opening.user}

--- a/src/index.css
+++ b/src/index.css
@@ -77,6 +77,38 @@
   animation: fadeOut 2s ease-in-out forwards;
 }
 
+/* live drop entry: the wrapper opens a gap in the row, then the card falls into it */
+.animate-livedrop-gap {
+  animation: livedrop-gap 0.2s ease-out both;
+}
+
+.animate-livedrop-fall {
+  animation: livedrop-fall 0.5s ease-out both;
+}
+
+@keyframes livedrop-gap {
+  from {
+    width: 0;
+  }
+
+  to {
+    width: 10rem;
+  }
+}
+
+@keyframes livedrop-fall {
+  0%,
+  40% {
+    transform: translateY(-120%);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;


### PR DESCRIPTION
Problem: new live drops pop into the row with no animation. The row keyed cards by array index, so every new drop rewrote all cards in place, which also made any entry animation impossible.

Change: each drop gets a stable id (used as the React key), and a new card enters in two phases: the row smoothly opens a 160px gap, pushing the older drops right, then the card falls into the gap from above, clipped by the row until it lands. Existing hover flip and rarity border are untouched.

Tests: lint (no new warnings), unit (19), and build all pass.