### PR TITLE
Crash bet panel with auto cashout and next-round queueing

### DIFF
--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -144,6 +144,48 @@ test("crash writes a round, ties the stake to it, and settles it at the bust", a
   expect(done.bets[0].payout).toBe(0); // an instant bust pays nobody
 });
 
+test("an auto cashout pays at exactly its target", async () => {
+  // a seed with a high crash point, and a low target: the curve grows in real time
+  // (1.05x lands ~0.8s in), so the test never has to wait out a whole round
+  mockCrashSeed = RUNNING_SEED;
+  const user = await makeUser(5000);
+  const io = makeIo();
+
+  start(crashGame, io, FAST_CRASH);
+  const socket = makeSocket(String(user._id));
+  io.connection(socket);
+  const opened = await betOnRound("crash", "crash:bet", socket, [
+    { amount: 100, autoCashoutAt: 1.05 },
+  ]);
+
+  const paid = await until(async () => {
+    const r = await Round.findById(opened._id);
+    return r && r.bets[0] && r.bets[0].payout > 0 ? r : null;
+  }, "the auto cashout to land on the round");
+  // paid at the target, not at whatever multiplier the tick happened to see
+  expect(paid.bets[0].multiplier).toBe(1.05);
+  expect(paid.bets[0].payout).toBeCloseTo(105, 6);
+  const tx = await Transaction.findOne({ userId: user._id, type: TX.CRASH_CASHOUT });
+  expect(tx.amount).toBeCloseTo(105, 6);
+  expect(tx.meta.multiplier).toBe(1.05);
+});
+
+test("a bad auto-cashout target refuses the bet before any money moves", async () => {
+  mockCrashSeed = RUNNING_SEED;
+  const user = await makeUser(5000);
+  const io = makeIo();
+
+  start(crashGame, io, FAST_CRASH);
+  const socket = makeSocket(String(user._id));
+  io.connection(socket);
+
+  await until(roundIn("crash", "betting"), "crash betting to open");
+  let reply;
+  await socket.handlers["crash:bet"]({ amount: 100, autoCashoutAt: 0.5 }, (r) => { reply = r; });
+  expect(reply.error).toBeTruthy();
+  expect(await Transaction.findOne({ userId: user._id, type: TX.CRASH_BET })).toBeNull();
+});
+
 test("a crash cashout is recorded on the round", async () => {
   // a seed with a high crash point, so the round is comfortably still running at cashout
   mockCrashSeed = RUNNING_SEED;

--- a/backend/__tests__/unit/crashMath.test.js
+++ b/backend/__tests__/unit/crashMath.test.js
@@ -1,4 +1,4 @@
-const { multiplierAt, crashPointFromRandom, crashPointFromSeed, INSTANT_CRASH_CHANCE } = require("../../utils/crashMath");
+const { multiplierAt, crashPointFromRandom, crashPointFromSeed, normalizeAutoCashout, INSTANT_CRASH_CHANCE } = require("../../utils/crashMath");
 const { sha256 } = require("../../utils/hashChain");
 
 // the OLD, broken derivation: read the outcome straight off sha256(seed). since sha256(seed)
@@ -57,5 +57,20 @@ describe("crash math", () => {
       expect(m).toBeGreaterThanOrEqual(prev);
       prev = m;
     }
+  });
+
+  test("auto-cashout targets are rounded to cents and bounded", () => {
+    expect(normalizeAutoCashout(2)).toBe(2);
+    expect(normalizeAutoCashout(1.238)).toBe(1.24);
+    expect(normalizeAutoCashout(1.01)).toBe(1.01);
+    expect(normalizeAutoCashout(10000)).toBe(10000);
+    // below the floor, above the cap, or not a finite number -> refused
+    expect(normalizeAutoCashout(1.004)).toBe(null); // rounds under the 1.01 floor
+    expect(normalizeAutoCashout(0.5)).toBe(null);
+    expect(normalizeAutoCashout(10001)).toBe(null);
+    expect(normalizeAutoCashout(NaN)).toBe(null);
+    expect(normalizeAutoCashout(Infinity)).toBe(null);
+    expect(normalizeAutoCashout("2")).toBe(null);
+    expect(normalizeAutoCashout(null)).toBe(null);
   });
 });

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -1,12 +1,14 @@
 const Round = require("../models/Round");
 const { chargeUser, creditUser, TX } = require("../utils/economy");
