### PR TITLE
Cap the live drop queue immutably

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,8 @@ function App() {
 
       // Wait 7.5 seconds to show the notification
       setTimeout(() => {
-        setRecentCaseOpenings((prevOpenings: any) => [data, ...prevOpenings]);
+        // cap the queue immutably as it grows; the oldest drop falls off the end
+        setRecentCaseOpenings((prevOpenings: any) => [data, ...prevOpenings].slice(0, 20));
       }, 7500);
     });
 
@@ -166,16 +167,6 @@ function App() {
   const toogleUserFlow = (state: boolean) => {
     setOpenUserFlow(state);
   }
-
-  //if there's more than 20 items, remove the last one from the array
-  useEffect(() => {
-    if (recentCaseOpenings.length > 20) {
-      setRecentCaseOpenings((prevOpenings: any) => {
-        prevOpenings.pop();
-        return prevOpenings;
-      });
-    }
-  }, [recentCaseOpenings]);
 
   return (
     <div className="flex flex-col min-h-screen items-start justify-start bg-[#151225] text-white">


### PR DESCRIPTION
Problem: the live drop queue capped itself in an effect that popped the state array in place and returned the same reference. React bails out on same-reference updates, so the state was mutated behind React's back and the queue sat one item over the cap. Fragile, and the suspect behind the row appearing to stop updating once full.

Change: cap at the prepend (`[data, ...prev].slice(0, 20)`), immutably, and delete the extra effect. Verified in a browser harness: with the row overflowing the viewport, new drops keep appearing newest-first and the oldest falls off, both for burst and spaced arrivals.

Tests: typecheck, lint, and build pass.