### PR TITLE
Stop loading every user to compute a ranking window

### DIFF
--- a/backend/__tests__/integration/ranking.test.js
+++ b/backend/__tests__/integration/ranking.test.js
@@ -1,0 +1,76 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeLadder(winnings) {
+  const users = [];
+  for (const w of winnings) {
+    const s = uniqueSuffix();
+    users.push(await User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", weeklyWinnings: w }));
+  }
+  return users;
+}
+
+const getRanking = (user) =>
+  request(app).get("/users/ranking").set({ Authorization: `Bearer ${tokenFor(user)}` });
+
+test("a mid-ladder user sees their rank and a seven-row window around them", async () => {
+  const users = await makeLadder([100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
+  const res = await getRanking(users[4]); // 60 -> rank 5
+
+  expect(res.status).toBe(200);
+  expect(res.body.ranking).toBe(5);
+  expect(res.body.users).toHaveLength(7);
+  expect(res.body.users[3].username).toBe(users[4].username);
+  const winnings = res.body.users.map((u) => u.weeklyWinnings);
+  expect(winnings).toEqual([90, 80, 70, 60, 50, 40, 30]);
+});
+
+test("the leader's window pads downward and stays seven rows", async () => {
+  const users = await makeLadder([100, 90, 80, 70, 60, 50, 40, 30]);
+  const res = await getRanking(users[0]);
+
+  expect(res.body.ranking).toBe(1);
+  expect(res.body.users).toHaveLength(7);
+  expect(res.body.users[0].username).toBe(users[0].username);
+  expect(res.body.users.map((u) => u.weeklyWinnings)).toEqual([100, 90, 80, 70, 60, 50, 40]);
+});
+
+test("the last place pads upward and stays seven rows", async () => {
+  const users = await makeLadder([100, 90, 80, 70, 60, 50, 40, 30]);
+  const res = await getRanking(users[7]);
+
+  expect(res.body.ranking).toBe(8);
+  expect(res.body.users).toHaveLength(7);
+  expect(res.body.users[6].username).toBe(users[7].username);
+  expect(res.body.users.map((u) => u.weeklyWinnings)).toEqual([90, 80, 70, 60, 50, 40, 30]);
+});
+
+test("tied players get distinct neighboring ranks", async () => {
+  const users = await makeLadder([50, 50, 50]);
+  const ranks = [];
+  for (const u of users) {
+    ranks.push((await getRanking(u)).body.ranking);
+  }
+  expect([...ranks].sort()).toEqual([1, 2, 3]);
+});
+
+test("a small ladder returns everyone without padding artifacts", async () => {
+  const users = await makeLadder([20, 10]);
+  const res = await getRanking(users[1]);
+  expect(res.body.ranking).toBe(2);
+  expect(res.body.users).toHaveLength(2);
+  expect(res.body.users.map((u) => u.weeklyWinnings)).toEqual([20, 10]);
+});

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -117,5 +117,6 @@ const UserSchema = new mongoose.Schema({
 
 UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });
 UserSchema.index({ referredBy: 1 }, { sparse: true });
+UserSchema.index({ weeklyWinnings: -1 }); // leaderboard, ranking window, weekly cron
 
 module.exports = User = mongoose.model("User", UserSchema);

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -283,25 +283,37 @@ router.get('/topPlayers', async (req, res) => {
 // Fetch user ranking
 router.get('/ranking', authMiddleware.isAuthenticated, async (req, res) => {
   try {
-    const allUsers = await User.find({}).sort({ weeklyWinnings: -1 }).select('username weeklyWinnings');
-    const userIndex = allUsers.findIndex(u => u.id === req.user.id);
+    const me = { _id: req.user._id, username: req.user.username, weeklyWinnings: req.user.weeklyWinnings || 0 };
+    // rank and neighbors come from indexed range queries instead of loading every
+    // user; ties break by _id so two equal players never share a position
+    const aboveFilter = {
+      $or: [
+        { weeklyWinnings: { $gt: me.weeklyWinnings } },
+        { weeklyWinnings: me.weeklyWinnings, _id: { $lt: me._id } },
+      ],
+    };
+    const belowFilter = {
+      $or: [
+        { weeklyWinnings: { $lt: me.weeklyWinnings } },
+        { weeklyWinnings: me.weeklyWinnings, _id: { $gt: me._id } },
+      ],
+    };
 
-    let start = userIndex - 3; // Fetch 3 users above
-    let end = userIndex + 4; // Fetch 3 users below (+1 for inclusive)
+    const [rankAbove, aboveAll, belowAll] = await Promise.all([
+      User.countDocuments(aboveFilter),
+      User.find(aboveFilter).sort({ weeklyWinnings: 1, _id: -1 }).limit(6).select('username weeklyWinnings'),
+      User.find(belowFilter).sort({ weeklyWinnings: -1, _id: 1 }).limit(6).select('username weeklyWinnings'),
+    ]);
 
-    // Adjust if start or end goes out of bounds
-    if (start < 0) {
-      start = 0;
-      end = Math.min(7, allUsers.length); // Adjust end if start is adjusted
-    }
-    if (end > allUsers.length) {
-      end = allUsers.length;
-      start = Math.max(0, end - 7); // Adjust start if end is adjusted
-    }
+    // pad the 7-row window toward the other side when near the top or bottom
+    let aboveTake = Math.min(aboveAll.length, 3);
+    let belowTake = Math.min(belowAll.length, 3);
+    belowTake = Math.min(belowAll.length, belowTake + (3 - aboveTake));
+    aboveTake = Math.min(aboveAll.length, aboveTake + (3 - Math.min(belowAll.length, 3)));
 
-    const surroundingUsers = allUsers.slice(start, end);
+    const users = [...aboveAll.slice(0, aboveTake).reverse(), me, ...belowAll.slice(0, belowTake)];
 
-    res.json({ ranking: userIndex + 1, users: surroundingUsers });
+    res.json({ ranking: rankAbove + 1, users });
   } catch (err) {
     res.status(500).json({ message: 'Server error' });
   }


### PR DESCRIPTION
The ranking endpoint fetched every user sorted by weekly winnings and found the caller's index in the array, so its cost grew with the user count (2,800+ documents per call today).

It now uses three indexed queries: a count of players ranked above for the position, and two small range queries for the neighbors, with _id as a deterministic tiebreak. The seven-row window still pads toward the other side at the top and bottom, and the response shape is unchanged. Adds the missing weeklyWinnings index, which topPlayers and the weekly cron sort on too.

Tests: new ranking suite (window shape, leader and last place padding, tie determinism, small ladders); full backend suite, 344 passing.