-const { multiplierAt, crashPointFromSeed } = require("../utils/crashMath");
+const { multiplierAt, crashPointFromSeed, normalizeAutoCashout } = require("../utils/crashMath");
 const { consumeNextSeed } = require("../utils/gameChain");
 const { sha256 } = require("../utils/hashChain");
 
 const freshState = () => ({
   gameBets: {},
   gamePlayers: {},
+  // per-user auto-cashout targets; server-enforced so a lagging tab still cashes out
+  autoCashouts: {},
   crashPoint: 1.0,
   gameStartTime: null,
   serverSeed: null, // the round's seed, kept secret until the round ends
@@ -64,7 +66,15 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
         if (!userId) return reply({ error: "You must be logged in to bet" });
         if (!bettingOpen || !round) return reply({ error: "Betting is closed for this round" });
 
-        if (!Number.isInteger(bet) || bet < 1 || bet > 1000000) {
+        // the bet panel sends { amount, autoCashoutAt }; a bare number still works
+        const payload = typeof bet === "object" && bet !== null ? bet : { amount: bet };
+        const amount = payload.amount;
+        const autoCashoutAt =
+          payload.autoCashoutAt == null ? null : normalizeAutoCashout(payload.autoCashoutAt);
+        if (payload.autoCashoutAt != null && autoCashoutAt === null) {
+          return reply({ error: "Invalid auto cashout target" });
+        }
+        if (!Number.isInteger(amount) || amount < 1 || amount > 1000000) {
           return reply({ error: "Invalid bet amount" });
         }
 
@@ -79,10 +89,10 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
         pendingBets.add(userId);
         let updatedUser;
         try {
-          updatedUser = await chargeUser(userId, bet, {
+          updatedUser = await chargeUser(userId, amount, {
             awardXp: false,
             type: TX.CRASH_BET,
-            meta: { bet, roundId },
+            meta: { bet: amount, roundId },
           });
         } finally {
           pendingBets.delete(userId);
@@ -97,12 +107,13 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
           { _id: round._id },
           {
             $push: {
-              bets: { userId, username: updatedUser.username, amount: bet, payout: 0 },
+              bets: { userId, username: updatedUser.username, amount, payout: 0 },
             },
           }
         );
 
-        gameState.gameBets[userId] = bet;
+        gameState.gameBets[userId] = amount;
+        if (autoCashoutAt) gameState.autoCashouts[userId] = autoCashoutAt;
         gameState.gamePlayers[userId] = {
           _id: updatedUser._id,
           username: updatedUser.username,
@@ -143,45 +154,8 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
         const multiplier = calculateMultiplier();
 
         if (multiplier < gameState.crashPoint) {
-          const betAmount = gameState.gameBets[userId];
-          const payout = betAmount * multiplier;
-
-          // claim the cashout before paying: a second emit in the same tick must
-          // not be paid again while this credit is still in flight
-          const roundId = round ? String(round._id) : null;
-          pendingCashouts.add(userId);
-          let updatedUser;
-          try {
-            updatedUser = await creditUser(userId, payout, payout - betAmount, {
-              type: TX.CRASH_CASHOUT,
-              meta: { betAmount, multiplier, roundId },
-            });
-          } finally {
-            pendingCashouts.delete(userId);
-          }
-          if (!updatedUser) {
-            return done(); // account is gone; leave the bet uncashed
-          }
-
-          if (round) {
-            await Round.updateOne(
-              { _id: round._id, "bets.userId": userId },
-              { $set: { "bets.$.payout": payout, "bets.$.multiplier": multiplier, "bets.$.settledAt": new Date() } }
-            );
-          }
-
-          // keep the player visible with their locked-in payout
-          player.payout = multiplier;
-
-          io.to(userId.toString()).emit("userDataUpdated", {
-            walletBalance: updatedUser.walletBalance,
-            xp: updatedUser.xp,
-            level: updatedUser.level,
-          });
-
-          io.emit("crash:gameState", publicState(gameState));
-
-          socket.emit("crash:cashoutSuccess", { userId, payout, multiplier });
+          delete gameState.autoCashouts[userId]; // the manual click beat the target
+          await settleCashout(userId, multiplier, (data) => socket.emit("crash:cashoutSuccess", data));
         }
 
         return done();
@@ -191,6 +165,57 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
       }
     });
   });
+
+  // pay one player's bet at `multiplier` and lock the payout in; shared by the manual
+  // cashout and the auto-cashout sweep. returns true only when the credit landed.
+  const settleCashout = async (userId, multiplier, notify) => {
+    const player = gameState.gamePlayers[userId];
+    if (!player || player.payout != null || pendingCashouts.has(userId)) return false;
+
+    const betAmount = gameState.gameBets[userId];
+    const payout = betAmount * multiplier;
+    // capture the round now: a settle in flight while the round turns over must not
+    // write into the next round's record
+    const activeRound = round;
+    const roundId = activeRound ? String(activeRound._id) : null;
+
+    // claim the cashout before paying: a second attempt in the same tick must
+    // not be paid again while this credit is still in flight
+    pendingCashouts.add(userId);
+    let updatedUser;
+    try {
+      updatedUser = await creditUser(userId, payout, payout - betAmount, {
+        type: TX.CRASH_CASHOUT,
+        meta: { betAmount, multiplier, roundId },
+      });
+    } finally {
+      pendingCashouts.delete(userId);
+    }
+    if (!updatedUser) {
+      return false; // account is gone; leave the bet uncashed
+    }
+
+    if (activeRound) {
+      await Round.updateOne(
+        { _id: activeRound._id, "bets.userId": userId },
+        { $set: { "bets.$.payout": payout, "bets.$.multiplier": multiplier, "bets.$.settledAt": new Date() } }
+      );
+    }
+
+    // keep the player visible with their locked-in payout
+    player.payout = multiplier;
+
+    io.to(userId.toString()).emit("userDataUpdated", {
+      walletBalance: updatedUser.walletBalance,
+      xp: updatedUser.xp,
+      level: updatedUser.level,
+    });
+
+    io.emit("crash:gameState", publicState(gameState));
+
+    notify({ userId, payout, multiplier });
+    return true;
+  };
 
   const calculateMultiplier = () => {
     if (!gameState.gameStartTime) return 1.0; // no round running
@@ -250,9 +275,38 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
       ).catch((e) => console.log(e));
     }
 
