### PR TITLE
Give the backoffice real casino analytics

### DIFF
--- a/backend/__tests__/integration/adminStatsV2.test.js
+++ b/backend/__tests__/integration/adminStatsV2.test.js
@@ -1,0 +1,164 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const { recordTransaction, TX } = require("../../utils/economy");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 1000,
+    ...overrides,
+  });
+}
+
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+const get = (path, user) => auth(request(app).get(path), user);
+const row = (userId, type, direction, amount, meta = {}) =>
+  recordTransaction({ userId, type, direction, amount, meta });
+
+const dayString = (date) => date.toISOString().slice(0, 10);
+
+describe("access", () => {
+  test("the new stats paths refuse anonymous and non-admin callers", async () => {
+    const pleb = await makeUser();
+    const paths = [
+      "/admin/stats/timeseries",
+      "/admin/stats/wins",
+      `/admin/stats/users/${pleb._id}`,
+    ];
+    for (const p of paths) {
+      expect((await request(app).get(p)).status).toBe(401);
+      expect((await get(p, pleb)).status).toBe(403);
+    }
+  });
+});
+
+describe("GET /admin/stats/timeseries", () => {
+  test("buckets wagers, payouts, faucet and players by day", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const a = await makeUser();
+    const b = await makeUser();
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    await row(a._id, TX.SLOT_BET, "debit", 100);
+    await row(a._id, TX.SLOT_WIN, "credit", 40);
+    await row(b._id, TX.BONUS, "credit", 200);
+    await Transaction.create({
+      userId: a._id, type: TX.CRASH_BET, direction: "debit", amount: 900, createdAt: yesterday,
+    });
+
+    const res = await get("/admin/stats/timeseries", admin);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+
+    const today = res.body.find((d) => d.day === dayString(new Date()));
+    expect(today).toMatchObject({ wagered: 100, paidOut: 40, ggr: 60, faucet: 200, players: 2 });
+
+    const before = res.body.find((d) => d.day === dayString(yesterday));
+    expect(before).toMatchObject({ wagered: 900, paidOut: 0, ggr: 900, players: 1 });
+    expect(res.body[0].day < res.body[1].day).toBe(true);
+  });
+});
+
+describe("GET /admin/stats/wins", () => {
+  test("returns the biggest single payouts with who hit them", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const lucky = await makeUser();
+    const other = await makeUser();
+    await row(lucky._id, TX.SLOT_WIN, "credit", 5000, { betAmount: 50 });
+    await row(other._id, TX.PLINKO_WIN, "credit", 800, { betAmount: 100 });
+    await row(other._id, TX.SLOT_BET, "debit", 9999); // a bet is not a win
+
+    const res = await get("/admin/stats/wins", admin);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({
+      username: lucky.username, type: TX.SLOT_WIN, amount: 5000, bet: 50, multiple: 100,
+    });
+    expect(res.body[1]).toMatchObject({ type: TX.PLINKO_WIN, amount: 800, multiple: 8 });
+  });
+});
+
+describe("GET /admin/stats/games enrichment", () => {
+  test("plinko appears and rows carry reach, biggest win and the designed edge", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const a = await makeUser();
+    const b = await makeUser();
+    await row(a._id, TX.PLINKO_BET, "debit", 100, { risk: "medium" });
+    await row(b._id, TX.PLINKO_BET, "debit", 50, { risk: "high" });
+    await row(a._id, TX.PLINKO_WIN, "credit", 290, { risk: "medium" });
+
+    const res = await get("/admin/stats/games", admin);
+    const plinko = res.body.games.find((g) => g.game === "plinko");
+    expect(plinko).toMatchObject({
+      plays: 2, wagered: 150, paidOut: 290, net: -140, uniquePlayers: 2, biggestWin: 290,
+    });
+    expect(plinko.theoRtp).toBeCloseTo(0.9655, 4);
+  });
+});
+
+describe("GET /admin/stats/users/:id", () => {
+  test("composes identity, totals, per-game lines and the recent ledger", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const referrer = await makeUser();
+    const player = await makeUser({
+      referredBy: referrer._id,
+      inventory: [{ _id: new mongoose.Types.ObjectId(), name: "i", image: "i.png", rarity: "1", uniqueId: "uq-1" }],
+    });
+    await makeUser({ referredBy: player._id });
+
+    await row(player._id, TX.SIGNUP, "credit", 200);
+    await row(player._id, TX.BONUS, "credit", 300);
+    await row(player._id, TX.SLOT_BET, "debit", 400);
+    await row(player._id, TX.SLOT_WIN, "credit", 1000, { betAmount: 400 });
+    await row(player._id, TX.CASE_OPEN, "debit", 250, { quantity: 5, caseId: new mongoose.Types.ObjectId() });
+    await row(player._id, TX.MARKET_BUY, "debit", 120);
+    await row(player._id, TX.ITEM_SELL, "credit", 60);
+
+    const res = await get(`/admin/stats/users/${player._id}`, admin);
+    expect(res.status).toBe(200);
+
+    expect(res.body.user).toMatchObject({
+      username: player.username,
+      referredBy: referrer.username,
+      referrals: 1,
+      inventoryCount: 1,
+    });
+    expect(res.body.totals).toMatchObject({
+      wagered: 650, won: 1000, net: -350, faucet: 500, marketSpent: 120, itemsSold: 60,
+    });
+    expect(res.body.totals.biggestWin).toMatchObject({ type: TX.SLOT_WIN, amount: 1000 });
+
+    const byGame = Object.fromEntries(res.body.games.map((g) => [g.game, g]));
+    expect(byGame.slots).toMatchObject({ plays: 1, wagered: 400, won: 1000, net: -600 });
+    expect(byGame.cases).toMatchObject({ plays: 5, wagered: 250 });
+    expect(byGame.crash).toBeUndefined(); // never played
+
+    expect(res.body.recent.length).toBe(7);
+    expect(res.body.recent[0].type).toBe(TX.ITEM_SELL);
+  });
+
+  test("unknown and malformed ids answer 404", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    expect((await get(`/admin/stats/users/${new mongoose.Types.ObjectId()}`, admin)).status).toBe(404);
+    expect((await get("/admin/stats/users/not-an-id", admin)).status).toBe(404);
+  });
+});

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -46,6 +46,35 @@ router.get("/stats/users", isAuthenticated, isAdmin, async (req, res) => {
   }
 });
 
