### PR TITLE
Stop flashing multi-open results before the spin

### DIFF
--- a/src/pages/CasePage/CasePage.tsx
+++ b/src/pages/CasePage/CasePage.tsx
@@ -20,7 +20,6 @@ const CasePage = () => {
   const [started, setStarted] = useState<boolean>(false);
   const [openedItems, setOpenedItems] = useState<BasicItem[]>([]);
   const [showPrize, setShowPrize] = useState<boolean>(false);
-  const [hasSpinned, setHasSpinned] = useState<boolean>(false);
   const [animationAux, setAnimationAux] = useState<boolean>(false);
   const [animationAux2, setAnimationAux2] = useState<boolean>(false);
   const [loadingButton, setLoadingButton] = useState<boolean>(false);
@@ -60,7 +59,6 @@ const CasePage = () => {
 
     setTimeout(() => {
       setStarted(true);
-      setHasSpinned(true);
     }, 500);
 
     setTimeout(() => {
@@ -86,7 +84,6 @@ const CasePage = () => {
       toast.success(res.message, { theme: "dark" });
       setShowPrize(false);
       setAnimationAux2(false);
-      setHasSpinned(false);
       setOpenedItems([]);
     } catch (error: any) {
       toast.error(error?.response?.data?.message || "Could not sell items", { theme: "dark" });
@@ -135,7 +132,7 @@ const CasePage = () => {
           {loading ? <Skeleton width={200} height={30} /> : data && data.title}
         </h1>
 
-        <RouletteContainer started={started} showPrize={showPrize} hasSpinned={hasSpinned} loading={loading} data={data} openedItems={openedItems} animationAux={animationAux} animationAux2={animationAux2} quantity={quantity} />
+        <RouletteContainer started={started} showPrize={showPrize} loading={loading} data={data} openedItems={openedItems} animationAux={animationAux} animationAux2={animationAux2} quantity={quantity} />
         <div
           className={`flex flex-col md:flex-row justify-center items-center gap-4 w-68 mt-8  ${started ? "opacity-0" : "opacity-100"} transition-all`}
         >

--- a/src/pages/CasePage/RoulleteContainer.tsx
+++ b/src/pages/CasePage/RoulleteContainer.tsx
@@ -9,14 +9,13 @@ interface RouletteContainerProps {
     data: Case;
     started: boolean;
     showPrize: boolean;
-    hasSpinned: boolean;
     animationAux: boolean;
     openedItems: any[];
     animationAux2: boolean;
     quantity: number;
 }
 
-const RouletteContainer: React.FC<RouletteContainerProps> = ({ loading, data, started, showPrize, hasSpinned, animationAux, openedItems, animationAux2, quantity }) => {
+const RouletteContainer: React.FC<RouletteContainerProps> = ({ loading, data, started, showPrize, animationAux, openedItems, animationAux2, quantity }) => {
 
     return (
         <div className="flex">
@@ -42,22 +41,11 @@ const RouletteContainer: React.FC<RouletteContainerProps> = ({ loading, data, st
                         height: "48px"
                     }} />
                 </div>
-                {!started && !showPrize && !hasSpinned ? (
-                    loading ? (
-                        <Skeleton width={208} height={208} />
-                    ) : (
-                        <img
-                            src={data.image}
-                            alt={data.title}
-                            className={classNames(
-                                "w-52 h-52 object-cover z-10",
-                                { "animate-bounce-up-fade": animationAux },
-                                "transition duration-500"
-                            )}
-                            id="caseImage"
-                        />
-                    )
-                ) : started && !showPrize ? (
+                {/* prize renders only once showPrize is set; falling through to it during
+                    the pre-spin delay used to flash the multi-open result names early */}
+                {showPrize ? (
+                    <ShowPrize openedItems={openedItems} showPrize={showPrize} animationAux2={animationAux2} />
+                ) : started ? (
 
                     <div className={`flex gap-8`}>
                         {
@@ -74,8 +62,19 @@ const RouletteContainer: React.FC<RouletteContainerProps> = ({ loading, data, st
 
                         }
                     </div>
+                ) : loading ? (
+                    <Skeleton width={208} height={208} />
                 ) : (
-                    <ShowPrize openedItems={openedItems} showPrize={showPrize} animationAux2={animationAux2} />
+                    <img
+                        src={data.image}
+                        alt={data.title}
+                        className={classNames(
+                            "w-52 h-52 object-cover z-10",
+                            { "animate-bounce-up-fade": animationAux },
+                            "transition duration-500"
+                        )}
+                        id="caseImage"
+                    />
                 )}
             </div>
 


### PR DESCRIPTION
Problem: opening a case again (for example 5x, the vertical reels) briefly showed the names of the items just won, before the reels started. `resetProps` clears `showPrize` but `started` only turns on 500ms later, and during that gap the roulette container's condition chain fell through to `ShowPrize`, which for multi-opens renders the item names unconditionally. The winners flashed on screen at the start of every repeat spin.

Change: the prize branch is gated on `showPrize` alone, and the pre-spin gap shows the case image (with its bounce animation) like a first open does. The `hasSpinned` state existed only to serve the old condition ordering and is removed.

Tests: typecheck, lint, and build pass.