### PR TITLE
Keep mass plinko drops smooth

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,30 @@
   }
 }
 
+/* plinko peg struck by a ball; runs outside react so mass drops stay smooth */
+.peg-pulse {
+  animation: peg-pulse 0.35s ease-out;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@keyframes peg-pulse {
+  0% {
+    transform: scale(1);
+    fill: #cfccdf;
+  }
+
+  40% {
+    transform: scale(1.8);
+    fill: #ffe08a;
+  }
+
+  100% {
+    transform: scale(1);
+    fill: #cfccdf;
+  }
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -26,11 +26,9 @@ export const usePlinkoServices = () => {
   const [balls, setBalls] = useState<PlinkoBall[]>([]);
   const [history, setHistory] = useState<PlinkoBall[]>([]);
   const [lastHit, setLastHit] = useState<{ bin: number; seq: number } | null>(null);
-  const [pegPulses, setPegPulses] = useState<Record<string, number>>({});
 
   const ballSeq = useRef(0);
   const hitSeq = useRef(0);
-  const pulseSeq = useRef(0);
   const settled = useRef<Set<string>>(new Set());
   const autoLeftRef = useRef(0);
   const autoTimer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -103,13 +101,6 @@ export const usePlinkoServices = () => {
     setDropping(false);
   };
 
-  // a fresh sequence per strike remounts the peg's pulse animation
-  const pulsePeg = useCallback((row: number, index: number) => {
-    pulseSeq.current += 1;
-    const seq = pulseSeq.current;
-    setPegPulses((prev) => ({ ...prev, [`${row}-${index}`]: seq }));
-  }, []);
-
   // guarded by key so a duplicate animation-complete cannot double-record a ball
   const settleBall = useCallback((ball: PlinkoBall) => {
     if (settled.current.has(ball.key)) return;
@@ -157,8 +148,6 @@ export const usePlinkoServices = () => {
     balls,
     history,
     lastHit,
-    pegPulses,
-    pulsePeg,
     settleBall,
     openRoll: (rollId: string) => navigate(`/provably-fair?roll=${rollId}`),
   };

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { memo, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import Title from "../../components/Title";
 import MainButton from "../../components/MainButton";
@@ -28,24 +28,37 @@ import { PlinkoBall, PlinkoViewProps } from "./Plinko.types";
 
 const PEG_ROWS = pegRows();
 
-const FallingBall = ({
-  ball,
-  onSettle,
-  onPegHit,
-}: {
-  ball: PlinkoBall;
-  onSettle: (ball: PlinkoBall) => void;
-  onPegHit: (row: number, index: number) => void;
-}) => {
+// pegs never re-render; pulses run as a css animation outside react so a hundred
+// concurrent balls cannot flood the tree with state updates
+const PegField = memo(() => (
+  <>
+    {PEG_ROWS.map((row, i) =>
+      row.map((peg, k) => (
+        <circle key={`${i}-${k}`} id={`peg-${i}-${k}`} cx={peg.x} cy={peg.y} r={PEG_RADIUS} fill="#cfccdf" />
+      ))
+    )}
+  </>
+));
+
+const pulsePegElement = (row: number, index: number) => {
+  const peg = document.getElementById(`peg-${row}-${index}`);
+  if (!peg) return;
+  // remove and reflow so a peg struck twice in a row restarts its animation
+  peg.classList.remove("peg-pulse");
+  void peg.getBoundingClientRect();
+  peg.classList.add("peg-pulse");
+};
+
+const FallingBall = memo(({ ball, onSettle }: { ball: PlinkoBall; onSettle: (ball: PlinkoBall) => void }) => {
   const frames = useMemo(() => ballKeyframes(ball.path, Math.random), [ball.path]);
 
   // pulse each peg right as the ball reaches it
   useEffect(() => {
     const timers = frames.hits.map((h) =>
-      setTimeout(() => onPegHit(h.row, h.index), h.t * DROP_DURATION_S * 1000)
+      setTimeout(() => pulsePegElement(h.row, h.index), h.t * DROP_DURATION_S * 1000)
     );
     return () => timers.forEach(clearTimeout);
-  }, [frames, onPegHit]);
+  }, [frames]);
 
   return (
     <motion.circle
@@ -59,7 +72,7 @@ const FallingBall = ({
       onAnimationComplete={() => onSettle(ball)}
     />
   );
-};
+});
 
 const PlinkoView: React.FC<PlinkoViewProps> = ({
   isLogged,
@@ -87,8 +100,6 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
   balls,
   history,
   lastHit,
-  pegPulses,
-  pulsePeg,
   settleBall,
   openRoll,
 }) => (
@@ -239,26 +250,7 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
         </div>
 
         <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[680px]">
-          {PEG_ROWS.map((row, i) =>
-            row.map((peg, k) => {
-              const seq = pegPulses[`${i}-${k}`];
-              return seq ? (
-                <motion.circle
-                  key={`${i}-${k}-${seq}`}
-                  cx={peg.x}
-                  cy={peg.y}
-                  initial={{ r: PEG_RADIUS, fill: "#cfccdf" }}
-                  animate={{
-                    r: [PEG_RADIUS, PEG_RADIUS * 1.8, PEG_RADIUS],
-                    fill: ["#cfccdf", "#ffe08a", "#cfccdf"],
-                  }}
-                  transition={{ duration: 0.35 }}
-                />
-              ) : (
-                <circle key={`${i}-${k}`} cx={peg.x} cy={peg.y} r={PEG_RADIUS} fill="#cfccdf" />
-              );
-            })
-          )}
+          <PegField />
 
           {Array.from({ length: BINS }, (_, k) => {
             const label = formatMultiplier(PAYOUT_MULTIPLIERS[risk][k]);
@@ -299,7 +291,7 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
           })}
 
           {balls.map((ball) => (
-            <FallingBall key={ball.key} ball={ball} onSettle={settleBall} onPegHit={pulsePeg} />
+            <FallingBall key={ball.key} ball={ball} onSettle={settleBall} />
           ))}
         </svg>
       </div>


### PR DESCRIPTION
Auto-running many plinko balls made the page crawl: every peg strike went through react state, so a 100-ball run forced roughly 40 full re-renders of the board per second. The main thread saturated and the frame-driven ball animations stretched from 3 seconds to minutes.

Peg pulses now run as a css animation triggered imperatively on the struck peg, the peg field is memoized and never re-renders, and each ball only touches react twice (drop and settle).

Tests: unit and build green; headless load run with 39 concurrent balls settled 3.1s after the last click with pulses firing and no errors.