+router.get("/stats/timeseries", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    res.json(await adminStats.timeseries(req.query.days));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.get("/stats/wins", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    res.json(await adminStats.bigWins(req.query.days));
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
+router.get("/stats/users/:id", isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const detail = await adminStats.playerDetail(req.params.id, req.query.days);
+    if (!detail) return res.status(404).json({ message: "User not found" });
+    res.json(detail);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: "Server error" });
+  }
+});
+
 router.get("/users", isAuthenticated, isAdmin, async (req, res) => {
   try {
     const users = await User.find().select("-password");

--- a/backend/utils/adminStats.js
+++ b/backend/utils/adminStats.js
@@ -3,9 +3,17 @@ const User = require("../models/User");
 const Case = require("../models/Case");
 const Transaction = require("../models/Transaction");
 const { accountBalance, ledgerSupply, TX, STAKE_TYPES } = require("./economy");
-const { HOUSE, MINT, ESCROW } = require("./accounts");
+const { HOUSE, MINT, ESCROW, GENESIS } = require("./accounts");
 
 const PAGE_SIZE = 20;
+
+// KP-paying game wins and stake returns, for daily series and big-win surfacing
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const REFUND_TYPES = [TX.CRASH_REFUND, TX.COINFLIP_REFUND, TX.BATTLE_REFUND];
+// KP printed to players outside the games
+const FAUCET_TYPES = [TX.SIGNUP, TX.BONUS, TX.MISSION_REWARD, TX.REFERRAL_BONUS, TX.REFERRAL_MILESTONE, TX.AD_REWARD];
+// designed edges per game, so the realized return can be judged against intent
+const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, cases: 0.9, battles: 0.9 };
 
 // window start, or null for all-time
 const sinceFor = (days) => {
@@ -38,6 +46,7 @@ const GAME_LINES = [
   { game: "crash", bets: [TX.CRASH_BET], outs: [TX.CRASH_CASHOUT, TX.CRASH_REFUND] },
   { game: "coinflip", bets: [TX.COINFLIP_BET], outs: [TX.COINFLIP_WIN, TX.COINFLIP_REFUND] },
   { game: "slots", bets: [TX.SLOT_BET], outs: [TX.SLOT_WIN] },
+  { game: "plinko", bets: [TX.PLINKO_BET], outs: [TX.PLINKO_WIN] },
   { game: "cases", bets: [TX.CASE_OPEN], outs: [] },
   { game: "battles", bets: [TX.BATTLE_ENTRY], outs: [TX.BATTLE_REFUND] },
 ];
@@ -74,17 +83,36 @@ async function gameStats(days) {
   const sumOf = (types, dir) =>
     types.reduce((s, t) => s + ((byTypeDir[`${t}:${dir}`] || {}).amount || 0), 0);
 
+  // per-type reach and outliers feed the enriched game rows
+  const gameTypes = new Set(GAME_LINES.flatMap((g) => [...g.bets, ...g.outs]));
+  const perType = await Transaction.aggregate([
+    { $match: { type: { $in: [...gameTypes] }, ...matchSince(since) } },
+    { $group: { _id: "$type", users: { $addToSet: "$userId" }, maxAmount: { $max: "$amount" } } },
+    { $project: { users: { $size: "$users" }, maxAmount: 1 } },
+  ]);
+  const reach = new Map(perType.map((r) => [r._id, r]));
+
   const games = GAME_LINES.map(({ game, bets, outs }) => {
     const betSlot = byTypeDir[`${bets[0]}:debit`] || { amount: 0, count: 0, qty: 0 };
     const plays = game === "cases" ? betSlot.qty || betSlot.count : betSlot.count;
     const wagered = sumOf(bets, "debit");
     const paidOut = sumOf(outs, "credit");
-    return { game, plays, wagered, paidOut, net: wagered - paidOut };
+    const uniquePlayers = (reach.get(bets[0]) || {}).users || 0;
+    const biggestWin = outs.reduce((m, t) => Math.max(m, (reach.get(t) || {}).maxAmount || 0), 0);
+    return {
+      game,
+      plays,
+      wagered,
+      paidOut,
+      net: wagered - paidOut,
+      uniquePlayers,
+      biggestWin,
+      theoRtp: THEO_RTP[game] || null,
+    };
   }).sort((a, b) => b.net - a.net);
 
   // everything else settling against the house or the mint, signed from the house's
   // and the supply's point of view; grouped by type so new lines appear on their own
-  const gameTypes = new Set(GAME_LINES.flatMap((g) => [...g.bets, ...g.outs]));
   const houseLines = [];
   const issuance = [];
   const acc = {};
@@ -145,6 +173,157 @@ async function caseStats(days) {
   });
 }
 
+// daily buckets for the dashboard charts; all-time falls back to the last 90 days
+// so the series stays bounded. system accounts are excluded so player counts are real.
+async function timeseries(days) {
+  const since = sinceFor(days) || new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+  const rows = await Transaction.aggregate([
+    { $match: { createdAt: { $gte: since }, userId: { $nin: [HOUSE, MINT, ESCROW, GENESIS] } } },
+    {
+      $group: {
+        _id: { $dateToString: { format: "%Y-%m-%d", date: "$createdAt" } },
+        wagered: { $sum: { $cond: [{ $in: ["$type", STAKE_TYPES] }, "$amount", 0] } },
+        paidOut: { $sum: { $cond: [{ $in: ["$type", [...WIN_TYPES, ...REFUND_TYPES]] }, "$amount", 0] } },
+        faucet: {
+          $sum: {
+            $cond: [
+              { $and: [{ $eq: ["$counterparty", MINT] }, { $eq: ["$direction", "credit"] }] },
+              "$amount",
+              0,
+            ],
+          },
+        },
+        players: { $addToSet: "$userId" },
+      },
+    },
+    { $project: { wagered: 1, paidOut: 1, faucet: 1, players: { $size: "$players" } } },
+    { $sort: { _id: 1 } },
+  ]);
+  return rows.map((r) => ({
+    day: r._id,
+    wagered: r.wagered,
+    paidOut: r.paidOut,
+    ggr: r.wagered - r.paidOut,
+    faucet: r.faucet,
+    players: r.players,
+  }));
+}
+
+// the largest single game payouts in the window, with who hit them
+async function bigWins(days, limit = 10) {
+  const since = sinceFor(days);
+  const rows = await Transaction.find({ type: { $in: WIN_TYPES }, ...matchSince(since) })
+    .sort({ amount: -1 })
+    .limit(limit)
+    .select("userId type amount meta createdAt")
+    .lean();
+  const users = await User.find(
+    { _id: { $in: rows.map((r) => r.userId) } },
+    { username: 1, profilePicture: 1 }
+  ).lean();
+  const byId = new Map(users.map((u) => [String(u._id), u]));
+  return rows.map((r) => {
+    const u = byId.get(String(r.userId));
+    const bet = r.meta && r.meta.betAmount ? r.meta.betAmount : null;
+    return {
+      userId: String(r.userId),
+      username: u ? u.username : "(deleted user)",
+      profilePicture: u ? u.profilePicture || "" : "",
+      type: r.type,
+      amount: r.amount,
+      bet,
+      multiple: bet ? r.amount / bet : null,
+      at: r.createdAt,
+    };
+  });
+}
+
+// everything the backoffice needs about one player, composed from the ledger
+async function playerDetail(id, days) {
+  if (!mongoose.Types.ObjectId.isValid(id)) return null;
+  const user = await User.findById(id)
+    .select("username profilePicture level xp walletBalance isAdmin weeklyWinnings referredBy inventory")
+    .lean();
+  if (!user) return null;
+
+  const since = sinceFor(days);
+  const uid = user._id;
+  const [byTypeDirRows, recent, referrals, referrer] = await Promise.all([
+    Transaction.aggregate([
+      { $match: { userId: uid, ...matchSince(since) } },
+      {
+        $group: {
+          _id: { type: "$type", direction: "$direction" },
+          total: { $sum: "$amount" },
+          count: { $sum: 1 },
+          max: { $max: "$amount" },
+          qty: { $sum: { $ifNull: ["$meta.quantity", 0] } },
+          last: { $max: "$createdAt" },
+        },
+      },
+    ]),
+    Transaction.find({ userId: uid })
+      .sort({ createdAt: -1 })
+      .limit(15)
+      .select("type direction amount balanceAfter createdAt")
+      .lean(),
+    User.countDocuments({ referredBy: uid }),
+    user.referredBy ? User.findById(user.referredBy).select("username").lean() : null,
+  ]);
+
+  const slots = new Map(byTypeDirRows.map((r) => [`${r._id.type}:${r._id.direction}`, r]));
+  const get = (type, direction) => slots.get(`${type}:${direction}`) || { total: 0, count: 0, max: 0, qty: 0 };
+
+  const games = GAME_LINES.map(({ game, bets, outs }) => {
+    const bet = get(bets[0], "debit");
+    const won = outs.reduce((s, o) => s + get(o, "credit").total, 0);
+    const plays = game === "cases" ? bet.qty || bet.count : bet.count;
+    return { game, plays, wagered: bet.total, won, net: bet.total - won };
+  }).filter((g) => g.plays > 0);
+
+  const wagered = games.reduce((s, g) => s + g.wagered, 0);
+  const won = games.reduce((s, g) => s + g.won, 0);
+  const faucet = FAUCET_TYPES.reduce((s, t) => s + get(t, "credit").total, 0);
+  const biggestWin = WIN_TYPES.reduce(
+    (best, t) => {
+      const m = get(t, "credit");
+      return m.max > best.amount ? { type: t, amount: m.max } : best;
+    },
+    { type: null, amount: 0 }
+  );
+  const lastActive = byTypeDirRows.reduce((d, r) => (!d || r.last > d ? r.last : d), null);
+
+  return {
+    user: {
+      id: String(uid),
+      username: user.username,
+      profilePicture: user.profilePicture || "",
+      level: user.level || 0,
+      xp: user.xp || 0,
+      walletBalance: user.walletBalance,
+      isAdmin: !!user.isAdmin,
+      weeklyWinnings: user.weeklyWinnings || 0,
+      joined: uid.getTimestamp(),
+      inventoryCount: (user.inventory || []).length,
+      referredBy: referrer ? referrer.username : null,
+      referrals,
+    },
+    totals: {
+      wagered,
+      won,
+      net: wagered - won,
+      faucet,
+      marketSpent: get(TX.MARKET_BUY, "debit").total,
+      marketEarned: get(TX.MARKET_SALE, "credit").total,
+      itemsSold: get(TX.ITEM_SELL, "credit").total,
+      biggestWin,
+      lastActive,
+    },
+    games,
+    recent,
+  };
+}
+
 const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const SORTS = { newest: { _id: -1 }, balance: { walletBalance: -1 }, level: { level: -1 } };
 
@@ -201,4 +380,4 @@ async function userStats({ days, page = 1, search = "", sort = "newest" } = {}) 
   };
 }
 