+    // the sweep awaits credits, so a slow one must not let the next tick run the
+    // bust branch concurrently and settle the round twice
+    let ticking = false;
     const multiplierInterval = setInterval(async () => {
       if (stopped) return clearInterval(multiplierInterval);
+      if (ticking) return;
+      ticking = true;
+      try {
+        await tick();
+      } finally {
+        ticking = false;
+      }
+    }, tickMs);
+
+    const tick = async () => {
       const currentMultiplier = calculateMultiplier();
+
+      // pay due auto-cashouts at exactly their target before the bust check, so a
+      // target the curve did reach still pays on the very tick the round ends
+      const due = Object.entries(gameState.autoCashouts).filter(
+        ([, target]) => target <= currentMultiplier && target < gameState.crashPoint
+      );
+      if (due.length) {
+        for (const [userId] of due) delete gameState.autoCashouts[userId];
+        await Promise.all(
+          due.map(([userId, target]) =>
+            settleCashout(userId, target, (data) =>
+              io.to(userId).emit("crash:cashoutSuccess", data)
+            ).catch((e) => console.log(e))
+          )
+        );
+      }
 
       if (currentMultiplier >= gameState.crashPoint) {
         clearInterval(multiplierInterval);
@@ -278,7 +332,7 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
       } else {
         io.emit("crash:multiplier", currentMultiplier);
       }
-    }, tickMs);
+    };
     ticker = multiplierInterval;
   };
 

