### PR TITLE
Stop shipping range tables on the case routes

### DIFF
--- a/backend/__tests__/integration/caseRoutesPayload.test.js
+++ b/backend/__tests__/integration/caseRoutesPayload.test.js
@@ -1,0 +1,47 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+const Case = require("../../models/Case");
+const Item = require("../../models/Item");
+const { recomputeCaseValues } = require("../../utils/itemValue");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeCaseWithConfig() {
+  const s = uniqueSuffix();
+  const item = await Item.create({ name: `i-${s}`, image: "i.png", rarity: "3", baseValue: 100 });
+  const c = await Case.create({ title: `c-${s}`, image: "c.png", price: 50, items: [item._id] });
+  await recomputeCaseValues(c._id);
+  return c;
+}
+
+test("the case listing ships neither items nor the range table", async () => {
+  const c = await makeCaseWithConfig();
+  expect((await Case.findById(c._id)).rangeTable.length).toBeGreaterThan(0);
+
+  const res = await request(app).get("/cases");
+  expect(res.status).toBe(200);
+  const row = res.body.find((x) => x.title === c.title);
+  expect(row).toBeTruthy();
+  expect(row.items).toBeUndefined();
+  expect(row.rangeTable).toBeUndefined();
+  expect(row.price).toBe(50);
+});
+
+test("the case detail keeps its items but drops the range table", async () => {
+  const c = await makeCaseWithConfig();
+  const res = await request(app).get(`/cases/${c._id}`);
+  expect(res.status).toBe(200);
+  expect(res.body.items).toHaveLength(1);
+  expect(res.body.items[0].name).toMatch(/^i-/);
+  expect(res.body.rangeTable).toBeUndefined();
+});

--- a/backend/routes/caseRoutes.js
+++ b/backend/routes/caseRoutes.js
@@ -12,7 +12,8 @@ router.get("/", async (req, res) => {
     // escape regex metacharacters so search is a literal, injection/ReDoS-safe match
     const safe = q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const filter = q ? { title: { $regex: safe, $options: "i" } } : {};
-    const cases = await Case.find(filter).select('-items');
+    // the committed range table is one entry per item and no listing consumer reads it
+    const cases = await Case.find(filter).select('-items -rangeTable');
     publicCache(res, TTL.caseList);
     res.json(cases);
   } catch (err) {
@@ -39,10 +40,12 @@ router.post("/", isAuthenticated, isAdmin, async (req, res) => {
 
 router.get("/:id", async (req, res) => {
   try {
-    const caseData = await Case.findById(req.params.id).populate({
-      path: "items",
-      options: { sort: { rarity: -1 } },
-    });
+    const caseData = await Case.findById(req.params.id)
+      .select("-rangeTable")
+      .populate({
+        path: "items",
+        options: { sort: { rarity: -1 } },
+      });
     publicCache(res, TTL.caseDetail);
     res.json(caseData);
   } catch (err) {


### PR DESCRIPTION
The case listing excluded items but still serialized every case's committed rangeTable, one entry per item. On the live data that is 358 entries and 90% of the payload: 29.5KB for 10 cases where the home page needs 2.9KB. The case detail route shipped it too, on top of its populated items.

Both routes now exclude rangeTable. No client reads it from these endpoints (fair-page verification gets it from /fair, and the game server reads the model directly), so nothing else changes.

Tests: new caseRoutesPayload suite (listing has no items/rangeTable, detail keeps items, drops rangeTable); full backend suite, 339 passing.