### PR TITLE
Add provably fair Plinko game

### DIFF
--- a/backend/__tests__/integration/plinkoPF.test.js
+++ b/backend/__tests__/integration/plinkoPF.test.js
@@ -1,0 +1,125 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Roll = require("../../models/Roll");
+const Seed = require("../../models/Seed");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+const { ROWS, PAYOUTS } = require("../../utils/plinkoMath");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  await Promise.all([Seed.syncIndexes(), Roll.syncIndexes()]);
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(walletBalance = 1000) {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+}
+
+test("a drop charges the bet, credits the bin payout, and records a plinko roll", async () => {
+  const u = await makeUser(1000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const res = await request(app).post("/games/plinko").set(auth).send({ betAmount: 100, risk: "medium" });
+  expect(res.status).toBe(200);
+  expect(res.body.rollId).toMatch(/^R\d+$/);
+  expect(res.body.path).toMatch(new RegExp(`^[LR]{${ROWS}}$`));
+  expect(res.body.bin).toBe(res.body.path.split("R").length - 1);
+  expect(res.body.multiplier).toBe(PAYOUTS.medium[res.body.bin] / 100);
+  expect(res.body.payout).toBe((100 * PAYOUTS.medium[res.body.bin]) / 100);
+
+  const roll = await Roll.findOne({ userId: u._id, game: "plinko" });
+  expect(roll).toBeTruthy();
+  expect(roll.outcome.path).toBe(res.body.path);
+  expect(roll.outcome.payout).toBe(res.body.payout);
+  expect((await Seed.findOne({ userId: u._id, active: true })).nonce).toBe(1);
+
+  const after = await User.findById(u._id);
+  expect(after.walletBalance).toBeCloseTo(1000 - 100 + res.body.payout, 10);
+
+  const bet = await Transaction.findOne({ userId: u._id, type: TX.PLINKO_BET });
+  const win = await Transaction.findOne({ userId: u._id, type: TX.PLINKO_WIN });
+  expect(bet).toBeTruthy();
+  expect(bet.amount).toBe(100);
+  expect(win).toBeTruthy();
+  expect(win.amount).toBe(res.body.payout);
+});
+
+test("an insufficient balance answers 400 and moves no money", async () => {
+  const u = await makeUser(5);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const res = await request(app).post("/games/plinko").set(auth).send({ betAmount: 100, risk: "low" });
+  expect(res.status).toBe(400);
+  expect((await User.findById(u._id)).walletBalance).toBe(5);
+  expect(await Roll.findOne({ userId: u._id, game: "plinko" })).toBeNull();
+});
+
+test("bad inputs are rejected before any money moves", async () => {
+  const u = await makeUser(100000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const bad = [
+    { betAmount: 10, risk: "extreme" },
+    { betAmount: 10, risk: "constructor" }, // inherited object keys are not risks
+    { betAmount: 10, risk: "__proto__" },
+    { betAmount: 10, risk: 5 },
+    { betAmount: 10 },
+    { betAmount: 10.5, risk: "low" },
+    { betAmount: 0, risk: "low" },
+    { betAmount: -5, risk: "medium" },
+    { betAmount: "10", risk: "high" },
+    { betAmount: 2000, risk: "high" }, // over the per-risk cap
+    { betAmount: 20000, risk: "medium" },
+  ];
+  for (const body of bad) {
+    const res = await request(app).post("/games/plinko").set(auth).send(body);
+    expect(res.status).toBe(400);
+  }
+  expect((await User.findById(u._id)).walletBalance).toBe(100000);
+});
+
+test("concurrent drops reserve distinct nonces", async () => {
+  const u = await makeUser(1000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const [a, b] = await Promise.all([
+    request(app).post("/games/plinko").set(auth).send({ betAmount: 10, risk: "low" }),
+    request(app).post("/games/plinko").set(auth).send({ betAmount: 10, risk: "low" }),
+  ]);
+  expect(a.status).toBe(200);
+  expect(b.status).toBe(200);
+
+  const nonces = (await Roll.find({ userId: u._id, game: "plinko" })).map((r) => r.nonce).sort();
+  expect(nonces).toEqual([0, 1]);
+});
+
+test("a rotated seed lets the verifier reproduce the drop", async () => {
+  const u = await makeUser(1000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const drop = await request(app).post("/games/plinko").set(auth).send({ betAmount: 50, risk: "high" });
+  expect(drop.status).toBe(200);
+
+  // still hidden: the active seed must not verify
+  const early = await request(app).get(`/fair/roll/${drop.body.rollId}/verify`);
+  expect(early.body.ok).toBe(false);
+
+  await request(app).post("/fair/rotate").set(auth).send({});
+
+  const verified = await request(app).get(`/fair/roll/${drop.body.rollId}/verify`);
+  expect(verified.body.ok).toBe(true);
+  expect(verified.body.commitmentValid).toBe(true);
+  expect(verified.body.recomputedPath).toBe(drop.body.path);
+  expect(verified.body.recomputedBin).toBe(drop.body.bin);
+  expect(verified.body.recomputedMultiplier).toBe(drop.body.multiplier);
+});

--- a/backend/__tests__/unit/plinkoMath.test.js
+++ b/backend/__tests__/unit/plinkoMath.test.js
@@ -1,0 +1,75 @@
+const { ROWS, PAYOUTS, derivePath, binFromPath } = require("../../utils/plinkoMath");
+const PlinkoGameController = require("../../games/plinko");
+
+// binomial C(16, k) for each landing bin, over a 2^16 sample space
+function binomialCoefficients(n) {
+  let row = [1];
+  for (let i = 0; i < n; i++) {
+    row = row.map((v, k) => v + (row[k - 1] || 0)).concat(1);
+  }
+  return row;
+}
+
+describe("plinko payout tables", () => {
+  const coefficients = binomialCoefficients(ROWS);
+  const space = Math.pow(2, ROWS);
+
+  test("every risk has one multiplier per bin, symmetric, in whole cents", () => {
+    for (const table of Object.values(PAYOUTS)) {
+      expect(table).toHaveLength(ROWS + 1);
+      for (let k = 0; k <= ROWS; k++) {
+        expect(Number.isInteger(table[k])).toBe(true);
+        expect(table[k]).toBeGreaterThan(0);
+        expect(table[k]).toBe(table[ROWS - k]);
+      }
+    }
+  });
+
+  test("the exact return of every risk sits in the house's 3-4% edge band", () => {
+    for (const [risk, table] of Object.entries(PAYOUTS)) {
+      let weighted = 0;
+      for (let k = 0; k <= ROWS; k++) {
+        weighted += coefficients[k] * table[k];
+      }
+      const rtp = weighted / 100 / space;
+      expect(rtp).toBeGreaterThan(0.955);
+      expect(rtp).toBeLessThan(0.975);
+    }
+  });
+
+  test("each risk's bet cap keeps the top payout at exactly 1,000,000", () => {
+    for (const [risk, table] of Object.entries(PAYOUTS)) {
+      expect((PlinkoGameController.MAX_BET[risk] * table[0]) / 100).toBeLessThanOrEqual(1000000);
+    }
+  });
+});
+
+describe("plinko path derivation", () => {
+  const serverSeed = "s".repeat(64);
+
+  test("paths are deterministic, one step per row, and only ever L or R", () => {
+    for (let nonce = 0; nonce < 200; nonce++) {
+      const path = derivePath(serverSeed, "client", nonce);
+      expect(path).toHaveLength(ROWS);
+      expect(/^[LR]+$/.test(path)).toBe(true);
+    }
+    expect(derivePath(serverSeed, "client", 7)).toBe(derivePath(serverSeed, "client", 7));
+  });
+
+  test("the bin is the count of rightward deflections", () => {
+    expect(binFromPath("L".repeat(ROWS))).toBe(0);
+    expect(binFromPath("R".repeat(ROWS))).toBe(ROWS);
+    expect(binFromPath("LR".repeat(ROWS / 2))).toBe(ROWS / 2);
+  });
+
+  test("bins center around the middle of the board", () => {
+    // deterministic sample: the average landing bin over many nonces stays near 8
+    let sum = 0;
+    const draws = 500;
+    for (let nonce = 0; nonce < draws; nonce++) {
+      sum += binFromPath(derivePath(serverSeed, "client", nonce));
+    }
+    expect(sum / draws).toBeGreaterThan(7.5);
+    expect(sum / draws).toBeLessThan(8.5);
+  });
+});

--- a/backend/games/plinko.js
+++ b/backend/games/plinko.js
@@ -1,0 +1,120 @@
+const { chargeUser, creditUser, TX } = require("../utils/economy");
+const seeds = require("../utils/seeds");
+const rolls = require("../utils/rolls");
+const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const { PLINKO_ALGO_VERSION, PAYOUTS, derivePath, binFromPath } = require("../utils/plinkoMath");
+
+// per-risk bet ceilings keep the maximum payout at 1,000,000 (cap times top multiplier)
+const MAX_BET = { low: 50000, medium: 10000, high: 1000 };
+
+// errors carry an http status so the route can answer 400s without string matching
+function httpError(status, message) {
+    const err = new Error(message);
+    err.status = status;
+    return err;
+}
+
+class PlinkoGameController {
+
+    static async drop(userId, betAmount, risk, io) {
+
+        // own-property check: inherited keys like "constructor" must not pass as risks
+        if (typeof risk !== "string" || !Object.prototype.hasOwnProperty.call(PAYOUTS, risk)) {
+            throw httpError(400, "Invalid risk level");
+        }
+        const table = PAYOUTS[risk];
+
+        // check bet amount (whole coins only: fractional bets leak into the balance)
+        if (!Number.isInteger(betAmount) || betAmount < 1 || betAmount > MAX_BET[risk]) {
+            throw httpError(400, "Invalid bet amount");
+        }
+
+        // reserve the provably-fair nonce up front (atomic, never rolled back)
+        const reserved = await seeds.reserveNonces(userId, 1);
+        const nonce = reserved.startNonce;
+
+        // atomically take the stake, rejecting if the balance can't cover it
+        const player = await chargeUser(userId, betAmount, {
+            type: TX.PLINKO_BET,
+            meta: { betAmount, risk },
+        });
+        if (!player) {
+            throw httpError(400, "Insufficient balance");
+        }
+
+        // derive the peg path from the seed (one draw per row) and price the landing bin
+        const path = derivePath(reserved.serverSeed, reserved.clientSeed, nonce);
+        const bin = binFromPath(path);
+        const multiplierCents = table[bin];
+        const payout = (betAmount * multiplierCents) / 100; // exact: integer bet times integer cents
+
+        // pay out winnings atomically; a rolled-back credit is settled manually from the roll
+        let balanceAfter = player.walletBalance;
+        let credited = null;
+        if (payout > 0) {
+            credited = await creditUser(userId, payout, payout, {
+                type: TX.PLINKO_WIN,
+                meta: { betAmount, risk, bin, payout },
+            });
+            if (credited) balanceAfter = credited.walletBalance;
+        }
+        const payoutFailed = payout > 0 && !credited;
+
+        const updatedUserData = {
+            walletBalance: balanceAfter,
+            xp: player.xp,
+            level: player.level,
+        };
+
+        // delayed so the new balance lands about when the ball does
+        const emitTimer = setTimeout(() => {
+            io.to(userId.toString()).emit('userDataUpdated', updatedUserData);
+        }, 3000);
+        if (emitTimer.unref) emitTimer.unref(); // don't hold the event loop open (tests)
+
+        // record the provably-fair audit roll (the path and payout reproduce from the seed);
+        // money is already settled, so a failed record must not turn the drop into an error
+        let rec = null;
+        try {
+            rec = await rolls.recordRoll({
+                game: "plinko",
+                userId,
+                seedId: reserved.seedId,
+                clientSeed: reserved.clientSeed,
+                serverSeedHash: reserved.serverSeedHash,
+                nonce,
+                roll: Math.floor(rollFloat(reserved.serverSeed, reserved.clientSeed, nonce, 0) * TOTAL) + 1,
+                total: TOTAL,
+                outcome: {
+                    risk,
+                    betAmount,
+                    path,
+                    bin,
+                    multiplier: multiplierCents / 100,
+                    payout,
+                    algoVersion: PLINKO_ALGO_VERSION,
+                },
+            });
+        } catch (recordError) {
+            console.error("plinko roll record failed", recordError);
+        }
+
+        if (payoutFailed) {
+            throw httpError(500, "Payout failed, contact support");
+        }
+
+        return {
+            betAmount,
+            risk,
+            path,
+            bin,
+            multiplier: multiplierCents / 100,
+            payout,
+            rollId: rec ? rec.rollId : null,
+        };
+    }
+}
+
+PlinkoGameController.MAX_BET = MAX_BET;
+
+module.exports = PlinkoGameController;

--- a/backend/games/plinko.js
+++ b/backend/games/plinko.js
@@ -69,7 +69,7 @@ class PlinkoGameController {
         // delayed so the new balance lands about when the ball does
         const emitTimer = setTimeout(() => {
             io.to(userId.toString()).emit('userDataUpdated', updatedUserData);
-        }, 3000);
+        }, 3200);
         if (emitTimer.unref) emitTimer.unref(); // don't hold the event loop open (tests)
 
         // record the provably-fair audit roll (the path and payout reproduce from the seed);

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -8,7 +8,7 @@ const RollSchema = new mongoose.Schema(
   {
     rollId: { type: String, required: true, unique: true }, // public short id, e.g. R821872881
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    game: { type: String, enum: ["case", "upgrade", "slots", "battle"], required: true },
+    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko"], required: true },
 
     seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
     clientSeed: { type: String, required: true },

--- a/backend/routes/fairRoutes.js
+++ b/backend/routes/fairRoutes.js
@@ -88,10 +88,10 @@ router.get("/roll-by-item/:uniqueId", async (req, res) => {
   }
 });
 
-// server-side reproduction of a case roll (only possible after reveal)
+// server-side reproduction of a roll (only possible after reveal); case and plinko today
 router.get("/roll/:rollId/verify", async (req, res) => {
   try {
-    res.json(await rolls.verifyCaseRoll(req.params.rollId));
+    res.json(await rolls.verifyRoll(req.params.rollId));
   } catch (e) {
     res.status(500).json({ message: "Server error" });
   }

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -7,6 +7,7 @@ const Case = require("../models/Case");
 const Round = require("../models/Round");
 const upgradeItems = require("../games/upgrade");
 const SlotGameController = require("../games/slot");
+const PlinkoGameController = require("../games/plinko");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const referrals = require("../utils/referrals");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
@@ -193,6 +194,23 @@ module.exports = (io) => {
       res.json(result);
     } catch (error) {
       res.status(500).json({ message: error.message });
+    }
+  });
+
+  // drop a plinko ball
+  router.post('/plinko', isAuthenticated, async (req, res) => {
+    const user = req.user;
+
+    try {
+      const { betAmount, risk } = req.body;
+
+      const result = await PlinkoGameController.drop(user._id, betAmount, risk, io);
+      res.json(result);
+    } catch (error) {
+      // statused errors are intentional answers; anything else stays generic
+      if (error.status) return res.status(error.status).json({ message: error.message });
+      console.error(error);
+      res.status(500).json({ message: "Internal server error" });
     }
   });
 

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -25,6 +25,8 @@ const COUNTERPARTY_FOR_TYPE = {
   case_open: HOUSE,
   slot_bet: HOUSE,
   slot_win: HOUSE,
+  plinko_bet: HOUSE,
+  plinko_win: HOUSE,
   crash_bet: HOUSE,
   crash_cashout: HOUSE,
   crash_refund: HOUSE,

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -13,6 +13,8 @@ const TX = {
   CASE_OPEN: "case_open",
   SLOT_BET: "slot_bet",
   SLOT_WIN: "slot_win",
+  PLINKO_BET: "plinko_bet",
+  PLINKO_WIN: "plinko_win",
   CRASH_BET: "crash_bet",
   CRASH_CASHOUT: "crash_cashout",
   CRASH_REFUND: "crash_refund", // stake returned when a restart voids a live round
@@ -38,7 +40,7 @@ const TX = {
 };
 
 // every KP put at risk on a game; missions and referral commission both count these
-const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
+const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 function calculateXPForLevel(level) {
   return Math.floor(BASE_XP * Math.pow(GROWTH_RATE, level - 1));

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -7,8 +7,8 @@ const MissionState = require("../models/MissionState");
 const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
 const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 
-// a "big win" is any single game payout (slots / crash cashout / coin flip win)
-const WIN_TYPES = [TX.SLOT_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+// a "big win" is any single game payout (slots / plinko / crash cashout / coin flip win)
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 
 // missions currently offered; a disabled one (active:false) stays defined but is
 // never shown, announced, or claimable

--- a/backend/utils/plinkoMath.js
+++ b/backend/utils/plinkoMath.js
@@ -1,0 +1,33 @@
+const { rollFloat } = require("./provablyFair");
+
+const PLINKO_ALGO_VERSION = 1; // bump if the row count or a payout table changes
+
+const ROWS = 16;
+
+// multipliers in integer cents per landing bin (0..16), symmetric around the center.
+// tables are tuned to a ~3.5% house edge on every risk, in line with slots and crash.
+const PAYOUTS = {
+  low: [1500, 800, 220, 160, 130, 110, 105, 95, 60, 95, 105, 110, 130, 160, 220, 800, 1500],
+  medium: [10000, 4000, 900, 500, 290, 140, 100, 50, 30, 50, 100, 140, 290, 500, 900, 4000, 10000],
+  high: [100000, 12000, 2500, 900, 400, 170, 30, 20, 20, 20, 30, 170, 400, 900, 2500, 12000, 100000],
+};
+
+// one draw per row; below 0.5 deflects the ball left, otherwise right (an unbiased bit per peg)
+function derivePath(serverSeed, clientSeed, nonce) {
+  let path = "";
+  for (let row = 0; row < ROWS; row++) {
+    path += rollFloat(serverSeed, clientSeed, nonce, row) < 0.5 ? "L" : "R";
+  }
+  return path;
+}
+
+// the landing bin is simply how many pegs sent the ball right
+function binFromPath(path) {
+  let bin = 0;
+  for (const step of path) {
+    if (step === "R") bin += 1;
+  }
+  return bin;
+}
+
+module.exports = { PLINKO_ALGO_VERSION, ROWS, PAYOUTS, derivePath, binFromPath };

--- a/backend/utils/rolls.js
+++ b/backend/utils/rolls.js
@@ -2,7 +2,8 @@ const crypto = require("crypto");
 const Roll = require("../models/Roll");
 const Seed = require("../models/Seed");
 const CaseConfig = require("../models/CaseConfig");
-const { roll: computeRoll, pickFromRanges } = require("./provablyFair");
+const { roll: computeRoll, pickFromRanges, hashServerSeed } = require("./provablyFair");
+const { PAYOUTS: PLINKO_PAYOUTS, PLINKO_ALGO_VERSION, derivePath, binFromPath } = require("./plinkoMath");
 
 function generateRollId() {
   return "R" + crypto.randomInt(100000000, 1000000000).toString(); // "R" + 9 digits
@@ -91,4 +92,67 @@ async function verifyCaseRoll(rollId) {
   };
 }
 
-module.exports = { generateRollId, recordRoll, getRollForVerify, getRollForItem, verifyCaseRoll };
+// recompute a plinko roll's path and payout from its public inputs; the same steps
+// any third party would run once the seed is revealed
+async function verifyPlinkoRoll(rollId) {
+  const v = await getRollForVerify(rollId);
+  if (!v || v.game !== "plinko") return { ok: false, reason: "not a plinko roll" };
+  if (!v.serverSeed) return { ok: false, reason: "server seed not revealed yet" };
+
+  const outcome = v.outcome || {};
+  // rolls from an older table or row count cannot verify against the current constants
+  if (outcome.algoVersion !== PLINKO_ALGO_VERSION) {
+    return { ok: false, reason: "algorithm version superseded" };
+  }
+  const table = Object.prototype.hasOwnProperty.call(PLINKO_PAYOUTS, outcome.risk)
+    ? PLINKO_PAYOUTS[outcome.risk]
+    : null;
+  if (!table) return { ok: false, reason: "unknown risk level" };
+
+  const commitmentValid = hashServerSeed(v.serverSeed) === v.serverSeedHash;
+  const recomputedRoll = computeRoll(v.serverSeed, v.clientSeed, v.nonce, {
+    total: v.total,
+    cursor: v.cursor,
+  });
+  const path = derivePath(v.serverSeed, v.clientSeed, v.nonce);
+  const bin = binFromPath(path);
+  const multiplier = table[bin] / 100;
+  const ok =
+    commitmentValid &&
+    recomputedRoll === v.roll &&
+    path === outcome.path &&
+    bin === outcome.bin &&
+    multiplier === outcome.multiplier;
+
+  return {
+    ok,
+    commitmentValid,
+    recomputedRoll,
+    expectedRoll: v.roll,
+    recomputedPath: path,
+    recomputedBin: bin,
+    recomputedMultiplier: multiplier,
+    expectedPath: outcome.path,
+    expectedBin: outcome.bin,
+    expectedMultiplier: outcome.multiplier,
+  };
+}
+
+// route a verify request to the game's reference verifier
+async function verifyRoll(rollId) {
+  const r = await Roll.findOne({ rollId }).select("game").lean();
+  if (!r) return { ok: false, reason: "roll not found" };
+  if (r.game === "case") return verifyCaseRoll(rollId);
+  if (r.game === "plinko") return verifyPlinkoRoll(rollId);
+  return { ok: false, reason: "no server-side verifier for this game" };
+}
+
+module.exports = {
+  generateRollId,
+  recordRoll,
+  getRollForVerify,
+  getRollForItem,
+  verifyCaseRoll,
+  verifyPlinkoRoll,
+  verifyRoll,
+};

--- a/backend/utils/seeds.js
+++ b/backend/utils/seeds.js
@@ -34,7 +34,12 @@ async function reserveNonces(userId, count = 1) {
     { $inc: { nonce: count } },
     { new: false }
   );
-  if (!before) throw new Error("Seed rotated mid-roll, please retry");
+  if (!before) {
+    // a benign race with a concurrent rotate; callers can surface it as a retryable 409
+    const err = new Error("Seed rotated mid-roll, please retry");
+    err.status = 409;
+    throw err;
+  }
 
   const material = {
     seedId: seed._id,

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -38,6 +38,7 @@ test("every game in the listing is clickable and navigates", async ({ page }) =>
     { text: "Play CoinFlip", url: /\/coinflip/ },
     { text: "Play Upgrade", url: /\/upgrade/ },
     { text: "Play Slot", url: /\/slot/ },
+    { text: "Play Plinko", url: /\/plinko/ },
   ];
 
   for (const game of games) {

--- a/public/images/plinko.svg
+++ b/public/images/plinko.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 348">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#221f3d"/>
+      <stop offset="1" stop-color="#151225"/>
+    </linearGradient>
+    <radialGradient id="ball" cx="0.35" cy="0.3" r="1">
+      <stop offset="0" stop-color="#ffe680"/>
+      <stop offset="1" stop-color="#f2b705"/>
+    </radialGradient>
+  </defs>
+  <rect width="256" height="348" rx="14" fill="url(#bg)"/>
+  <g fill="#cfccdf">
+    <circle cx="104" cy="96" r="5"/><circle cx="128" cy="96" r="5"/><circle cx="152" cy="96" r="5"/>
+    <circle cx="92" cy="130" r="5"/><circle cx="116" cy="130" r="5"/><circle cx="140" cy="130" r="5"/><circle cx="164" cy="130" r="5"/>
+    <circle cx="80" cy="164" r="5"/><circle cx="104" cy="164" r="5"/><circle cx="128" cy="164" r="5"/><circle cx="152" cy="164" r="5"/><circle cx="176" cy="164" r="5"/>
+    <circle cx="68" cy="198" r="5"/><circle cx="92" cy="198" r="5"/><circle cx="116" cy="198" r="5"/><circle cx="140" cy="198" r="5"/><circle cx="164" cy="198" r="5"/><circle cx="188" cy="198" r="5"/>
+    <circle cx="56" cy="232" r="5"/><circle cx="80" cy="232" r="5"/><circle cx="104" cy="232" r="5"/><circle cx="128" cy="232" r="5"/><circle cx="152" cy="232" r="5"/><circle cx="176" cy="232" r="5"/><circle cx="200" cy="232" r="5"/>
+  </g>
+  <circle cx="140" cy="146" r="12" fill="url(#ball)" stroke="#151225" stroke-width="2"/>
+  <g>
+    <rect x="46" y="268" width="24" height="26" rx="4" fill="#FFCC00"/>
+    <rect x="74" y="268" width="24" height="26" rx="4" fill="#DF3D6E"/>
+    <rect x="102" y="268" width="24" height="26" rx="4" fill="#8B4ADF"/>
+    <rect x="130" y="268" width="24" height="26" rx="4" fill="#8B4ADF"/>
+    <rect x="158" y="268" width="24" height="26" rx="4" fill="#DF3D6E"/>
+    <rect x="186" y="268" width="24" height="26" rx="4" fill="#FFCC00"/>
+  </g>
+  <text x="128" y="326" text-anchor="middle" font-family="Arial, sans-serif" font-size="26" font-weight="bold" fill="#e1dde9" letter-spacing="6">PLINKO</text>
+</svg>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -7,6 +7,7 @@ import CoinFlip from "./pages/Coin/CoinFlip";
 import CrashGame from "./pages/Crash/Crash";
 import Upgrade from "./pages/Upgrade/Upgrade";
 import Slot from "./pages/Slot/Slot";
+import Plinko from "./pages/Plinko";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
 import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
@@ -26,6 +27,7 @@ const defaultRoutes = (
     <Route path="/crash" element={<CrashGame />} />
     <Route path="/upgrade" element={<Upgrade />} />
     <Route path="/slot" element={<Slot />} />
+    <Route path="/plinko" element={<Plinko />} />
     <Route path="/battles" element={<Battles />} />
     <Route path="/battles/:id" element={<BattleRoom />} />
     <Route path="/provably-fair" element={<ProvablyFair />} />

--- a/src/components/header/Navbar/Navbar.tsx
+++ b/src/components/header/Navbar/Navbar.tsx
@@ -11,7 +11,7 @@ import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { BsCoin } from "react-icons/bs";
 import { SlPlane } from "react-icons/sl";
 import { GiUpgrade, GiCrossedSwords } from 'react-icons/gi';
-import { TbCat } from "react-icons/tb";
+import { TbCat, TbGridDots } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { FaBars } from 'react-icons/fa';
 import RightContent from "./RightContent";
@@ -89,6 +89,11 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
       name: "Slots",
       path: "/slot",
       icon: <TbCat className="text-2xl" />,
+    },
+    {
+      name: "Plinko",
+      path: "/plinko",
+      icon: <TbGridDots className="text-2xl" />,
     },
     {
       name: "Case Battles",

--- a/src/components/header/Sidebar.tsx
+++ b/src/components/header/Sidebar.tsx
@@ -4,7 +4,7 @@ import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { SlPlane } from "react-icons/sl";
 import { FaHome } from "react-icons/fa";
 import { Link } from "react-router-dom";
-import { TbCat } from "react-icons/tb";
+import { TbCat, TbGridDots } from "react-icons/tb";
 import ClaimBonus from "../header/ClaimBonus";
 import { useContext } from "react";
 import UserContext from "../../UserContext";
@@ -48,6 +48,11 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
             name: "Slots",
             path: "/slot",
             icon: <TbCat className="text-2xl" />,
+        },
+        {
+            name: "Plinko",
+            path: "/plinko",
+            icon: <TbGridDots className="text-2xl" />,
         },
         {
             name: "Case Battles",

--- a/src/pages/Home/GamesListing.tsx
+++ b/src/pages/Home/GamesListing.tsx
@@ -38,6 +38,12 @@ const GameListing: React.FC<GameListingProps> = ({ name, description }) => {
       image: "/images/boo.webp",
       link: "/battles",
     },
+    {
+      id: "6",
+      title: "Plinko",
+      image: "/images/plinko.svg",
+      link: "/plinko",
+    },
   ];
   return (
     <div className="w-full flex flex-col gap-4 py-10 items-center" key={name}>

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -26,9 +26,11 @@ export const usePlinkoServices = () => {
   const [balls, setBalls] = useState<PlinkoBall[]>([]);
   const [history, setHistory] = useState<PlinkoBall[]>([]);
   const [lastHit, setLastHit] = useState<{ bin: number; seq: number } | null>(null);
+  const [pegPulses, setPegPulses] = useState<Record<string, number>>({});
 
   const ballSeq = useRef(0);
   const hitSeq = useRef(0);
+  const pulseSeq = useRef(0);
   const settled = useRef<Set<string>>(new Set());
   const autoLeftRef = useRef(0);
   const autoTimer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -101,6 +103,13 @@ export const usePlinkoServices = () => {
     setDropping(false);
   };
 
+  // a fresh sequence per strike remounts the peg's pulse animation
+  const pulsePeg = useCallback((row: number, index: number) => {
+    pulseSeq.current += 1;
+    const seq = pulseSeq.current;
+    setPegPulses((prev) => ({ ...prev, [`${row}-${index}`]: seq }));
+  }, []);
+
   // guarded by key so a duplicate animation-complete cannot double-record a ball
   const settleBall = useCallback((ball: PlinkoBall) => {
     if (settled.current.has(ball.key)) return;
@@ -148,6 +157,8 @@ export const usePlinkoServices = () => {
     balls,
     history,
     lastHit,
+    pegPulses,
+    pulsePeg,
     settleBall,
     openRoll: (rollId: string) => navigate(`/provably-fair?roll=${rollId}`),
   };

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -1,0 +1,154 @@
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import UserContext from "../../UserContext";
+import { dropPlinko } from "../../services/games/GamesServices";
+import { MAX_BET, PlinkoRisk } from "./plinkoBoard";
+import { PlinkoBall, PlinkoDropResult } from "./Plinko.types";
+
+const DEFAULT_BET = 10;
+const HISTORY_SIZE = 8;
+// paced so an auto run reads as a stream of balls instead of one burst
+const AUTO_DROP_INTERVAL_MS = 400;
+export const AUTO_COUNTS = [10, 25, 50, 100];
+
+export const usePlinkoServices = () => {
+  const { userData, toogleUserFlow } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
+  const [risk, setRisk] = useState<PlinkoRisk>("medium");
+  const [mode, setMode] = useState<"manual" | "auto">("manual");
+  const [autoCount, setAutoCount] = useState<number>(AUTO_COUNTS[0]);
+  const [autoRunning, setAutoRunning] = useState(false);
+  const [autoLeft, setAutoLeft] = useState(0);
+  const [dropping, setDropping] = useState(false);
+  const [balls, setBalls] = useState<PlinkoBall[]>([]);
+  const [history, setHistory] = useState<PlinkoBall[]>([]);
+  const [lastHit, setLastHit] = useState<{ bin: number; seq: number } | null>(null);
+
+  const ballSeq = useRef(0);
+  const hitSeq = useRef(0);
+  const settled = useRef<Set<string>>(new Set());
+  const autoLeftRef = useRef(0);
+  const autoTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const maxBet = MAX_BET[risk];
+  const betValue = Math.min(Math.max(Math.floor(Number(betInput)) || 1, 1), maxBet);
+
+  const fireDrop = async (): Promise<boolean> => {
+    if (userData == null) {
+      toogleUserFlow(true);
+      return false;
+    }
+    if (userData.walletBalance < betValue) {
+      toast.error("Insufficient funds", { theme: "dark" });
+      return false;
+    }
+    try {
+      const result: PlinkoDropResult = await dropPlinko(betValue, risk);
+      ballSeq.current += 1;
+      setBalls((prev) => [...prev, { ...result, key: `b${ballSeq.current}` }]);
+      return true;
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Could not drop the ball", { theme: "dark" });
+      return false;
+    }
+  };
+
+  // the auto interval reads through a ref so it always sees the current bet and risk
+  const fireDropRef = useRef(fireDrop);
+  fireDropRef.current = fireDrop;
+
+  const stopAuto = useCallback(() => {
+    if (autoTimer.current) clearInterval(autoTimer.current);
+    autoTimer.current = null;
+    autoLeftRef.current = 0;
+    setAutoLeft(0);
+    setAutoRunning(false);
+  }, []);
+
+  const startAuto = () => {
+    if (autoRunning) return;
+    if (userData == null) {
+      toogleUserFlow(true);
+      return;
+    }
+    setAutoRunning(true);
+    autoLeftRef.current = autoCount;
+    setAutoLeft(autoCount);
+    const tick = async () => {
+      if (autoLeftRef.current <= 0) {
+        stopAuto();
+        return;
+      }
+      autoLeftRef.current -= 1;
+      setAutoLeft(autoLeftRef.current);
+      const ok = await fireDropRef.current();
+      if (!ok) stopAuto();
+      else if (autoLeftRef.current <= 0) stopAuto();
+    };
+    tick();
+    autoTimer.current = setInterval(tick, AUTO_DROP_INTERVAL_MS);
+  };
+
+  useEffect(() => () => stopAuto(), [stopAuto]);
+
+  const drop = async () => {
+    if (dropping) return;
+    setDropping(true);
+    await fireDrop();
+    setDropping(false);
+  };
+
+  // guarded by key so a duplicate animation-complete cannot double-record a ball
+  const settleBall = useCallback((ball: PlinkoBall) => {
+    if (settled.current.has(ball.key)) return;
+    settled.current.add(ball.key);
+    hitSeq.current += 1;
+    setBalls((prev) => prev.filter((b) => b.key !== ball.key));
+    setLastHit({ bin: ball.bin, seq: hitSeq.current });
+    setHistory((h) => [ball, ...h].slice(0, HISTORY_SIZE));
+  }, []);
+
+  const canChangeRisk = balls.length === 0 && !autoRunning;
+  const changeRisk = (next: PlinkoRisk) => {
+    if (!canChangeRisk) return;
+    setRisk(next);
+    setBetInput((prev) => String(Math.min(Math.max(Math.floor(Number(prev)) || 1, 1), MAX_BET[next])));
+  };
+
+  const normalizeBet = () => setBetInput(String(betValue));
+
+  return {
+    isLogged: userData != null,
+    walletBalance: userData?.walletBalance ?? 0,
+    betInput,
+    betValue,
+    maxBet,
+    setBetInput,
+    normalizeBet,
+    halveBet: () => setBetInput(String(Math.max(1, Math.floor(betValue / 2)))),
+    doubleBet: () => setBetInput(String(Math.min(maxBet, betValue * 2))),
+    maxOutBet: () =>
+      setBetInput(String(Math.min(maxBet, Math.max(1, Math.floor(userData?.walletBalance ?? maxBet))))),
+    risk,
+    canChangeRisk,
+    changeRisk,
+    mode,
+    setMode,
+    autoCount,
+    setAutoCount,
+    autoRunning,
+    autoLeft,
+    startAuto,
+    stopAuto,
+    drop,
+    dropping,
+    balls,
+    history,
+    lastHit,
+    settleBall,
+    openRoll: (rollId: string) => navigate(`/provably-fair?roll=${rollId}`),
+  };
+};

--- a/src/pages/Plinko/Plinko.types.ts
+++ b/src/pages/Plinko/Plinko.types.ts
@@ -1,0 +1,18 @@
+import { usePlinkoServices } from "./Plinko.services";
+import { PlinkoRisk } from "./plinkoBoard";
+
+export interface PlinkoDropResult {
+  betAmount: number;
+  risk: PlinkoRisk;
+  path: string;
+  bin: number;
+  multiplier: number;
+  payout: number;
+  rollId: string | null;
+}
+
+export interface PlinkoBall extends PlinkoDropResult {
+  key: string;
+}
+
+export type PlinkoViewProps = ReturnType<typeof usePlinkoServices>;

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import Title from "../../components/Title";
 import MainButton from "../../components/MainButton";
@@ -28,8 +28,25 @@ import { PlinkoBall, PlinkoViewProps } from "./Plinko.types";
 
 const PEG_ROWS = pegRows();
 
-const FallingBall = ({ ball, onSettle }: { ball: PlinkoBall; onSettle: (ball: PlinkoBall) => void }) => {
-  const frames = useMemo(() => ballKeyframes(ball.path), [ball.path]);
+const FallingBall = ({
+  ball,
+  onSettle,
+  onPegHit,
+}: {
+  ball: PlinkoBall;
+  onSettle: (ball: PlinkoBall) => void;
+  onPegHit: (row: number, index: number) => void;
+}) => {
+  const frames = useMemo(() => ballKeyframes(ball.path, Math.random), [ball.path]);
+
+  // pulse each peg right as the ball reaches it
+  useEffect(() => {
+    const timers = frames.hits.map((h) =>
+      setTimeout(() => onPegHit(h.row, h.index), h.t * DROP_DURATION_S * 1000)
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [frames, onPegHit]);
+
   return (
     <motion.circle
       r={BALL_RADIUS}
@@ -38,7 +55,7 @@ const FallingBall = ({ ball, onSettle }: { ball: PlinkoBall; onSettle: (ball: Pl
       strokeWidth={2}
       initial={{ cx: frames.xs[0], cy: frames.ys[0] }}
       animate={{ cx: frames.xs, cy: frames.ys }}
-      transition={{ duration: DROP_DURATION_S, times: frames.times, ease: "linear" }}
+      transition={{ duration: DROP_DURATION_S, times: frames.times, ease: frames.eases }}
       onAnimationComplete={() => onSettle(ball)}
     />
   );
@@ -70,6 +87,8 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
   balls,
   history,
   lastHit,
+  pegPulses,
+  pulsePeg,
   settleBall,
   openRoll,
 }) => (
@@ -219,11 +238,26 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
           ))}
         </div>
 
-        <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[760px]">
+        <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[680px]">
           {PEG_ROWS.map((row, i) =>
-            row.map((peg, k) => (
-              <circle key={`${i}-${k}`} cx={peg.x} cy={peg.y} r={PEG_RADIUS} fill="#cfccdf" />
-            ))
+            row.map((peg, k) => {
+              const seq = pegPulses[`${i}-${k}`];
+              return seq ? (
+                <motion.circle
+                  key={`${i}-${k}-${seq}`}
+                  cx={peg.x}
+                  cy={peg.y}
+                  initial={{ r: PEG_RADIUS, fill: "#cfccdf" }}
+                  animate={{
+                    r: [PEG_RADIUS, PEG_RADIUS * 1.8, PEG_RADIUS],
+                    fill: ["#cfccdf", "#ffe08a", "#cfccdf"],
+                  }}
+                  transition={{ duration: 0.35 }}
+                />
+              ) : (
+                <circle key={`${i}-${k}`} cx={peg.x} cy={peg.y} r={PEG_RADIUS} fill="#cfccdf" />
+              );
+            })
           )}
 
           {Array.from({ length: BINS }, (_, k) => {
@@ -265,7 +299,7 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
           })}
 
           {balls.map((ball) => (
-            <FallingBall key={ball.key} ball={ball} onSettle={settleBall} />
+            <FallingBall key={ball.key} ball={ball} onSettle={settleBall} onPegHit={pulsePeg} />
           ))}
         </svg>
       </div>

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -1,0 +1,276 @@
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+import Title from "../../components/Title";
+import MainButton from "../../components/MainButton";
+import Monetary from "../../components/Monetary";
+import {
+  BALL_RADIUS,
+  BINS,
+  BIN_H,
+  BIN_W,
+  BIN_Y,
+  BOARD_H,
+  BOARD_W,
+  DROP_DURATION_S,
+  MAX_WIN,
+  PAYOUT_MULTIPLIERS,
+  PEG_RADIUS,
+  RISKS,
+  ballKeyframes,
+  binCenterX,
+  binColor,
+  binTextColor,
+  formatMultiplier,
+  pegRows,
+} from "./plinkoBoard";
+import { AUTO_COUNTS } from "./Plinko.services";
+import { PlinkoBall, PlinkoViewProps } from "./Plinko.types";
+
+const PEG_ROWS = pegRows();
+
+const FallingBall = ({ ball, onSettle }: { ball: PlinkoBall; onSettle: (ball: PlinkoBall) => void }) => {
+  const frames = useMemo(() => ballKeyframes(ball.path), [ball.path]);
+  return (
+    <motion.circle
+      r={BALL_RADIUS}
+      fill="#FFCC00"
+      stroke="#151225"
+      strokeWidth={2}
+      initial={{ cx: frames.xs[0], cy: frames.ys[0] }}
+      animate={{ cx: frames.xs, cy: frames.ys }}
+      transition={{ duration: DROP_DURATION_S, times: frames.times, ease: "linear" }}
+      onAnimationComplete={() => onSettle(ball)}
+    />
+  );
+};
+
+const PlinkoView: React.FC<PlinkoViewProps> = ({
+  isLogged,
+  betInput,
+  betValue,
+  maxBet,
+  setBetInput,
+  normalizeBet,
+  halveBet,
+  doubleBet,
+  maxOutBet,
+  risk,
+  canChangeRisk,
+  changeRisk,
+  mode,
+  setMode,
+  autoCount,
+  setAutoCount,
+  autoRunning,
+  autoLeft,
+  startAuto,
+  stopAuto,
+  drop,
+  dropping,
+  balls,
+  history,
+  lastHit,
+  settleBall,
+  openRoll,
+}) => (
+  <div className="w-screen flex flex-col items-center py-6 px-4">
+    <Title title="Plinko" />
+
+    <div className="flex flex-col lg:flex-row gap-6 w-full max-w-[1300px] pt-6">
+      {/* control panel */}
+      <div className="w-full lg:w-72 shrink-0 bg-[#212031] rounded-lg p-4 flex flex-col gap-4 self-start">
+        <div className="flex bg-[#19172D] rounded p-1">
+          {(["manual", "auto"] as const).map((m) => (
+            <button
+              key={m}
+              onClick={() => setMode(m)}
+              disabled={autoRunning}
+              className={`flex-1 py-2 rounded text-sm font-semibold capitalize transition-colors ${
+                mode === m ? "bg-[#281D3F]" : "text-[#84819a] hover:text-white"
+              } disabled:opacity-50`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-wider text-[#84819a]">Amount</span>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              min={1}
+              max={maxBet}
+              value={betInput}
+              onChange={(e) => setBetInput(e.target.value)}
+              onBlur={normalizeBet}
+              className="w-full min-w-0 bg-[#19172D] border border-gray-700 focus:border-indigo-500 outline-none rounded px-3 py-2 text-sm"
+            />
+            <button onClick={halveBet} className="px-2 rounded bg-[#281D3F] hover:bg-[#3a2c5c] text-xs font-semibold">
+              1/2
+            </button>
+            <button onClick={doubleBet} className="px-2 rounded bg-[#281D3F] hover:bg-[#3a2c5c] text-xs font-semibold">
+              x2
+            </button>
+            <button onClick={maxOutBet} className="px-2 rounded bg-[#281D3F] hover:bg-[#3a2c5c] text-xs font-semibold">
+              Max
+            </button>
+          </div>
+          <span className="text-xs text-[#84819a]">
+            Bet 1 to {maxBet.toLocaleString("en-US")} on {risk} risk
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <span className="text-xs uppercase tracking-wider text-[#84819a]">Risk</span>
+          <div className="flex gap-2">
+            {RISKS.map((r) => (
+              <button
+                key={r}
+                onClick={() => changeRisk(r)}
+                disabled={!canChangeRisk}
+                className={`flex-1 py-2 rounded text-sm font-semibold capitalize transition-colors ${
+                  risk === r ? "bg-indigo-600" : "bg-[#19172D] text-[#84819a] hover:text-white"
+                } disabled:opacity-50`}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {mode === "auto" && (
+          <div className="flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-wider text-[#84819a]">Balls</span>
+            <div className="flex gap-2">
+              {AUTO_COUNTS.map((n) => (
+                <button
+                  key={n}
+                  onClick={() => setAutoCount(n)}
+                  disabled={autoRunning}
+                  className={`flex-1 py-2 rounded text-sm font-semibold ${
+                    autoCount === n ? "bg-indigo-600" : "bg-[#19172D] text-[#84819a] hover:text-white"
+                  } disabled:opacity-50`}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {mode === "manual" ? (
+          <MainButton
+            text={
+              isLogged ? (
+                <div className="flex items-center justify-center text-base">
+                  <span className="mr-1">Drop ball - </span>
+                  <Monetary value={betValue} />
+                </div>
+              ) : (
+                "Sign in to play"
+              )
+            }
+            onClick={drop}
+            loading={dropping}
+            disabled={dropping}
+          />
+        ) : autoRunning ? (
+          <MainButton text={`Stop (${autoLeft} left)`} onClick={stopAuto} type="danger" />
+        ) : (
+          <MainButton
+            text={
+              isLogged ? (
+                <div className="flex items-center justify-center text-base">
+                  <span className="mr-1">Drop {autoCount} balls - </span>
+                  <Monetary value={betValue * autoCount} />
+                </div>
+              ) : (
+                "Sign in to play"
+              )
+            }
+            onClick={startAuto}
+          />
+        )}
+
+        <div className="text-xs text-[#84819a] border-t border-[#2a2840] pt-3 flex flex-col gap-1">
+          <span className="flex items-center gap-1">
+            Max win <Monetary value={MAX_WIN} />
+          </span>
+          <span>Every drop is provably fair; click a result to verify it.</span>
+        </div>
+      </div>
+
+      {/* board */}
+      <div className="relative flex-1 flex justify-center">
+        <div className="absolute right-0 top-0 flex flex-col gap-1 items-end z-10">
+          {history.map((h) => (
+            <motion.button
+              key={h.key}
+              initial={{ opacity: 0, x: 12 }}
+              animate={{ opacity: 1, x: 0 }}
+              onClick={() => h.rollId && openRoll(h.rollId)}
+              title={h.rollId ? `Roll ${h.rollId}` : undefined}
+              className="px-2 py-1 rounded text-xs font-bold"
+              style={{ backgroundColor: binColor(h.bin), color: binTextColor(h.bin) }}
+            >
+              {formatMultiplier(h.multiplier)}
+            </motion.button>
+          ))}
+        </div>
+
+        <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[760px]">
+          {PEG_ROWS.map((row, i) =>
+            row.map((peg, k) => (
+              <circle key={`${i}-${k}`} cx={peg.x} cy={peg.y} r={PEG_RADIUS} fill="#cfccdf" />
+            ))
+          )}
+
+          {Array.from({ length: BINS }, (_, k) => {
+            const label = formatMultiplier(PAYOUT_MULTIPLIERS[risk][k]);
+            const chip = (
+              <>
+                <rect
+                  x={binCenterX(k) - BIN_W / 2}
+                  y={BIN_Y}
+                  width={BIN_W}
+                  height={BIN_H}
+                  rx={6}
+                  fill={binColor(k)}
+                />
+                <text
+                  x={binCenterX(k)}
+                  y={BIN_Y + BIN_H / 2 + 4}
+                  textAnchor="middle"
+                  fontSize={label.length > 4 ? 11 : 13}
+                  fontWeight={700}
+                  fill={binTextColor(k)}
+                >
+                  {label}
+                </text>
+              </>
+            );
+            return lastHit && lastHit.bin === k ? (
+              <motion.g
+                key={`${k}-${lastHit.seq}`}
+                initial={{ y: 0 }}
+                animate={{ y: [0, 12, 0] }}
+                transition={{ duration: 0.3 }}
+              >
+                {chip}
+              </motion.g>
+            ) : (
+              <g key={`${k}-static`}>{chip}</g>
+            );
+          })}
+
+          {balls.map((ball) => (
+            <FallingBall key={ball.key} ball={ball} onSettle={settleBall} />
+          ))}
+        </svg>
+      </div>
+    </div>
+  </div>
+);
+
+export default PlinkoView;

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -221,7 +221,7 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
       </div>
 
       {/* board */}
-      <div className="relative flex-1 flex justify-center">
+      <div className="relative flex-1 flex justify-start">
         <div className="absolute right-0 top-0 flex flex-col gap-1 items-end z-10">
           {history.map((h) => (
             <motion.button

--- a/src/pages/Plinko/index.tsx
+++ b/src/pages/Plinko/index.tsx
@@ -1,0 +1,9 @@
+import PlinkoView from "./Plinko.view";
+import { usePlinkoServices } from "./Plinko.services";
+
+const Plinko = () => {
+  const service = usePlinkoServices();
+  return <PlinkoView {...service} />;
+};
+
+export default Plinko;

--- a/src/pages/Plinko/plinkoBoard.test.ts
+++ b/src/pages/Plinko/plinkoBoard.test.ts
@@ -40,17 +40,42 @@ describe("plinko board geometry", () => {
 
   test("ball keyframes follow the path and end at the landing bin", () => {
     const path = "RLRRLLRLRLRRLLRL";
-    const { xs, ys, times, bin } = ballKeyframes(path);
+    const { xs, ys, times, eases, bin, hits } = ballKeyframes(path);
     expect(bin).toBe(path.split("R").length - 1);
     expect(xs).toHaveLength(2 + ROWS * 2);
     expect(ys).toHaveLength(xs.length);
     expect(times).toHaveLength(xs.length);
+    expect(eases).toHaveLength(xs.length - 1);
     expect(times[0]).toBe(0);
     expect(times[times.length - 1]).toBeCloseTo(1, 10);
     for (let i = 1; i < times.length; i++) {
       expect(times[i]).toBeGreaterThan(times[i - 1]);
     }
     expect(xs[xs.length - 1]).toBe(binCenterX(bin));
+  });
+
+  test("every row registers one peg hit at increasing times", () => {
+    const path = "LLLLLLLLRRRRRRRR";
+    const { hits } = ballKeyframes(path);
+    expect(hits).toHaveLength(ROWS);
+    hits.forEach((h, i) => {
+      expect(h.row).toBe(i);
+      expect(Number.isInteger(h.index)).toBe(true);
+      expect(h.index).toBeGreaterThanOrEqual(0);
+      expect(h.index).toBeLessThan(i + 3);
+      if (i > 0) expect(h.t).toBeGreaterThan(hits[i - 1].t);
+    });
+  });
+
+  test("jitter moves arc peaks but never contacts or the landing point", () => {
+    const path = "RLRLRLRLRLRLRLRL";
+    const straight = ballKeyframes(path);
+    const wobbled = ballKeyframes(path, () => 0.9);
+    for (let i = 1; i < straight.xs.length - 1; i += 2) {
+      expect(wobbled.xs[i]).toBe(straight.xs[i]);
+    }
+    expect(wobbled.xs[wobbled.xs.length - 1]).toBe(straight.xs[straight.xs.length - 1]);
+    expect(wobbled.bin).toBe(straight.bin);
   });
 
   test("edge paths land in the outermost bins", () => {

--- a/src/pages/Plinko/plinkoBoard.test.ts
+++ b/src/pages/Plinko/plinkoBoard.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  BINS,
+  MAX_BET,
+  MAX_WIN,
+  PAYOUT_MULTIPLIERS,
+  RISKS,
+  ROWS,
+  ballKeyframes,
+  binCenterX,
+  binColor,
+  pegRows,
+} from "./plinkoBoard";
+
+describe("plinko payout display tables", () => {
+  test("every risk has one multiplier per bin, mirrored around the center", () => {
+    for (const risk of RISKS) {
+      const table = PAYOUT_MULTIPLIERS[risk];
+      expect(table).toHaveLength(BINS);
+      for (let k = 0; k < BINS; k++) {
+        expect(table[k]).toBe(table[ROWS - k]);
+        expect(table[k]).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("the bet cap of each risk keeps its top payout at the max win", () => {
+    for (const risk of RISKS) {
+      expect(MAX_BET[risk] * PAYOUT_MULTIPLIERS[risk][0]).toBeLessThanOrEqual(MAX_WIN);
+    }
+  });
+});
+
+describe("plinko board geometry", () => {
+  test("the peg triangle grows one peg per row", () => {
+    const rows = pegRows();
+    expect(rows).toHaveLength(ROWS);
+    rows.forEach((row, i) => expect(row).toHaveLength(i + 3));
+  });
+
+  test("ball keyframes follow the path and end at the landing bin", () => {
+    const path = "RLRRLLRLRLRRLLRL";
+    const { xs, ys, times, bin } = ballKeyframes(path);
+    expect(bin).toBe(path.split("R").length - 1);
+    expect(xs).toHaveLength(2 + ROWS * 2);
+    expect(ys).toHaveLength(xs.length);
+    expect(times).toHaveLength(xs.length);
+    expect(times[0]).toBe(0);
+    expect(times[times.length - 1]).toBeCloseTo(1, 10);
+    for (let i = 1; i < times.length; i++) {
+      expect(times[i]).toBeGreaterThan(times[i - 1]);
+    }
+    expect(xs[xs.length - 1]).toBe(binCenterX(bin));
+  });
+
+  test("edge paths land in the outermost bins", () => {
+    expect(ballKeyframes("L".repeat(ROWS)).bin).toBe(0);
+    expect(ballKeyframes("R".repeat(ROWS)).bin).toBe(ROWS);
+  });
+
+  test("every bin has a color", () => {
+    for (let k = 0; k < BINS; k++) {
+      expect(binColor(k)).toMatch(/^#/);
+    }
+  });
+});

--- a/src/pages/Plinko/plinkoBoard.ts
+++ b/src/pages/Plinko/plinkoBoard.ts
@@ -25,15 +25,15 @@ const PEG_SPACING = 52;
 const ROW_GAP = 46;
 const TOP_Y = 110;
 const DROP_Y = 30;
-const CONTACT_LIFT = 16; // ball center sits a radius above the peg it strikes
-const HOP_LIFT = 12;
+const CONTACT_LIFT = 15; // ball center sits a radius above the peg it strikes
+const HOP_LIFT = 16;
 
 export const PEG_RADIUS = 5;
-export const BALL_RADIUS = 11;
+export const BALL_RADIUS = 10;
 export const BIN_Y = 830;
 export const BIN_W = PEG_SPACING - 6;
 export const BIN_H = 46;
-export const DROP_DURATION_S = 2.5;
+export const DROP_DURATION_S = 3.1;
 
 export const pegRows = (): { x: number; y: number }[][] => {
   const rows: { x: number; y: number }[][] = [];
@@ -53,11 +53,15 @@ export const pegRows = (): { x: number; y: number }[][] => {
 export const binCenterX = (bin: number) => CENTER_X + (bin - ROWS / 2) * PEG_SPACING;
 
 // waypoints the ball passes through for a server path: a contact above each row's peg,
-// a short hop toward the side it deflects to, then the mouth of the landing bin
-export const ballKeyframes = (path: string) => {
+// a bounce arc toward the side it deflects to, then the mouth of the landing bin.
+// falls ease in and bounces ease out so the motion reads as gravity; `rand` adds a
+// per-ball wobble to the arc peaks without ever moving a contact point or the bin
+export const ballKeyframes = (path: string, rand: () => number = () => 0.5) => {
   const xs: number[] = [CENTER_X];
   const ys: number[] = [DROP_Y];
   const weights: number[] = [];
+  const eases: string[] = [];
+  const hits: { row: number; index: number; t: number }[] = [];
   let offset = 0; // in half-spacings from the center line
 
   for (let row = 0; row < ROWS; row++) {
@@ -65,25 +69,32 @@ export const ballKeyframes = (path: string) => {
     const contactY = TOP_Y + row * ROW_GAP - CONTACT_LIFT;
     xs.push(contactX);
     ys.push(contactY);
-    weights.push(row === 0 ? 1.2 : 0.6);
+    weights.push(row === 0 ? 1.3 : 0.55);
+    eases.push("easeIn");
+    hits.push({ row, index: (offset + row + 2) / 2, t: 0 });
 
     const dir = path[row] === "R" ? 1 : -1;
     offset += dir;
-    xs.push(contactX + (dir * PEG_SPACING) / 4);
-    ys.push(contactY - HOP_LIFT);
-    weights.push(0.4);
+    xs.push(contactX + dir * PEG_SPACING * 0.3 + (rand() - 0.5) * 6);
+    ys.push(contactY - HOP_LIFT + (rand() - 0.5) * 8);
+    weights.push(0.45);
+    eases.push("easeOut");
   }
 
   const bin = path.split("R").length - 1;
   xs.push(binCenterX(bin));
   ys.push(BIN_Y + BIN_H / 2);
-  weights.push(0.8);
+  weights.push(0.9);
+  eases.push("easeIn");
 
   const total = weights.reduce((sum, w) => sum + w, 0);
   let acc = 0;
   const times = [0, ...weights.map((w) => (acc += w) / total)];
+  hits.forEach((h, i) => {
+    h.t = times[1 + 2 * i];
+  });
 
-  return { xs, ys, times, bin };
+  return { xs, ys, times, eases, bin, hits };
 };
 
 // bin fills fade from blue at the center to gold at the rims

--- a/src/pages/Plinko/plinkoBoard.ts
+++ b/src/pages/Plinko/plinkoBoard.ts
@@ -1,0 +1,105 @@
+export type PlinkoRisk = "low" | "medium" | "high";
+
+export const RISKS: PlinkoRisk[] = ["low", "medium", "high"];
+
+export const ROWS = 16;
+export const BINS = ROWS + 1;
+
+// display copy of the server payout tables; the server stays authoritative for money
+const mirror = (half: number[]) => [...half, ...half.slice(0, -1).reverse()];
+export const PAYOUT_MULTIPLIERS: Record<PlinkoRisk, number[]> = {
+  low: mirror([15, 8, 2.2, 1.6, 1.3, 1.1, 1.05, 0.95, 0.6]),
+  medium: mirror([100, 40, 9, 5, 2.9, 1.4, 1, 0.5, 0.3]),
+  high: mirror([1000, 120, 25, 9, 4, 1.7, 0.3, 0.2, 0.2]),
+};
+
+// per-risk bet ceilings keep the top payout at the max win (cap times top multiplier)
+export const MAX_BET: Record<PlinkoRisk, number> = { low: 50000, medium: 10000, high: 1000 };
+export const MAX_WIN = 1000000;
+
+// board geometry in viewBox units; the svg scales it to any container width
+export const BOARD_W = 1000;
+export const BOARD_H = 900;
+const CENTER_X = BOARD_W / 2;
+const PEG_SPACING = 52;
+const ROW_GAP = 46;
+const TOP_Y = 110;
+const DROP_Y = 30;
+const CONTACT_LIFT = 16; // ball center sits a radius above the peg it strikes
+const HOP_LIFT = 12;
+
+export const PEG_RADIUS = 5;
+export const BALL_RADIUS = 11;
+export const BIN_Y = 830;
+export const BIN_W = PEG_SPACING - 6;
+export const BIN_H = 46;
+export const DROP_DURATION_S = 2.5;
+
+export const pegRows = (): { x: number; y: number }[][] => {
+  const rows: { x: number; y: number }[][] = [];
+  for (let row = 0; row < ROWS; row++) {
+    const pegs: { x: number; y: number }[] = [];
+    for (let k = 0; k < row + 3; k++) {
+      pegs.push({
+        x: CENTER_X + (k - (row + 2) / 2) * PEG_SPACING,
+        y: TOP_Y + row * ROW_GAP,
+      });
+    }
+    rows.push(pegs);
+  }
+  return rows;
+};
+
+export const binCenterX = (bin: number) => CENTER_X + (bin - ROWS / 2) * PEG_SPACING;
+
+// waypoints the ball passes through for a server path: a contact above each row's peg,
+// a short hop toward the side it deflects to, then the mouth of the landing bin
+export const ballKeyframes = (path: string) => {
+  const xs: number[] = [CENTER_X];
+  const ys: number[] = [DROP_Y];
+  const weights: number[] = [];
+  let offset = 0; // in half-spacings from the center line
+
+  for (let row = 0; row < ROWS; row++) {
+    const contactX = CENTER_X + (offset * PEG_SPACING) / 2;
+    const contactY = TOP_Y + row * ROW_GAP - CONTACT_LIFT;
+    xs.push(contactX);
+    ys.push(contactY);
+    weights.push(row === 0 ? 1.2 : 0.6);
+
+    const dir = path[row] === "R" ? 1 : -1;
+    offset += dir;
+    xs.push(contactX + (dir * PEG_SPACING) / 4);
+    ys.push(contactY - HOP_LIFT);
+    weights.push(0.4);
+  }
+
+  const bin = path.split("R").length - 1;
+  xs.push(binCenterX(bin));
+  ys.push(BIN_Y + BIN_H / 2);
+  weights.push(0.8);
+
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  let acc = 0;
+  const times = [0, ...weights.map((w) => (acc += w) / total)];
+
+  return { xs, ys, times, bin };
+};
+
+// bin fills fade from blue at the center to gold at the rims
+const BIN_COLORS = [
+  "#3B82F6",
+  "#4F6EF0",
+  "#6D5CE7",
+  "#8B4ADF",
+  "#A93BC9",
+  "#C433A0",
+  "#DF3D6E",
+  "#F25C3F",
+  "#FFCC00",
+];
+
+export const binColor = (bin: number) => BIN_COLORS[Math.abs(bin - ROWS / 2)];
+export const binTextColor = (bin: number) => (Math.abs(bin - ROWS / 2) >= 7 ? "#151225" : "#ffffff");
+
+export const formatMultiplier = (multiplier: number) => `x${multiplier}`;

--- a/src/pages/ProvablyFair/ProvablyFair.view.tsx
+++ b/src/pages/ProvablyFair/ProvablyFair.view.tsx
@@ -32,8 +32,8 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
     <Title title="Provably Fair" />
 
     <p className="text-[#84819a] text-sm max-w-[640px] text-center">
-      Every case, upgrade and slot roll is HMAC-SHA256 of your client seed, a
-      nonce, and a secret server seed we commit to up front.
+      Every case, upgrade, slot and plinko roll is HMAC-SHA256 of your client
+      seed, a nonce, and a secret server seed we commit to up front.
     </p>
 
     {/* roll lookup */}
@@ -63,10 +63,12 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
           </span>
           <button
             onClick={doVerify}
-            disabled={verifying || roll.game !== "case"}
+            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko")}
             className="px-4 py-1.5 rounded bg-green-700 hover:bg-green-600 text-sm font-semibold disabled:opacity-50"
             title={
-              roll.game !== "case" ? "Auto-verify supported for case rolls" : ""
+              roll.game !== "case" && roll.game !== "plinko"
+                ? "Auto-verify supported for case and plinko rolls"
+                : ""
             }
           >
             {verifying ? "Verifying..." : "Verify"}
@@ -112,7 +114,9 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
             }`}
           >
             {verify.ok
-              ? `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
+              ? verify.recomputedPath
+                ? `Verified: the recomputed path lands in bin ${verify.recomputedBin} at x${verify.recomputedMultiplier}.`
+                : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
               : `Not verified${verify.reason ? `: ${verify.reason}` : ""}.`}
           </div>
         )}

--- a/src/seo/routes.json
+++ b/src/seo/routes.json
@@ -28,6 +28,10 @@
       "title": "Slots | KaniCasino",
       "description": "Spin the reels for fake coins. Provably fair, no real money involved."
     },
+    "/plinko": {
+      "title": "Plinko | KaniCasino",
+      "description": "Drop a ball down the pegs and chase the golden edge bins. Provably fair, no real money involved."
+    },
     "/battles": {
       "title": "Case Battles | KaniCasino",
       "description": "Open cases head to head against other players. Best total value takes the pot."

--- a/src/services/fair/FairServices.ts
+++ b/src/services/fair/FairServices.ts
@@ -22,7 +22,7 @@ export interface RollRange {
 
 export interface RollView {
   rollId: string;
-  game: "case" | "upgrade" | "slots" | "battle";
+  game: "case" | "upgrade" | "slots" | "battle" | "plinko";
   clientSeed: string;
   serverSeedHash: string;
   serverSeed: string | null;
@@ -46,6 +46,12 @@ export interface VerifyResult {
   expectedRoll?: number;
   expectedItemId?: string;
   pickedItemId?: string;
+  recomputedPath?: string;
+  recomputedBin?: number;
+  recomputedMultiplier?: number;
+  expectedPath?: string;
+  expectedBin?: number;
+  expectedMultiplier?: number;
 }
 
 export const getSeed = () => api.get<SeedState>("/fair/seed").then((r) => r.data);

--- a/src/services/games/GamesServices.ts
+++ b/src/services/games/GamesServices.ts
@@ -23,3 +23,8 @@ export async function spinSlots(betAmount: number) {
     });
     return response.data;
 }
+
+export async function dropPlinko(betAmount: number, risk: string) {
+    const response = await api.post(`/games/plinko/`, { betAmount, risk });
+    return response.data;
+}


### PR DESCRIPTION
Adds Plinko: 16 rows, 17 bins, risk tables (low/medium/high) tuned to a ~3.5% house edge, and per-risk bet caps that keep the top payout at 1,000,000.

Backend: POST /games/plinko derives a 16-step path from the seed chain (one nonce, one cursor per row), moves money through chargeUser/creditUser with plinko_bet/plinko_win ledger rows, records a plinko Roll, and adds a server-side verifier reachable from /fair/roll/:id/verify. Frontend: new /plinko page with an animated board that follows the exact server path, manual and auto modes, and history chips that link to the fair page.

Tests: unit (exact RTP band, table symmetry, path determinism, board geometry), integration (drop round trip, ledger rows, bad input rejection including inherited-key risks, concurrent nonce reservation, verify after rotation), e2e home tile navigation.