### PR TITLE
Batch the battle preroll case loads

### DIFF
--- a/backend/__tests__/integration/battlePreroll.test.js
+++ b/backend/__tests__/integration/battlePreroll.test.js
@@ -1,0 +1,58 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const Case = require("../../models/Case");
+const Item = require("../../models/Item");
+const { generateServerSeed, hashServerSeed } = require("../../utils/provablyFair");
+const { prerollBattle } = require("../../games/battleEngine");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeCase() {
+  const s = uniqueSuffix();
+  const item = await Item.create({ name: `i-${s}`, image: "i.png", rarity: "3", baseValue: 100 });
+  return Case.create({ title: `c-${s}`, image: "c.png", price: 50, items: [item._id] });
+}
+
+function battleDoc(cases) {
+  const serverSeed = generateServerSeed();
+  return {
+    mode: "1v1",
+    cases: cases.map((c) => c._id),
+    players: [
+      { slot: 0, clientSeed: "alice" },
+      { slot: 1, clientSeed: "bob" },
+    ],
+    pfServerSeed: serverSeed,
+    pfServerSeedHash: hashServerSeed(serverSeed),
+  };
+}
+
+test("a battle repeating one case prerolls a round per entry, in order", async () => {
+  const c = await makeCase();
+  const rolls = await prerollBattle(battleDoc([c, c, c]));
+  expect(rolls).toHaveLength(3);
+  for (const round of rolls) {
+    expect(round).toHaveLength(2);
+    expect(round.every((it) => it.name.startsWith("i-"))).toBe(true);
+  }
+});
+
+test("mixed cases preroll in the order the battle lists them", async () => {
+  const a = await makeCase();
+  const b = await makeCase();
+  const rolls = await prerollBattle(battleDoc([b, a, b]));
+  const aItem = (await Case.findById(a._id).populate("items")).items[0].name;
+  const bItem = (await Case.findById(b._id).populate("items")).items[0].name;
+  expect(rolls.map((round) => round[0].name)).toEqual([bItem, aItem, bItem]);
+});
+
+test("a deleted case still fails the preroll", async () => {
+  const a = await makeCase();
+  const doc = battleDoc([a]);
+  await Case.deleteOne({ _id: a._id });
+  await expect(prerollBattle(doc)).rejects.toThrow(/no longer exists/);
+});

--- a/backend/games/battleEngine.js
+++ b/backend/games/battleEngine.js
@@ -38,9 +38,15 @@ async function prerollBattle(battle) {
     return (p && p.clientSeed) || `slot:${slot}`;
   };
 
+  // one batched load: sequential per-case queries made a 20-case start pay dozens
+  // of database round trips; battles also repeat cases, so fetch each id once
+  const uniqueIds = [...new Set(battle.cases.map(String))];
+  const caseDocs = await Case.find({ _id: { $in: uniqueIds } }).populate("items");
+  const caseById = new Map(caseDocs.map((doc) => [String(doc._id), doc]));
+
   const rolls = [];
   for (let c = 0; c < battle.cases.length; c++) {
-    const caseDoc = await Case.findById(battle.cases[c]).populate("items");
+    const caseDoc = caseById.get(String(battle.cases[c]));
     if (!caseDoc) {
       throw new Error(`case ${battle.cases[c]} no longer exists`);
     }
@@ -99,9 +105,11 @@ async function chargeAndStart(battleId, io = noopIo) {
   const humans = battle.players.filter((p) => p.userId && !p.isBot);
 
   // pre-check balances so we don't do partial charges in the common case
+  const balanceDocs = await User.find({ _id: { $in: humans.map((p) => p.userId) } }).select("walletBalance");
+  const balanceById = new Map(balanceDocs.map((u) => [String(u._id), u.walletBalance]));
   for (const p of humans) {
-    const u = await User.findById(p.userId).select("walletBalance");
-    if (!u || u.walletBalance < battle.entryCost) {
+    const balance = balanceById.get(String(p.userId));
+    if (balance === undefined || balance < battle.entryCost) {
       await release();
       return { error: `${p.username} can't cover the entry`, shortSlot: p.slot };
     }


### PR DESCRIPTION
Starting a battle loaded every case with its own populated query, one at a time, and pre-checked each player balance the same way. With the database currently ~210ms away from the server, a 20-case battle paid around 40 sequential round trips and took roughly 8 seconds to start.

The preroll now loads the unique cases in one $in query with populate and maps them back in battle order; the balance pre-check batches the same way. Behavior is unchanged, including repeated cases and the deleted-case error.

Tests: new battlePreroll suite (repeated cases, order preservation, deleted case) plus the full backend suite, 337 passing.