-module.exports = { overview, gameStats, caseStats, userStats, PAGE_SIZE };
+module.exports = { overview, gameStats, caseStats, userStats, timeseries, bigWins, playerDetail, PAGE_SIZE };

--- a/src/pages/Backoffice/AdminChart.tsx
+++ b/src/pages/Backoffice/AdminChart.tsx
@@ -1,0 +1,162 @@
+import { useMemo, useState } from "react";
+import { CHART_AMBER, CHART_INDIGO, compactKp, shortDay } from "./adminSeries";
+
+interface AdminChartProps {
+  title: string;
+  points: { day: string; values: number[] }[];
+  series: { name: string; color: string }[];
+  mode: "bars" | "lines";
+  polarity?: boolean;
+  money?: boolean;
+}
+
+const W = 720;
+const H = 190;
+const PAD = { top: 10, right: 8, bottom: 20, left: 48 };
+
+const AdminChart: React.FC<AdminChartProps> = ({ title, points, series, mode, polarity, money }) => {
+  const [hover, setHover] = useState<number | null>(null);
+
+  const geom = useMemo(() => {
+    const plotW = W - PAD.left - PAD.right;
+    const plotH = H - PAD.top - PAD.bottom;
+    const all = points.flatMap((p) => p.values);
+    let lo = Math.min(0, ...all);
+    let hi = Math.max(0, ...all);
+    if (hi === lo) hi = lo + 1;
+    const pad = (hi - lo) * 0.08;
+    if (lo < 0) lo -= pad;
+    hi += pad;
+    const y = (v: number) => PAD.top + plotH - ((v - lo) / (hi - lo)) * plotH;
+    const step = points.length ? plotW / points.length : plotW;
+    const x = (i: number) => PAD.left + step * (i + 0.5);
+    return { plotW, plotH, lo, hi, y, x, step };
+  }, [points]);
+
+  const ticks = [geom.hi, (geom.hi + geom.lo) / 2, geom.lo];
+  const hasData = points.some((p) => p.values.some((v) => v !== 0));
+  const fmt = (v: number) => (money ? `${compactKp(v)} KP` : Math.round(v).toLocaleString());
+  const barColor = (v: number) => (polarity ? (v >= 0 ? CHART_INDIGO : CHART_AMBER) : series[0].color);
+
+  return (
+    <div className="bg-surface rounded-lg p-5">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-ink font-semibold">{title}</h2>
+        {series.length > 1 && (
+          <div className="flex items-center gap-3 text-xs text-ink-muted">
+            {series.map((s) => (
+              <span key={s.name} className="flex items-center gap-1.5">
+                <span className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: s.color }} />
+                {s.name}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {!hasData ? (
+        <div className="h-40 flex items-center justify-center text-sm text-ink-muted">No activity in this window.</div>
+      ) : (
+        <div className="relative">
+          <svg viewBox={`0 0 ${W} ${H}`} className="w-full" onMouseLeave={() => setHover(null)}>
+            {ticks.map((t, i) => (
+              <g key={i}>
+                <line x1={PAD.left} x2={W - PAD.right} y1={geom.y(t)} y2={geom.y(t)} stroke="#2A2840" strokeWidth={1} />
+                <text x={PAD.left - 6} y={geom.y(t) + 4} textAnchor="end" fontSize={11} fill="#84819A">
+                  {money ? compactKp(t) : Math.round(t).toLocaleString()}
+                </text>
+              </g>
+            ))}
+            {geom.lo < 0 && (
+              <line x1={PAD.left} x2={W - PAD.right} y1={geom.y(0)} y2={geom.y(0)} stroke="#3A365A" strokeWidth={1} />
+            )}
+
+            {mode === "bars" &&
+              points.map((p, i) => {
+                const v = p.values[0];
+                const top = Math.min(geom.y(v), geom.y(0));
+                const h = Math.max(Math.abs(geom.y(v) - geom.y(0)), v === 0 ? 0 : 2);
+                const w = Math.max(geom.step - 2, 1);
+                return (
+                  <rect
+                    key={p.day}
+                    x={geom.x(i) - w / 2}
+                    y={top}
+                    width={w}
+                    height={h}
+                    rx={Math.min(2, w / 2)}
+                    fill={barColor(v)}
+                    opacity={hover === null || hover === i ? 1 : 0.45}
+                  />
+                );
+              })}
+
+            {mode === "lines" &&
+              series.map((s, si) => (
+                <g key={s.name}>
+                  <polyline
+                    fill="none"
+                    stroke={s.color}
+                    strokeWidth={2}
+                    strokeLinejoin="round"
+                    points={points.map((p, i) => `${geom.x(i)},${geom.y(p.values[si])}`).join(" ")}
+                  />
+                  {hover !== null && points[hover] && (
+                    <circle
+                      cx={geom.x(hover)}
+                      cy={geom.y(points[hover].values[si])}
+                      r={4}
+                      fill={s.color}
+                      stroke="#212031"
+                      strokeWidth={2}
+                    />
+                  )}
+                </g>
+              ))}
+
+            {points.map((p, i) => (
+              <rect
+                key={`hit-${p.day}`}
+                x={PAD.left + geom.step * i}
+                y={PAD.top}
+                width={geom.step}
+                height={geom.plotH}
+                fill="transparent"
+                onMouseEnter={() => setHover(i)}
+              />
+            ))}
+
+            {[0, Math.floor((points.length - 1) / 2), points.length - 1]
+              .filter((i, k, arr) => points[i] && arr.indexOf(i) === k)
+              .map((i) => (
+                <text key={`x-${i}`} x={geom.x(i)} y={H - 6} textAnchor="middle" fontSize={11} fill="#84819A">
+                  {shortDay(points[i].day)}
+                </text>
+              ))}
+          </svg>
+
+          {hover !== null && points[hover] && (
+            <div
+              className="absolute top-1 pointer-events-none bg-surface-nav border border-line rounded-md px-3 py-2 text-xs z-10"
+              style={{
+                left: `${((hover + 0.5) / points.length) * 100}%`,
+                transform: hover > points.length / 2 ? "translateX(-105%)" : "translateX(5%)",
+              }}
+            >
+              <div className="text-ink-muted mb-1">{points[hover].day}</div>
+              {series.map((s, si) => (
+                <div key={s.name} className="flex items-center gap-1.5 text-ink">
+                  <span className="w-2 h-2 rounded-sm" style={{ backgroundColor: s.color }} />
+                  {series.length > 1 && <span className="text-ink-muted">{s.name}</span>}
+                  <span className="font-semibold">{fmt(points[hover].values[si])}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminChart;

--- a/src/pages/Backoffice/Backoffice.services.ts
+++ b/src/pages/Backoffice/Backoffice.services.ts
@@ -4,10 +4,16 @@ import {
   getAdminGameStats,
   getAdminCaseStats,
   getAdminUserStats,
+  getAdminTimeseries,
+  getAdminBigWins,
+  getAdminPlayerDetail,
   AdminOverview,
   AdminGameStats,
   AdminCaseRow,
   AdminUsersPage,
+  AdminBigWin,
+  AdminPlayerDetail,
+  TimeseriesPoint,
 } from "../../services/admin/AdminServices";
 import UserContext from "../../UserContext";
 
@@ -19,11 +25,16 @@ export const useBackofficeServices = () => {
   const [overview, setOverview] = useState<AdminOverview | null>(null);
   const [games, setGames] = useState<AdminGameStats | null>(null);
   const [cases, setCases] = useState<AdminCaseRow[] | null>(null);
+  const [series, setSeries] = useState<TimeseriesPoint[] | null>(null);
+  const [wins, setWins] = useState<AdminBigWin[] | null>(null);
   const [usersPage, setUsersPage] = useState<AdminUsersPage | null>(null);
   const [page, setPage] = useState<number>(1);
   const [search, setSearch] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<boolean>(false);
+  const [playerId, setPlayerId] = useState<string | null>(null);
+  const [player, setPlayer] = useState<AdminPlayerDetail | null>(null);
+  const [playerLoading, setPlayerLoading] = useState<boolean>(false);
 
   const isAdmin = !!userData?.isAdmin;
 
@@ -34,12 +45,20 @@ export const useBackofficeServices = () => {
     }
     let active = true;
     setLoading(true);
-    Promise.all([getAdminOverview(days), getAdminGameStats(days), getAdminCaseStats(days)])
-      .then(([o, g, c]) => {
+    Promise.all([
+      getAdminOverview(days),
+      getAdminGameStats(days),
+      getAdminCaseStats(days),
+      getAdminTimeseries(days),
+      getAdminBigWins(days),
+    ])
+      .then(([o, g, c, s, w]) => {
         if (!active) return;
         setOverview(o);
         setGames(g);
         setCases(c);
+        setSeries(s);
+        setWins(w);
         setError(false);
       })
       .catch(() => {
@@ -72,6 +91,26 @@ export const useBackofficeServices = () => {
     };
   }, [isAdmin, days, page, search]);
 
+  // the drill-down loads on open and follows the window toggle while open
+  useEffect(() => {
+    if (!isAdmin || !playerId) return;
+    let active = true;
+    setPlayerLoading(true);
+    getAdminPlayerDetail(playerId, days)
+      .then((d) => {
+        if (active) setPlayer(d);
+      })
+      .catch(() => {
+        if (active) setPlayer(null);
+      })
+      .finally(() => {
+        if (active) setPlayerLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isAdmin, playerId, days]);
+
   const changeSearch = (value: string) => {
     setSearch(value);
     setPage(1);
@@ -85,6 +124,8 @@ export const useBackofficeServices = () => {
     overview,
     games,
     cases,
+    series,
+    wins,
     usersPage,
     page,
     setPage,
@@ -92,5 +133,13 @@ export const useBackofficeServices = () => {
     changeSearch,
     loading,
     error,
+    playerId,
+    player,
+    playerLoading,
+    openPlayer: (id: string) => setPlayerId(id),
+    closePlayer: () => {
+      setPlayerId(null);
+      setPlayer(null);
+    },
   };
 };

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -6,8 +6,13 @@ import {
   AdminGameStats,
   AdminCaseRow,
   AdminUsersPage,
+  AdminBigWin,
+  AdminPlayerDetail,
+  TimeseriesPoint,
 } from "../../services/admin/AdminServices";
 import { Window } from "./Backoffice.services";
+import AdminChart from "./AdminChart";
+import { CHART_AMBER, CHART_INDIGO, fillDays } from "./adminSeries";
 
 interface Props {
   userData: any;
@@ -17,6 +22,8 @@ interface Props {
   overview: AdminOverview | null;
   games: AdminGameStats | null;
   cases: AdminCaseRow[] | null;
+  series: TimeseriesPoint[] | null;
+  wins: AdminBigWin[] | null;
   usersPage: AdminUsersPage | null;
   page: number;
   setPage: (p: number) => void;
@@ -24,14 +31,27 @@ interface Props {
   changeSearch: (s: string) => void;
   loading: boolean;
   error: boolean;
+  playerId: string | null;
+  player: AdminPlayerDetail | null;
+  playerLoading: boolean;
+  openPlayer: (id: string) => void;
+  closePlayer: () => void;
 }
 
 const GAME_LABELS: Record<string, string> = {
   crash: "Crash",
   coinflip: "Coin Flip",
   slots: "Slots",
+  plinko: "Plinko",
   cases: "Case openings",
   battles: "Case battles",
+};
+
+const WIN_LABELS: Record<string, string> = {
+  slot_win: "Slots",
+  plinko_win: "Plinko",
+  crash_cashout: "Crash",
+  coinflip_win: "Coin Flip",
 };
 
 const LINE_LABELS: Record<string, string> = {
@@ -49,6 +69,16 @@ const LINE_LABELS: Record<string, string> = {
 const label = (type: string) => LINE_LABELS[type] || type.replace(/_/g, " ");
 
 const netClass = (n: number) => (n > 0 ? "text-green-400" : n < 0 ? "text-red-400" : "text-ink-soft");
+
+// KP-paying games can be judged against their designed return; item games cannot
+const KP_GAMES = new Set(["crash", "coinflip", "slots", "plinko"]);
+const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
+const rtpClass = (actual: number, theo: number | null, wagered: number) => {
+  if (theo === null || wagered < 10000) return "text-ink-soft";
+  if (actual > theo + 0.03) return "text-red-400";
+  if (actual < theo - 0.03) return "text-green-400";
+  return "text-ink-soft";
+};
 
 const StatCard = ({ title, children, sub }: { title: string; children: React.ReactNode; sub?: React.ReactNode }) => (
   <div className="bg-surface rounded-lg p-4 flex flex-col gap-1">
@@ -71,9 +101,147 @@ const WINDOWS: { value: Window; text: string }[] = [
   { value: 7, text: "7 days" },
 ];
 
+const PlayerDetail = ({
+  player,
+  loading,
+  windowText,
+  onBack,
+}: {
+  player: AdminPlayerDetail | null;
+  loading: boolean;
+  windowText: string;
+  onBack: () => void;
+}) => {
+  if (loading) {
+    return <Skeleton height={420} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />;
+  }
+  if (!player || !player.user || !player.totals) {
+    return (
+      <div className="py-16 flex flex-col items-center gap-4 text-ink-muted">
+        Could not load this player.
+        <button onClick={onBack} className="px-3 py-1.5 rounded-md bg-surface-raised text-ink text-sm">
+          Back
+        </button>
+      </div>
+    );
+  }
+  const { user, totals, games, recent } = player;
+  const personalRtp = totals.wagered > 0 ? totals.won / totals.wagered : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-4 bg-surface rounded-lg p-5">
+        <button onClick={onBack} className="px-3 py-1.5 rounded-md bg-surface-raised text-ink text-sm shrink-0">
+          Back
+        </button>
+        <Avatar image={user.profilePicture} loading={false} id={user.id} size="medium" level={user.level} />
+        <div className="flex flex-col">
+          <span className="text-ink font-semibold text-lg flex items-center gap-2">
+            {user.username}
+            {user.isAdmin && <span className="text-xs px-1.5 py-0.5 rounded bg-accent/20 text-accent-light">admin</span>}
+          </span>
+          <span className="text-xs text-ink-muted">
+            Level {user.level} · joined {new Date(user.joined).toLocaleDateString()}
+            {user.referredBy ? ` · referred by ${user.referredBy}` : ""} · {user.referrals} referrals
+          </span>
+        </div>
+        <div className="ml-auto text-right">
+          <div className="text-xs text-ink-muted">Balance</div>
+          <div className="text-xl font-semibold text-accent-gold">
+            <Monetary value={Math.floor(user.walletBalance)} />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <StatCard title={`House net on this player (${windowText})`}>
+          <span className={netClass(totals.net)}>
+            <Monetary value={totals.net} />
+          </span>
+        </StatCard>
+        <StatCard title={`Wagered (${windowText})`}>
+          <Monetary value={totals.wagered} />
+        </StatCard>
+        <StatCard
+          title={`Personal RTP (${windowText})`}
+          sub={totals.biggestWin.type ? `biggest win ${WIN_LABELS[totals.biggestWin.type] || totals.biggestWin.type}` : undefined}
+        >
+          {personalRtp !== null ? pct(personalRtp) : "-"}
+        </StatCard>
+        <StatCard title={`Faucet claimed (${windowText})`} sub={`${user.inventoryCount} items in inventory`}>
+          <Monetary value={totals.faucet} />
+        </StatCard>
+      </div>
+
+      <Panel title={`Games (${windowText})`}>
+        {games.length === 0 ? (
+          <p className="text-ink-muted text-sm">No games played in this window.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="text-ink-muted">
+                  <th className="font-medium py-2 pr-4">Game</th>
+                  <th className="font-medium py-2 pr-4">Plays</th>
+                  <th className="font-medium py-2 pr-4">Wagered</th>
+                  <th className="font-medium py-2 pr-4">Won</th>
+                  <th className="font-medium py-2">House net</th>
+                </tr>
+              </thead>
+              <tbody>
+                {games.map((g) => (
+                  <tr key={g.game} className="border-t border-line">
+                    <td className="py-2.5 pr-4 text-ink">{GAME_LABELS[g.game] || g.game}</td>
+                    <td className="py-2.5 pr-4 text-ink-soft">{g.plays.toLocaleString()}</td>
+                    <td className="py-2.5 pr-4 text-ink-soft"><Monetary value={g.wagered} /></td>
+                    <td className="py-2.5 pr-4 text-ink-soft"><Monetary value={g.won} /></td>
+                    <td className={`py-2.5 font-semibold ${netClass(g.net)}`}><Monetary value={g.net} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Panel title="Marketplace">
+          <div className="flex flex-col gap-2 text-sm">
+            <div className="flex justify-between"><span className="text-ink-soft">Spent buying</span><span className="text-ink font-semibold"><Monetary value={totals.marketSpent} /></span></div>
+            <div className="flex justify-between"><span className="text-ink-soft">Earned selling</span><span className="text-ink font-semibold"><Monetary value={totals.marketEarned} /></span></div>
+            <div className="flex justify-between"><span className="text-ink-soft">Items sold to house</span><span className="text-ink font-semibold"><Monetary value={totals.itemsSold} /></span></div>
+            <div className="flex justify-between"><span className="text-ink-soft">Last active</span><span className="text-ink-muted">{totals.lastActive ? new Date(totals.lastActive).toLocaleString() : "-"}</span></div>
+          </div>
+        </Panel>
+        <Panel title="Recent transactions">
+          {recent.length === 0 ? (
+            <p className="text-ink-muted text-sm">No transactions yet.</p>
+          ) : (
+            <div className="flex flex-col gap-1.5 text-sm max-h-64 overflow-y-auto pr-1">
+              {recent.map((t, i) => (
+                <div key={i} className="flex items-center justify-between border-t border-line pt-1.5 first:border-0 first:pt-0">
+                  <span className="text-ink-soft">{label(t.type)}</span>
+                  <span className="flex items-center gap-3">
+                    <span className={t.direction === "credit" ? "text-green-400" : "text-red-400"}>
+                      {t.direction === "credit" ? "+" : "-"}
+                      <Monetary value={t.amount} />
+                    </span>
+                    <span className="text-xs text-ink-muted w-28 text-right">{new Date(t.createdAt).toLocaleString()}</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+};
+
 const BackofficeView: React.FC<Props> = ({
-  userData, isAdmin, days, setDays, overview, games, cases, usersPage,
+  userData, isAdmin, days, setDays, overview, games, cases, series, wins, usersPage,
   page, setPage, search, changeSearch, loading, error,
+  playerId, player, playerLoading, openPlayer, closePlayer,
 }) => {
   if (!userData || !isAdmin) {
     return <div className="w-full flex justify-center py-16 text-ink-soft">Nothing to see here.</div>;
@@ -92,6 +260,11 @@ const BackofficeView: React.FC<Props> = ({
   }
 
   const windowText = days ? `last ${days} days` : "all time";
+  const chartText = days ? `last ${days} days` : "last 90 days";
+  const filled = fillDays(series || [], days);
+  const totalWagered = games.games.reduce((s, g) => s + g.wagered, 0);
+  const totalNet = games.games.reduce((s, g) => s + g.net, 0);
+  const totalFaucet = games.issuance.reduce((s, l) => s + l.issued, 0);
 
   return (
     <div className="w-full flex justify-center">
@@ -113,190 +286,296 @@ const BackofficeView: React.FC<Props> = ({
           </div>
         </div>
 
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-          <StatCard title="Users" sub={days ? `+${overview.users.new} new in the window` : undefined}>
-            {overview.users.total.toLocaleString()}
-          </StatCard>
-          <StatCard title={`Players active (${windowText})`}>{overview.users.active.toLocaleString()}</StatCard>
-          <StatCard title="KP in circulation" sub="minted minus reclaimed, all time">
-            <Monetary value={overview.economy.supply} />
-          </StatCard>
-          <StatCard title="House balance" sub="lifetime edge minus payouts">
-            <span className={netClass(overview.economy.houseBalance)}>
-              <Monetary value={overview.economy.houseBalance} />
-            </span>
-          </StatCard>
-        </div>
-
-        <Panel title={`Games (${windowText}, most profitable first)`}>
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm">
-              <thead>
-                <tr className="text-ink-muted">
-                  <th className="font-medium py-2 pr-4">Game</th>
-                  <th className="font-medium py-2 pr-4">Plays</th>
-                  <th className="font-medium py-2 pr-4">Wagered</th>
-                  <th className="font-medium py-2 pr-4">Paid out</th>
-                  <th className="font-medium py-2">House net</th>
-                </tr>
-              </thead>
-              <tbody>
-                {games.games.map((g) => (
-                  <tr key={g.game} className="border-t border-line">
-                    <td className="py-3 pr-4 text-ink">{GAME_LABELS[g.game] || g.game}</td>
-                    <td className="py-3 pr-4 text-ink-soft">{g.plays.toLocaleString()}</td>
-                    <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.wagered} /></td>
-                    <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.paidOut} /></td>
-                    <td className={`py-3 font-semibold ${netClass(g.net)}`}><Monetary value={g.net} /></td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <p className="text-xs text-ink-muted mt-2">
-            Cases and battles pay winners in items, so their buybacks appear under item buybacks below.
-          </p>
-        </Panel>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          <Panel title="Other house lines">
-            {games.houseLines.length === 0 ? (
-              <p className="text-ink-muted text-sm">Nothing in this window.</p>
-            ) : (
-              <div className="flex flex-col gap-2">
-                {games.houseLines.map((l) => (
-                  <div key={l.type} className="flex items-center justify-between text-sm">
-                    <span className="text-ink-soft">{label(l.type)} ({l.count.toLocaleString()})</span>
-                    <span className={`font-semibold ${netClass(l.net)}`}><Monetary value={l.net} /></span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </Panel>
-          <Panel title="KP printed (faucets)">
-            {games.issuance.length === 0 ? (
-              <p className="text-ink-muted text-sm">Nothing in this window.</p>
-            ) : (
-              <div className="flex flex-col gap-2">
-                {games.issuance.map((l) => (
-                  <div key={l.type} className="flex items-center justify-between text-sm">
-                    <span className="text-ink-soft">{label(l.type)} ({l.count.toLocaleString()})</span>
-                    <span className="text-ink font-semibold"><Monetary value={l.issued} /></span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </Panel>
-        </div>
-
-        <Panel title={`Cases (${windowText}, most opened first)`}>
-          {cases.length === 0 ? (
-            <p className="text-ink-muted text-sm py-4 text-center">No cases opened in this window.</p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-left text-sm">
-                <thead>
-                  <tr className="text-ink-muted">
-                    <th className="font-medium py-2 pr-4">Case</th>
-                    <th className="font-medium py-2 pr-4">Opens</th>
-                    <th className="font-medium py-2 pr-4">Spent on opens</th>
-                    <th className="font-medium py-2 pr-4">Price</th>
-                    <th className="font-medium py-2">Last opened</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {cases.map((c) => (
-                    <tr key={c.caseId} className="border-t border-line">
-                      <td className="py-3 pr-4">
-                        <div className="flex items-center gap-3">
-                          {c.image && <img src={c.image} alt={c.title} className="w-10 h-8 object-contain" />}
-                          <span className="text-ink">{c.title}</span>
-                        </div>
-                      </td>
-                      <td className="py-3 pr-4 text-ink font-semibold">{c.opens.toLocaleString()}</td>
-                      <td className="py-3 pr-4 text-ink-soft"><Monetary value={c.spent} /></td>
-                      <td className="py-3 pr-4 text-ink-soft">{c.price !== null ? <Monetary value={c.price} /> : "-"}</td>
-                      <td className="py-3 text-ink-muted">{new Date(c.lastOpened).toLocaleDateString()}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        {playerId ? (
+          <PlayerDetail player={player} loading={playerLoading} windowText={windowText} onBack={closePlayer} />
+        ) : (
+          <>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+              <StatCard title="Users" sub={days ? `+${overview.users.new} new in the window` : undefined}>
+                {overview.users.total.toLocaleString()}
+              </StatCard>
+              <StatCard title={`Players active (${windowText})`}>{overview.users.active.toLocaleString()}</StatCard>
+              <StatCard title="KP in circulation" sub="minted minus reclaimed, all time">
+                <Monetary value={overview.economy.supply} />
+              </StatCard>
+              <StatCard title="House balance" sub="lifetime edge minus payouts">
+                <span className={netClass(overview.economy.houseBalance)}>
+                  <Monetary value={overview.economy.houseBalance} />
+                </span>
+              </StatCard>
             </div>
-          )}
-        </Panel>
 
-        <Panel title="Users">
-          <input
-            value={search}
-            onChange={(e) => changeSearch(e.target.value)}
-            placeholder="Search by username"
-            className="w-full md:w-72 bg-surface-nav rounded-md px-3 py-2 text-ink text-sm focus:outline-none mb-3"
-          />
-          {!usersPage ? (
-            <Skeleton height={200} borderRadius={8} highlightColor="#161427" baseColor="#1c1a31" />
-          ) : (
-            <>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+              <StatCard title={`GGR (${windowText})`} sub="wagered minus game payouts">
+                <span className={netClass(totalNet)}>
+                  <Monetary value={totalNet} />
+                </span>
+              </StatCard>
+              <StatCard title={`Wagered (${windowText})`}>
+                <Monetary value={totalWagered} />
+              </StatCard>
+              <StatCard title={`Hold (${windowText})`} sub="GGR over wagered">
+                {totalWagered > 0 ? pct(totalNet / totalWagered) : "-"}
+              </StatCard>
+              <StatCard title={`Faucet (${windowText})`} sub="KP printed to players">
+                <Monetary value={totalFaucet} />
+              </StatCard>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+              <AdminChart
+                title={`House GGR by day (${chartText})`}
+                points={filled.map((p) => ({ day: p.day, values: [p.ggr] }))}
+                series={[{ name: "GGR", color: CHART_INDIGO }]}
+                mode="bars"
+                polarity
+                money
+              />
+              <AdminChart
+                title={`Wagered by day (${chartText})`}
+                points={filled.map((p) => ({ day: p.day, values: [p.wagered] }))}
+                series={[{ name: "Wagered", color: CHART_INDIGO }]}
+                mode="bars"
+                money
+              />
+              <AdminChart
+                title={`Faucet vs GGR (${chartText})`}
+                points={filled.map((p) => ({ day: p.day, values: [p.faucet, p.ggr] }))}
+                series={[
+                  { name: "Faucet", color: CHART_AMBER },
+                  { name: "GGR", color: CHART_INDIGO },
+                ]}
+                mode="lines"
+                money
+              />
+              <AdminChart
+                title={`Active players by day (${chartText})`}
+                points={filled.map((p) => ({ day: p.day, values: [p.players] }))}
+                series={[{ name: "Players", color: CHART_INDIGO }]}
+                mode="lines"
+              />
+            </div>
+
+            <Panel title={`Games (${windowText}, most profitable first)`}>
               <div className="overflow-x-auto">
                 <table className="w-full text-left text-sm">
                   <thead>
                     <tr className="text-ink-muted">
-                      <th className="font-medium py-2 pr-4">User</th>
-                      <th className="font-medium py-2 pr-4">Level</th>
-                      <th className="font-medium py-2 pr-4">Balance</th>
-                      <th className="font-medium py-2 pr-4">Wagered ({windowText})</th>
-                      <th className="font-medium py-2 pr-4">Joined</th>
-                      <th className="font-medium py-2 pr-4">Last active</th>
-                      <th className="font-medium py-2">Referred by</th>
+                      <th className="font-medium py-2 pr-4">Game</th>
+                      <th className="font-medium py-2 pr-4">Plays</th>
+                      <th className="font-medium py-2 pr-4">Players</th>
+                      <th className="font-medium py-2 pr-4">Wagered</th>
+                      <th className="font-medium py-2 pr-4">Paid out</th>
+                      <th className="font-medium py-2 pr-4">RTP actual</th>
+                      <th className="font-medium py-2 pr-4">RTP design</th>
+                      <th className="font-medium py-2 pr-4">Biggest win</th>
+                      <th className="font-medium py-2">House net</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {usersPage.users.map((u) => (
-                      <tr key={u.id} className="border-t border-line">
-                        <td className="py-3 pr-4">
-                          <div className="flex items-center gap-3">
-                            <Avatar image={u.profilePicture} loading={false} id={u.id} size="small" level={0} />
-                            <span className="text-ink">{u.username}</span>
-                            {u.isAdmin && (
-                              <span className="text-xs px-1.5 py-0.5 rounded bg-accent/20 text-accent-light">admin</span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="py-3 pr-4 text-ink-soft">{u.level}</td>
-                        <td className="py-3 pr-4 text-ink-soft"><Monetary value={Math.floor(u.walletBalance)} /></td>
-                        <td className="py-3 pr-4 text-ink-soft"><Monetary value={u.wagered} /></td>
-                        <td className="py-3 pr-4 text-ink-muted">{new Date(u.joined).toLocaleDateString()}</td>
-                        <td className="py-3 pr-4 text-ink-muted">
-                          {u.lastActive ? new Date(u.lastActive).toLocaleDateString() : "-"}
-                        </td>
-                        <td className="py-3 text-ink-muted">{u.referredBy || "-"}</td>
-                      </tr>
-                    ))}
+                    {games.games.map((g) => {
+                      const kpGame = KP_GAMES.has(g.game);
+                      const actual = kpGame && g.wagered > 0 ? g.paidOut / g.wagered : null;
+                      return (
+                        <tr key={g.game} className="border-t border-line">
+                          <td className="py-3 pr-4 text-ink">{GAME_LABELS[g.game] || g.game}</td>
+                          <td className="py-3 pr-4 text-ink-soft">{g.plays.toLocaleString()}</td>
+                          <td className="py-3 pr-4 text-ink-soft">{g.uniquePlayers.toLocaleString()}</td>
+                          <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.wagered} /></td>
+                          <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.paidOut} /></td>
+                          <td className={`py-3 pr-4 font-semibold ${actual !== null ? rtpClass(actual, g.theoRtp, g.wagered) : "text-ink-muted"}`}>
+                            {actual !== null ? pct(actual) : "items"}
+                          </td>
+                          <td className="py-3 pr-4 text-ink-muted">{kpGame && g.theoRtp ? pct(g.theoRtp) : "-"}</td>
+                          <td className="py-3 pr-4 text-ink-soft">{g.biggestWin > 0 ? <Monetary value={g.biggestWin} /> : "-"}</td>
+                          <td className={`py-3 font-semibold ${netClass(g.net)}`}><Monetary value={g.net} /></td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
-              <div className="flex items-center justify-between mt-3 text-sm text-ink-muted">
-                <span>{usersPage.total.toLocaleString()} users</span>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={() => setPage(page - 1)}
-                    disabled={page <= 1}
-                    className="px-3 py-1.5 rounded-md bg-surface-raised disabled:opacity-40 text-ink"
-                  >
-                    Prev
-                  </button>
-                  <span>{usersPage.page} / {usersPage.pages}</span>
-                  <button
-                    onClick={() => setPage(page + 1)}
-                    disabled={page >= usersPage.pages}
-                    className="px-3 py-1.5 rounded-md bg-surface-raised disabled:opacity-40 text-ink"
-                  >
-                    Next
-                  </button>
+              <p className="text-xs text-ink-muted mt-2">
+                Cases and battles pay winners in items, so their buybacks appear under item buybacks below.
+                RTP flags red past 3 points over design once a game has real volume.
+              </p>
+            </Panel>
+
+            <Panel title={`Biggest wins (${windowText})`}>
+              {!wins || wins.length === 0 ? (
+                <p className="text-ink-muted text-sm">No game wins in this window.</p>
+              ) : (
+                <div className="flex flex-col gap-1.5 text-sm">
+                  {wins.map((w, i) => (
+                    <div key={i} className="flex items-center gap-3 border-t border-line pt-1.5 first:border-0 first:pt-0">
+                      <span className="w-5 text-ink-muted">{i + 1}</span>
+                      <button
+                        onClick={() => openPlayer(w.userId)}
+                        className="bg-transparent p-0 text-ink hover:text-accent-light text-left"
+                      >
+                        {w.username}
+                      </button>
+                      <span className="text-ink-muted">{WIN_LABELS[w.type] || w.type}</span>
+                      <span className="ml-auto flex items-center gap-3">
+                        {w.multiple && (
+                          <span className="text-xs text-ink-muted">
+                            x{w.multiple >= 100 ? Math.round(w.multiple).toLocaleString() : w.multiple.toFixed(1)}
+                          </span>
+                        )}
+                        <span className="text-accent-gold font-semibold"><Monetary value={w.amount} /></span>
+                        <span className="text-xs text-ink-muted w-20 text-right">{new Date(w.at).toLocaleDateString()}</span>
+                      </span>
+                    </div>
+                  ))}
                 </div>
-              </div>
-            </>
-          )}
-        </Panel>
+              )}
+            </Panel>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <Panel title="Other house lines">
+                {games.houseLines.length === 0 ? (
+                  <p className="text-ink-muted text-sm">Nothing in this window.</p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {games.houseLines.map((l) => (
+                      <div key={l.type} className="flex items-center justify-between text-sm">
+                        <span className="text-ink-soft">{label(l.type)} ({l.count.toLocaleString()})</span>
+                        <span className={`font-semibold ${netClass(l.net)}`}><Monetary value={l.net} /></span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Panel>
+              <Panel title="KP printed (faucets)">
+                {games.issuance.length === 0 ? (
+                  <p className="text-ink-muted text-sm">Nothing in this window.</p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {games.issuance.map((l) => (
+                      <div key={l.type} className="flex items-center justify-between text-sm">
+                        <span className="text-ink-soft">{label(l.type)} ({l.count.toLocaleString()})</span>
+                        <span className="text-ink font-semibold"><Monetary value={l.issued} /></span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </Panel>
+            </div>
+
+            <Panel title={`Cases (${windowText}, most opened first)`}>
+              {cases.length === 0 ? (
+                <p className="text-ink-muted text-sm py-4 text-center">No cases opened in this window.</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-left text-sm">
+                    <thead>
+                      <tr className="text-ink-muted">
+                        <th className="font-medium py-2 pr-4">Case</th>
+                        <th className="font-medium py-2 pr-4">Opens</th>
+                        <th className="font-medium py-2 pr-4">Spent on opens</th>
+                        <th className="font-medium py-2 pr-4">Price</th>
+                        <th className="font-medium py-2">Last opened</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {cases.map((c) => (
+                        <tr key={c.caseId} className="border-t border-line">
+                          <td className="py-3 pr-4">
+                            <div className="flex items-center gap-3">
+                              {c.image && <img src={c.image} alt={c.title} className="w-10 h-8 object-contain" />}
+                              <span className="text-ink">{c.title}</span>
+                            </div>
+                          </td>
+                          <td className="py-3 pr-4 text-ink font-semibold">{c.opens.toLocaleString()}</td>
+                          <td className="py-3 pr-4 text-ink-soft"><Monetary value={c.spent} /></td>
+                          <td className="py-3 pr-4 text-ink-soft">{c.price !== null ? <Monetary value={c.price} /> : "-"}</td>
+                          <td className="py-3 text-ink-muted">{new Date(c.lastOpened).toLocaleDateString()}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </Panel>
+
+            <Panel title="Users">
+              <input
+                value={search}
+                onChange={(e) => changeSearch(e.target.value)}
+                placeholder="Search by username"
+                className="w-full md:w-72 bg-surface-nav rounded-md px-3 py-2 text-ink text-sm focus:outline-none mb-3"
+              />
+              {!usersPage ? (
+                <Skeleton height={200} borderRadius={8} highlightColor="#161427" baseColor="#1c1a31" />
+              ) : (
+                <>
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left text-sm">
+                      <thead>
+                        <tr className="text-ink-muted">
+                          <th className="font-medium py-2 pr-4">User</th>
+                          <th className="font-medium py-2 pr-4">Level</th>
+                          <th className="font-medium py-2 pr-4">Balance</th>
+                          <th className="font-medium py-2 pr-4">Wagered ({windowText})</th>
+                          <th className="font-medium py-2 pr-4">Joined</th>
+                          <th className="font-medium py-2 pr-4">Last active</th>
+                          <th className="font-medium py-2">Referred by</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {usersPage.users.map((u) => (
+                          <tr
+                            key={u.id}
+                            onClick={() => openPlayer(u.id)}
+                            className="border-t border-line cursor-pointer hover:bg-surface-nav transition-colors"
+                          >
+                            <td className="py-3 pr-4">
+                              <div className="flex items-center gap-3">
+                                <Avatar image={u.profilePicture} loading={false} id={u.id} size="small" level={0} />
+                                <span className="text-ink">{u.username}</span>
+                                {u.isAdmin && (
+                                  <span className="text-xs px-1.5 py-0.5 rounded bg-accent/20 text-accent-light">admin</span>
+                                )}
+                              </div>
+                            </td>
+                            <td className="py-3 pr-4 text-ink-soft">{u.level}</td>
+                            <td className="py-3 pr-4 text-ink-soft"><Monetary value={Math.floor(u.walletBalance)} /></td>
+                            <td className="py-3 pr-4 text-ink-soft"><Monetary value={u.wagered} /></td>
+                            <td className="py-3 pr-4 text-ink-muted">{new Date(u.joined).toLocaleDateString()}</td>
+                            <td className="py-3 pr-4 text-ink-muted">
+                              {u.lastActive ? new Date(u.lastActive).toLocaleDateString() : "-"}
+                            </td>
+                            <td className="py-3 text-ink-muted">{u.referredBy || "-"}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className="flex items-center justify-between mt-3 text-sm text-ink-muted">
+                    <span>{usersPage.total.toLocaleString()} users</span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => setPage(page - 1)}
+                        disabled={page <= 1}
+                        className="px-3 py-1.5 rounded-md bg-surface-raised disabled:opacity-40 text-ink"
+                      >
+                        Prev
+                      </button>
+                      <span>{usersPage.page} / {usersPage.pages}</span>
+                      <button
+                        onClick={() => setPage(page + 1)}
+                        disabled={page >= usersPage.pages}
+                        className="px-3 py-1.5 rounded-md bg-surface-raised disabled:opacity-40 text-ink"
+                      >
+                        Next
+                      </button>
+                    </div>
+                  </div>
+                </>
+              )}
+            </Panel>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Backoffice/adminSeries.test.ts
+++ b/src/pages/Backoffice/adminSeries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { compactKp, dayString, fillDays, shortDay } from "./adminSeries";
+
+const point = (day: string, ggr = 0) => ({ day, wagered: 0, paidOut: 0, ggr, faucet: 0, players: 0 });
+const daysAgo = (n: number) => dayString(new Date(Date.now() - n * 24 * 60 * 60 * 1000));
+
+describe("fillDays", () => {
+  test("fills the gaps between active days with zero rows", () => {
+    const filled = fillDays([point(daysAgo(3), 50), point(daysAgo(0), 20)], 7);
+    expect(filled).toHaveLength(4);
+    expect(filled[0].ggr).toBe(50);
+    expect(filled[1].ggr).toBe(0);
+    expect(filled[2].ggr).toBe(0);
+    expect(filled[3].ggr).toBe(20);
+  });
+
+  test("never reaches past the window even when older rows exist", () => {
+    const filled = fillDays([point(daysAgo(30), 99), point(daysAgo(1), 5)], 7);
+    expect(filled.length).toBeLessThanOrEqual(7);
+    expect(filled.some((p) => p.ggr === 99)).toBe(false);
+  });
+
+  test("an empty series still yields a full window of zero days", () => {
+    const filled = fillDays([], 7);
+    expect(filled).toHaveLength(7);
+    expect(filled.every((p) => p.ggr === 0)).toBe(true);
+    expect(filled[6].day).toBe(daysAgo(0));
+  });
+});
+
+describe("formatting", () => {
+  test("compactKp abbreviates thousands and millions and keeps signs", () => {
+    expect(compactKp(950)).toBe("950");
+    expect(compactKp(1500)).toBe("1.5k");
+    expect(compactKp(25000)).toBe("25k");
+    expect(compactKp(4116480)).toBe("4.1M");
+    expect(compactKp(-1500)).toBe("-1.5k");
+  });
+
+  test("shortDay renders a day-month label", () => {
+    expect(shortDay("2026-07-19")).toBe("19/7");
+  });
+});

--- a/src/pages/Backoffice/adminSeries.ts
+++ b/src/pages/Backoffice/adminSeries.ts
@@ -1,0 +1,36 @@
+import { TimeseriesPoint } from "../../services/admin/AdminServices";
+
+// series colors validated against the dark card surface (lightness band, cvd
+// separation and contrast); text never wears these, only marks do
+export const CHART_INDIGO = "#606BC7";
+export const CHART_AMBER = "#C08312";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const dayString = (date: Date) => date.toISOString().slice(0, 10);
+
+// the api only returns days that had activity; charts need a continuous axis
+export function fillDays(points: TimeseriesPoint[], windowDays: number | null): TimeseriesPoint[] {
+  const span = windowDays || 90;
+  const byDay = new Map(points.map((p) => [p.day, p]));
+  const first = points.length ? points[0].day : dayString(new Date(Date.now() - (span - 1) * DAY_MS));
+  const start = new Date(Math.max(new Date(`${first}T00:00:00Z`).getTime(), Date.now() - (span - 1) * DAY_MS));
+  const out: TimeseriesPoint[] = [];
+  for (let t = start.getTime(); t <= Date.now(); t += DAY_MS) {
+    const day = dayString(new Date(t));
+    out.push(byDay.get(day) || { day, wagered: 0, paidOut: 0, ggr: 0, faucet: 0, players: 0 });
+  }
+  return out;
+}
+
+export const shortDay = (day: string) => {
+  const d = new Date(`${day}T00:00:00Z`);
+  return `${d.getUTCDate()}/${d.getUTCMonth() + 1}`;
+};
+
+export const compactKp = (value: number) => {
+  const abs = Math.abs(value);
+  const sign = value < 0 ? "-" : "";
+  if (abs >= 1000000) return `${sign}${(abs / 1000000).toFixed(1)}M`;
+  if (abs >= 1000) return `${sign}${(abs / 1000).toFixed(abs >= 10000 ? 0 : 1)}k`;
+  return `${sign}${Math.round(abs)}`;
+};

--- a/src/services/admin/AdminServices.ts
+++ b/src/services/admin/AdminServices.ts
@@ -11,6 +11,59 @@ export interface GameLine {
   wagered: number;
   paidOut: number;
   net: number;
+  uniquePlayers: number;
+  biggestWin: number;
+  theoRtp: number | null;
+}
+
+export interface TimeseriesPoint {
+  day: string;
+  wagered: number;
+  paidOut: number;
+  ggr: number;
+  faucet: number;
+  players: number;
+}
+
+export interface AdminBigWin {
+  userId: string;
+  username: string;
+  profilePicture: string;
+  type: string;
+  amount: number;
+  bet: number | null;
+  multiple: number | null;
+  at: string;
+}
+
+export interface AdminPlayerDetail {
+  user: {
+    id: string;
+    username: string;
+    profilePicture: string;
+    level: number;
+    xp: number;
+    walletBalance: number;
+    isAdmin: boolean;
+    weeklyWinnings: number;
+    joined: string;
+    inventoryCount: number;
+    referredBy: string | null;
+    referrals: number;
+  };
+  totals: {
+    wagered: number;
+    won: number;
+    net: number;
+    faucet: number;
+    marketSpent: number;
+    marketEarned: number;
+    itemsSold: number;
+    biggestWin: { type: string | null; amount: number };
+    lastActive: string | null;
+  };
+  games: { game: string; plays: number; wagered: number; won: number; net: number }[];
+  recent: { type: string; direction: "credit" | "debit"; amount: number; balanceAfter: number; createdAt: string }[];
 }
 
 export interface AdminGameStats {
@@ -66,3 +119,12 @@ export const getAdminUserStats = async (
   search: string
 ): Promise<AdminUsersPage> =>
   (await api.get("/admin/stats/users", { params: { ...withDays(days), page, search } })).data;
+
+export const getAdminTimeseries = async (days: number | null): Promise<TimeseriesPoint[]> =>
+  (await api.get("/admin/stats/timeseries", { params: withDays(days) })).data;
+
+export const getAdminBigWins = async (days: number | null): Promise<AdminBigWin[]> =>
+  (await api.get("/admin/stats/wins", { params: withDays(days) })).data;
+
+export const getAdminPlayerDetail = async (id: string, days: number | null): Promise<AdminPlayerDetail> =>
+  (await api.get(`/admin/stats/users/${id}`, { params: withDays(days) })).data;


### PR DESCRIPTION
The backoffice showed flat totals: no trends, no per-game health, no way to inspect a player. Todays slots scare took a manual ledger query to explain.

The dashboard now follows standard casino back office reporting. New tiles for GGR, wagered, hold and faucet over the selected window; four daily charts (GGR with polarity, wagered, faucet vs GGR, active players) drawn with a hand-rolled svg chart in the existing PriceChart style. The games table gains unique players, biggest win, and actual RTP against the designed edge with red flagging once a game has volume, and plinko now appears at all (it was missing from the stats). A biggest-wins panel names who hit what. Clicking any user or win opens a player view: house net on that player, personal RTP, faucet claimed, per-game breakdown, marketplace totals and recent ledger, all via a new admin-gated /admin/stats/users/:id endpoint plus /stats/timeseries and /stats/wins.

Tests: new adminStatsV2 suite (access control, daily bucketing, win ordering, player composition, 404s) and series helper unit tests; backend 350 passing, frontend unit and e2e green; rendered and eyeballed against fixture data.