### PR TITLE
Allow overlapping plinko drops with an in-flight cap

### DIFF
--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -35,4 +35,17 @@ const registerLimiter = rateLimit({
   message: { message: "Too many accounts created from this address. Try again later." },
 });
 
-module.exports = { loginLimiter, registerLimiter };
+// hard cap on plinko drops now that the client fires them concurrently; keyed per
+// user (runs after auth), generous enough that a fast human never hits it
+const plinkoDropLimiter = rateLimit({
+  windowMs: 10 * 1000,
+  max: 40,
+  keyGenerator: (req) => String(req.user._id),
+  skip: skipInTests,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  message: { message: "Too many drops, slow down a little." },
+});
+
+module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter };

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
+const { plinkoDropLimiter } = require("../middleware/rateLimit");
 
 const User = require("../models/User");
 const Case = require("../models/Case");
@@ -199,7 +200,7 @@ module.exports = (io) => {
   });
 
   // drop a plinko ball
-  router.post('/plinko', isAuthenticated, async (req, res) => {
+  router.post('/plinko', isAuthenticated, plinkoDropLimiter, async (req, res) => {
     const user = req.user;
 
     try {

--- a/src/index.css
+++ b/src/index.css
@@ -145,6 +145,26 @@
   }
 }
 
+/* plinko ball waiting at the drop mouth while its request is in flight */
+.ball-queued {
+  animation: ball-queued 0.8s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+@keyframes ball-queued {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+
+  50% {
+    transform: scale(1.15);
+    opacity: 0.9;
+  }
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -8,6 +8,8 @@ import { PlinkoBall, PlinkoDropResult } from "./Plinko.types";
 
 const DEFAULT_BET = 10;
 const HISTORY_SIZE = 8;
+// hard cap on concurrent balls (pending requests + falling); the server allows more
+const MAX_IN_FLIGHT = 12;
 // paced so an auto run reads as a stream of balls instead of one burst
 const AUTO_DROP_INTERVAL_MS = 400;
 export const AUTO_COUNTS = [10, 25, 50, 100];
@@ -22,13 +24,14 @@ export const usePlinkoServices = () => {
   const [autoCount, setAutoCount] = useState<number>(AUTO_COUNTS[0]);
   const [autoRunning, setAutoRunning] = useState(false);
   const [autoLeft, setAutoLeft] = useState(0);
-  const [dropping, setDropping] = useState(false);
+  const [pendingDrops, setPendingDrops] = useState(0);
   const [balls, setBalls] = useState<PlinkoBall[]>([]);
   const [history, setHistory] = useState<PlinkoBall[]>([]);
   const [lastHit, setLastHit] = useState<{ bin: number; seq: number } | null>(null);
 
   const ballSeq = useRef(0);
   const hitSeq = useRef(0);
+  const pendingStake = useRef(0);
   const settled = useRef<Set<string>>(new Set());
   const autoLeftRef = useRef(0);
   const autoTimer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -41,18 +44,24 @@ export const usePlinkoServices = () => {
       toogleUserFlow(true);
       return false;
     }
-    if (userData.walletBalance < betValue) {
+    // the wallet only refreshes when a ball lands, so count the stakes still in the air
+    if (userData.walletBalance - pendingStake.current < betValue) {
       toast.error("Insufficient funds", { theme: "dark" });
       return false;
     }
+    pendingStake.current += betValue;
+    setPendingDrops((n) => n + 1);
     try {
       const result: PlinkoDropResult = await dropPlinko(betValue, risk);
       ballSeq.current += 1;
       setBalls((prev) => [...prev, { ...result, key: `b${ballSeq.current}` }]);
       return true;
     } catch (error: any) {
+      pendingStake.current -= betValue;
       toast.error(error?.response?.data?.message || "Could not drop the ball", { theme: "dark" });
       return false;
+    } finally {
+      setPendingDrops((n) => n - 1);
     }
   };
 
@@ -94,24 +103,25 @@ export const usePlinkoServices = () => {
 
   useEffect(() => () => stopAuto(), [stopAuto]);
 
-  const drop = async () => {
-    if (dropping) return;
-    setDropping(true);
-    await fireDrop();
-    setDropping(false);
+  // drops fire without waiting for the previous one, capped by balls already in play
+  const canDrop = balls.length + pendingDrops < MAX_IN_FLIGHT;
+  const drop = () => {
+    if (!canDrop) return;
+    fireDrop();
   };
 
   // guarded by key so a duplicate animation-complete cannot double-record a ball
   const settleBall = useCallback((ball: PlinkoBall) => {
     if (settled.current.has(ball.key)) return;
     settled.current.add(ball.key);
+    pendingStake.current -= ball.betAmount; // the landing balance update covers it now
     hitSeq.current += 1;
     setBalls((prev) => prev.filter((b) => b.key !== ball.key));
     setLastHit({ bin: ball.bin, seq: hitSeq.current });
     setHistory((h) => [ball, ...h].slice(0, HISTORY_SIZE));
   }, []);
 
-  const canChangeRisk = balls.length === 0 && !autoRunning;
+  const canChangeRisk = balls.length === 0 && pendingDrops === 0 && !autoRunning;
   const changeRisk = (next: PlinkoRisk) => {
     if (!canChangeRisk) return;
     setRisk(next);
@@ -144,7 +154,8 @@ export const usePlinkoServices = () => {
     startAuto,
     stopAuto,
     drop,
-    dropping,
+    canDrop,
+    pendingDrops,
     balls,
     history,
     lastHit,

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -12,6 +12,8 @@ import {
   BOARD_H,
   BOARD_W,
   DROP_DURATION_S,
+  DROP_X,
+  DROP_Y,
   MAX_WIN,
   PAYOUT_MULTIPLIERS,
   PEG_RADIUS,
@@ -96,7 +98,8 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
   startAuto,
   stopAuto,
   drop,
-  dropping,
+  canDrop,
+  pendingDrops,
   balls,
   history,
   lastHit,
@@ -202,8 +205,7 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
               )
             }
             onClick={drop}
-            loading={dropping}
-            disabled={dropping}
+            disabled={!canDrop}
           />
         ) : autoRunning ? (
           <MainButton text={`Stop (${autoLeft} left)`} onClick={stopAuto} type="danger" />
@@ -289,6 +291,19 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
               <g key={`${k}-static`}>{chip}</g>
             );
           })}
+
+          {/* one ghost per drop still waiting on the server, so a click is visibly queued */}
+          {Array.from({ length: pendingDrops }, (_, i) => (
+            <circle
+              key={`q-${i}`}
+              className="ball-queued"
+              cx={DROP_X + (i - (pendingDrops - 1) / 2) * BALL_RADIUS * 2.5}
+              cy={DROP_Y}
+              r={BALL_RADIUS * 0.8}
+              fill="#FFCC00"
+              style={{ animationDelay: `${i * 0.15}s` }}
+            />
+          ))}
 
           {balls.map((ball) => (
             <FallingBall key={ball.key} ball={ball} onSettle={settleBall} />

--- a/src/pages/Plinko/plinkoBoard.ts
+++ b/src/pages/Plinko/plinkoBoard.ts
@@ -24,7 +24,8 @@ const CENTER_X = BOARD_W / 2;
 const PEG_SPACING = 52;
 const ROW_GAP = 46;
 const TOP_Y = 110;
-const DROP_Y = 30;
+export const DROP_X = CENTER_X;
+export const DROP_Y = 30;
 const CONTACT_LIFT = 15; // ball center sits a radius above the peg it strikes
 const HOP_LIFT = 16;
 


### PR DESCRIPTION
## Problem

Manual plinko waited for each drop request to finish before the button re-enabled, so the game felt slow next to auto mode, which already fires drops every 400ms without waiting. There was also no server-side cap on drop frequency, and nothing showed the player that a click had registered while the request was still loading.

## Change

- Manual drops fire immediately, capped at 12 concurrent balls (pending requests plus balls still falling); the button only disables at the cap.
- Each request in flight renders a pulsing ghost ball at the drop mouth, so a click is visibly queued before the server answers.
- The insufficient-funds pre-check subtracts stakes still in the air, since the wallet only refreshes when a ball lands.
- Risk switching now also waits for pending requests, not just falling balls.
- New per-user rate limit on POST /games/plinko (40 drops per 10s) as the hard cap; answers 429 with a message the existing toast surfaces.

## Tests

- Backend: full Jest suite passes (416 tests).
- Frontend: build, unit (48) and e2e all pass.