### PR TITLE
feat: reconnecting toast when the tunnel re-rolls

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -112,6 +112,17 @@ mongoose
 app.use(express.json());
 app.use(cors(corsOptions));
 
+// internal ops hook: the tunnel watchdog announces an imminent reconnect so clients can
+// toast it before cloudflared re-rolls. token-gated, bypasses the api-key gate, never public.
+app.post("/internal/notice", (req, res) => {
+  if (!process.env.MAINT_TOKEN || req.headers["x-maint-token"] !== process.env.MAINT_TOKEN) {
+    return res.status(403).json({ error: "forbidden" });
+  }
+  const { message, seconds } = req.body || {};
+  io.emit("serverNotice", { message, seconds });
+  res.json({ ok: true });
+});
+
 // block requests from outside
 app.use(checkApiKey);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,34 @@ function App() {
     };
   }, [socket]);
 
+  // the tunnel watchdog re-rolls cloudflared on a far-region stall, which briefly drops the
+  // socket; show a sticky toast (announced or on an unexpected drop) and clear it on reconnect
+  useEffect(() => {
+    const RECONNECT_ID = "server-reconnect";
+    const showReconnecting = (msg?: string) => {
+      if (toast.isActive(RECONNECT_ID)) return;
+      toast.loading(msg || "Reconnecting to the server...", { toastId: RECONNECT_ID });
+    };
+    const onNotice = (p: { message?: string; seconds?: number }) => showReconnecting(p?.message);
+    // ignore intentional client disconnects (the login/logout re-handshake below)
+    const onDisconnect = (reason: string) => {
+      if (reason !== "io client disconnect") showReconnecting();
+    };
+    const onConnect = () => {
+      if (toast.isActive(RECONNECT_ID)) {
+        toast.update(RECONNECT_ID, { render: "Reconnected", type: "success", isLoading: false, autoClose: 1500 });
+      }
+    };
+    socket.on("serverNotice", onNotice);
+    socket.on("disconnect", onDisconnect);
+    socket.on("connect", onConnect);
+    return () => {
+      socket.off("serverNotice", onNotice);
+      socket.off("disconnect", onDisconnect);
+      socket.off("connect", onConnect);
+    };
+  }, [socket]);
+
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
     if (token !== null) {


### PR DESCRIPTION
**Problem:** when the auto-heal watchdog re-rolls the cloudflared tunnel (or the socket drops for any reason), clients lose their realtime connection for a few seconds with no on-screen signal. Live-game players just see things freeze.

**Change:** the backend gains a token-gated internal hook (`POST /internal/notice`, bypasses the api-key gate, requires `MAINT_TOKEN`) that emits a `serverNotice` over Socket.IO. The frontend shows a sticky "Reconnecting..." toast either on that announce or on an unexpected socket disconnect, and updates it to "Reconnected" once the socket is back. Intentional login/logout re-handshakes are ignored.

**Tests:** `tsc --noEmit` clean, eslint clean on the change (only pre-existing warnings remain), backend `node --check` passes. Manual: hitting the internal hook shows the toast for all connected clients; a real tunnel restart shows it then clears on reconnect.

Note: `MAINT_TOKEN` must be set in the backend env for the hook to work; if unset the hook returns 403 and the watchdog simply restarts without the announce.