### PR TITLE
Most opened skeleton and crash betting countdown bar

### DIFF
--- a/src/pages/Crash/GameContainer.tsx
+++ b/src/pages/Crash/GameContainer.tsx
@@ -14,10 +14,13 @@ interface GameHistory {
     history: any;
 }
 
+// matches the countdown reset in Crash.tsx, itself just under the server's 12s betting window
+const BETTING_COUNTDOWN_S = 10.7;
+
 const GameContainer: React.FC<GameHistory> = ({ crashPoint, multiplier, gameStarted, gameEnded, countDown, up, idle, falling, history }) => {
     return (
         <div className="flex flex-col">
-            <div className="flex lg:w-[800px] border-b border-gray-700  p-4">
+            <div className="flex flex-col gap-2 lg:w-[800px] border-b border-gray-700  p-4">
                 <div className="flex rounded items-center flex-col justify-center w-full h-[340px] relative overflow-hidden bg-surface-nav">
                     <CrashGraph
                         gameStarted={gameStarted}
@@ -53,6 +56,16 @@ const GameContainer: React.FC<GameHistory> = ({ crashPoint, multiplier, gameStar
                                 </span>
                             )}
                     </div>
+                </div>
+                {/* drains through the betting window; the empty track stays so the layout never shifts */}
+                <div className="w-full h-1.5 bg-surface-raised overflow-hidden">
+                    <div
+                        className="h-full bg-accent-gold"
+                        style={{
+                            width: gameEnded ? `${Math.min((countDown / BETTING_COUNTDOWN_S) * 100, 100)}%` : "0%",
+                            transition: "width 100ms linear",
+                        }}
+                    />
                 </div>
             </div>
             <div className="flex w-screen lg:w-[800px] p-4 flex-col">

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -15,6 +15,7 @@ const Home = () => {
   const [cases, setCases] = useState<any>();
   const [loading, setLoading] = useState<boolean>(true);
   const [mostOpened, setMostOpened] = useState<MostOpenedCase[]>([]);
+  const [mostOpenedLoading, setMostOpenedLoading] = useState<boolean>(true);
 
   const getNewCases = async () => {
     setLoading(true);
@@ -33,7 +34,8 @@ const Home = () => {
     // the section hides itself if nothing has been opened yet, so a failure is quiet
     getMostOpenedCases(5)
       .then(setMostOpened)
-      .catch(() => setMostOpened([]));
+      .catch(() => setMostOpened([]))
+      .finally(() => setMostOpenedLoading(false));
   }, []);
 
   const BannerContent: BannerProps[] = [
@@ -92,13 +94,18 @@ const Home = () => {
             <Banner key={index} left={_item.left} right={_item.right} />
           ))}
         </Carousel>
-        {mostOpened.length > 0 && (
-          <CaseListing
-            name="Most Opened Cases"
-            description="What everyone is opening right now."
-            cases={mostOpened}
-            eager
-          />
+        {/* the skeleton reserves the row while loading so the sections below do not jump */}
+        {mostOpenedLoading ? (
+          <CaseListing name="Most Opened Cases" loading cases={[]} />
+        ) : (
+          mostOpened.length > 0 && (
+            <CaseListing
+              name="Most Opened Cases"
+              description="What everyone is opening right now."
+              cases={mostOpened}
+              eager
+            />
+          )
         )}
 
         <GameListing name="Our Games" />


### PR DESCRIPTION
Two small UX fixes.

- The most opened section rendered nothing while its request was in flight, then popped in above the games listing and pushed the whole page down. It now shows the same skeleton row the category sections use, so the space is reserved from first paint; when the response is empty the section still hides itself.
- After a crash there was no way to feel how long until the next round beyond the small text counter. A gold bar under the graph now drains through the betting window; the empty track stays in place while a round runs so the layout never shifts.

Tests: unit, e2e, lint and build suites green (the most-opened e2e pair covers both the rendered and absent states through the new loading phase).