--- a/backend/utils/crashMath.js
+++ b/backend/utils/crashMath.js
@@ -25,4 +25,12 @@ const crashPointFromSeed = (serverSeed) => {
   return crashPointFromRandom(parseInt(hash.slice(8, 16), 16));
 };
 
-module.exports = { GROWTH, INSTANT_CRASH_CHANCE, multiplierAt, crashPointFromRandom, crashPointFromSeed };
+// an auto-cashout target off the wire: cents precision, 1.01x..10000x; null = invalid
+const normalizeAutoCashout = (value) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const rounded = Math.round(value * 100) / 100;
+  if (rounded < 1.01 || rounded > 10000) return null;
+  return rounded;
+};
+
+module.exports = { GROWTH, INSTANT_CRASH_CHANCE, multiplierAt, crashPointFromRandom, crashPointFromSeed, normalizeAutoCashout };

--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import SocketConnection from "../../services/socket"
 import UserContext from "../../UserContext";
@@ -17,6 +17,8 @@ interface GameHistory {
 
 const CrashGame = () => {
   const [bet, setBet] = useState<number | null>(null);
+  const [cashoutAt, setCashoutAt] = useState<string>("2.00");
+  const [queued, setQueued] = useState(false);
   const [multiplier, setMultiplier] = useState(1.0);
   const [crashPoint, setCrashPoint] = useState(null as number | null);
   const [history, setHistory] = useState<GameHistory[]>([]);
@@ -36,6 +38,34 @@ const CrashGame = () => {
 
   const { isLogged, toogleUserData, userData, toogleUserFlow } = useContext(UserContext);
 
+  const queuedRef = useRef<{ amount: number; autoCashoutAt: number | null } | null>(null);
+
+  const buildPayload = () => {
+    const target = parseFloat(cashoutAt);
+    return {
+      amount: bet as number,
+      autoCashoutAt: Number.isFinite(target) && target >= 1.01 ? Math.round(target * 100) / 100 : null,
+    };
+  };
+
+  const placeBet = (payload: { amount: number; autoCashoutAt: number | null }) => {
+    setUserGambled(true);
+    setUserCashedOut(false);
+
+    // the server has the final word: a refused bet used to leave the ui claiming
+    // the player was in the round
+    socket.emit("crash:bet", payload, (result: { ok?: boolean; error?: string }) => {
+      if (result?.error) {
+        setUserGambled(false);
+        toast.error(result.error);
+      }
+    });
+  };
+  // the queue flush lives in a socket listener registered once; the ref keeps it
+  // reading the current closure instead of the mount-time one
+  const placeBetRef = useRef(placeBet);
+  placeBetRef.current = placeBet;
+
   const handleBet = () => {
     if (!isLogged) {
       toogleUserFlow(true);
@@ -43,17 +73,19 @@ const CrashGame = () => {
     }
 
     if (bet === null || bet < 1) return;
-    setUserGambled(true);
-    setUserCashedOut(false);
 
-    // the server has the final word: a refused bet used to leave the ui claiming
-    // the player was in the round
-    socket.emit("crash:bet", bet, (result: { ok?: boolean; error?: string }) => {
-      if (result?.error) {
-        setUserGambled(false);
-        toast.error(result.error);
+    // a click while a round runs queues the bet for the next window; a second click cancels
+    if (gameStarted) {
+      if (queuedRef.current) {
+        queuedRef.current = null;
+        setQueued(false);
+      } else {
+        queuedRef.current = buildPayload();
+        setQueued(true);
       }
-    });
+      return;
+    }
+    placeBet(buildPayload());
   };
 
   const handleCashout = () => {
@@ -81,6 +113,13 @@ const CrashGame = () => {
   useEffect(() => {
     const gameStateListener = (gameState: any) => {
       setGameState(gameState);
+      // a null start time means the betting window is open: flush a queued bet
+      if (gameState.gameStartTime == null && queuedRef.current) {
+        const payload = queuedRef.current;
+        queuedRef.current = null;
+        setQueued(false);
+        placeBetRef.current(payload);
+      }
     };
 
     socket.on("crash:gameState", gameStateListener);
@@ -185,7 +224,8 @@ const CrashGame = () => {
   return (
     <div className="w-screen flex flex-col items-center justify-center gap-12">
       <div className="flex bg-[#212031] rounded flex-col lg:flex-row">
-        <SideMenu bet={bet} setBet={setBet} gameStarted={gameStarted} handleBet={handleBet} handleCashout={handleCashout}
+        <SideMenu bet={bet} setBet={setBet} cashoutAt={cashoutAt} setCashoutAt={setCashoutAt} queued={queued}
+         multiplier={multiplier} gameStarted={gameStarted} handleBet={handleBet} handleCashout={handleCashout}
          isLogged={isLogged} userGambled={userGambled} userCashedOut={userCashedOut} userData={userData} userMultiplier={userMultiplier} disableButton={disableButton}/>
         <GameContainer
           crashPoint={crashPoint}

--- a/src/pages/Crash/SideMenu.tsx
+++ b/src/pages/Crash/SideMenu.tsx
@@ -1,8 +1,14 @@
+import { AiFillCaretDown, AiFillCaretUp } from 'react-icons/ai';
+import Monetary from '../../components/Monetary';
 import { User } from '../../components/Types';
 
 interface SideMenuProps {
     bet: number | null;
     setBet: any;
+    cashoutAt: string;
+    setCashoutAt: any;
+    queued: boolean;
+    multiplier: number;
     gameStarted: boolean;
     handleBet: any;
     handleCashout: any;
@@ -14,61 +20,138 @@ interface SideMenuProps {
     disableButton: boolean;
 }
 
-const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, gameStarted, handleBet, handleCashout, isLogged, userGambled, userCashedOut, userData, userMultiplier, disableButton }) => {
+const MAX_BET = 1000000;
+
+const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutAt, queued, multiplier, gameStarted, handleBet, handleCashout, isLogged, userGambled, userCashedOut, userData, userMultiplier, disableButton }) => {
+
+    const target = parseFloat(cashoutAt);
+    const hasTarget = Number.isFinite(target) && target >= 1.01;
+
+    // live profit while the player's bet rides the curve, planned profit otherwise
+    const inRound = userGambled && gameStarted && !userCashedOut;
+    const profit = inRound
+        ? (bet ?? 0) * multiplier - (bet ?? 0)
+        : hasTarget
+            ? (bet ?? 0) * target - (bet ?? 0)
+            : 0;
+
+    const stepTarget = (dir: 1 | -1) => {
+        const base = hasTarget ? target : 2;
+        const next = Math.max(1.01, Math.round((base + dir * 0.5) * 100) / 100);
+        setCashoutAt(next.toFixed(2));
+    };
+
+    const invalidBet =
+        !bet || bet < 1 || bet > MAX_BET || (userData && userData.walletBalance < bet);
 
     const renderMessage = () => {
       let message = "";
-  
+
       if (!isLogged) {
         message = "Sign in to play";
-      } else if (userCashedOut) {
+      } else if (userCashedOut && gameStarted) {
         message = `Cashed Out at x${userMultiplier.toFixed(2)}`;
       } else if (userGambled) {
         message = gameStarted ? "Cash Out" : "You're in!";
-      } else if (gameStarted) {
-        message = "Wait for next round";
-      } else if (bet === 0 || !bet || bet < 1) {
+      } else if (!bet || bet < 1) {
         message = "Place the bet value";
-      } else if (bet > 1000000) {
+      } else if (bet > MAX_BET) {
         message = "Max bet is 1M";
-      } else if (userData.walletBalance < (bet ?? 0)) {
+      } else if (userData.walletBalance < bet) {
         message = "Not enough money";
+      } else if (queued) {
+        message = "Queued (click to cancel)";
+      } else if (gameStarted) {
+        message = "Bet (Next Round)";
       } else {
         message = "Place Bet";
       }
       return message;
     }
-  
+
+    const disabled =
+        disableButton ||
+        (isLogged && (userGambled ? !gameStarted || userCashedOut : invalidBet));
+
     return (
-      <div className="lg:w-[340px] flex flex-col items-center gap-4 border-r border-gray-700 py-4 px-6">
-        <input
-          type="number"
-          value={bet || ""}
-          onKeyDown={(event) => {
-            if (!/[0-9]/.test(event.key) && event.key !== "Backspace") {
-              event.preventDefault();
-            }
-          }}
-          max={1000000}
-          onChange={(e) => {
-            const value = Number(e.target.value);
-            setBet(value < 0 ? 0 : value);
-          }}
-          className="p-2 border rounded w-1/2 lg:w-full"
-        />
+      <div className="lg:w-[340px] flex flex-col gap-2 border-r border-gray-700 py-4 px-6">
+        <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
+          <span>Bet Amount</span>
+          <span><Monetary value={bet || 0} /></span>
+        </div>
+        <div className="flex">
+          <input
+            type="number"
+            value={bet || ""}
+            onKeyDown={(event) => {
+              if (!/[0-9]/.test(event.key) && event.key !== "Backspace") {
+                event.preventDefault();
+              }
+            }}
+            max={MAX_BET}
+            onChange={(e) => {
+              const value = Number(e.target.value);
+              setBet(value < 0 ? 0 : value);
+            }}
+            className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm"
+          />
+          <button
+            onClick={() => setBet(Math.max(1, Math.floor((bet || 0) / 2)))}
+            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line text-sm font-semibold"
+          >
+            ½
+          </button>
+          <button
+            onClick={() => setBet(Math.min(MAX_BET, (bet || 1) * 2))}
+            className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold"
+          >
+            2×
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-2">
+          <span>Cashout At</span>
+          <span>{hasTarget ? `x${target.toFixed(2)}` : "Off"}</span>
+        </div>
+        <div className="flex">
+          <input
+            type="text"
+            inputMode="decimal"
+            value={cashoutAt}
+            placeholder="Off"
+            onChange={(e) => setCashoutAt(e.target.value.replace(/[^0-9.]/g, ""))}
+            className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm"
+          />
+          <button
+            onClick={() => stepTarget(-1)}
+            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line"
+          >
+            <AiFillCaretDown />
+          </button>
+          <button
+            onClick={() => stepTarget(1)}
+            className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none"
+          >
+            <AiFillCaretUp />
+          </button>
+        </div>
+
+        <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-2">
+          <span>Profit on Win</span>
+          <span className="text-accent-gold">
+            <Monetary value={profit} showFraction />
+          </span>
+        </div>
+
         <button
-          onClick={gameStarted ? handleCashout : handleBet}
-          className="p-2 border rounded bg-indigo-600 hover:bg-indigo-700 w-full mt-4"
-          disabled={
-            (gameStarted && (!userGambled || userCashedOut)) ||
-            (!gameStarted && userGambled) || (!gameStarted && bet === 0 || !bet || bet > 1000000) || disableButton
-          }
+          onClick={userGambled && gameStarted ? handleCashout : handleBet}
+          className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full mt-2 disabled:opacity-40 disabled:hover:bg-green-500 transition-colors"
+          disabled={disabled}
         >
           {renderMessage()}
         </button>
       </div>
     );
   }
-  
+
   export default SideMenu;
-  


### PR DESCRIPTION
The crash side menu was a bare number input and one button. This reworks it into a proper bet panel and adds the two features it implies.

- Bet panel: amount field with half/double quick buttons, a Cashout At field with steppers, and a Profit on Win row that shows the planned profit before the round and the live profit while the bet rides.
- Server-side auto cashout: the bet payload carries an optional `autoCashoutAt` (`{ amount, autoCashoutAt }`; a bare number still works). Targets are validated and cents-rounded (`normalizeAutoCashout`), and the tick loop pays due targets at exactly their multiplier before the bust check, so a target the curve reached still pays on the round's final tick and a lagging tab cannot miss its cashout. The manual path and the sweep share one settle helper, with a reentrancy latch so a slow credit can never let two ticks settle the round twice.
- Next-round queueing: clicking while a round runs queues the bet (click again cancels) and it fires automatically the moment the betting window opens.

Tests: integration cases for an auto cashout paying at exactly its target and a bad target refusing the bet before any money moves; unit cases for target normalization. Full backend (427), frontend unit, e2e, lint and build suites green.
