### PR TITLE
Crash panel: cashout starts off, flush stepper buttons

### DIFF
--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -17,7 +17,8 @@ interface GameHistory {
 
 const CrashGame = () => {
   const [bet, setBet] = useState<number | null>(null);
-  const [cashoutAt, setCashoutAt] = useState<string>("2.00");
+  // empty = no auto cashout; the field shows "Off" until the player opts in
+  const [cashoutAt, setCashoutAt] = useState<string>("");
   const [queued, setQueued] = useState(false);
   const [multiplier, setMultiplier] = useState(1.0);
   const [crashPoint, setCrashPoint] = useState(null as number | null);

--- a/src/pages/Crash/SideMenu.tsx
+++ b/src/pages/Crash/SideMenu.tsx
@@ -36,8 +36,9 @@ const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutA
             : 0;
 
     const stepTarget = (dir: 1 | -1) => {
-        const base = hasTarget ? target : 2;
-        const next = Math.max(1.01, Math.round((base + dir * 0.5) * 100) / 100);
+        // from "off", either arrow lands on the classic default first
+        if (!hasTarget) return setCashoutAt("2.00");
+        const next = Math.max(1.01, Math.round((target + dir * 0.5) * 100) / 100);
         setCashoutAt(next.toFixed(2));
     };
 
@@ -97,7 +98,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutA
           />
           <button
             onClick={() => setBet(Math.max(1, Math.floor((bet || 0) / 2)))}
-            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line text-sm font-semibold"
+            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold"
           >
             ½
           </button>
@@ -124,7 +125,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutA
           />
           <button
             onClick={() => stepTarget(-1)}
-            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line"
+            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none"
           >
             <AiFillCaretDown />
           </button>


### PR DESCRIPTION
Two follow-ups on the crash bet panel.

- The Cashout At field defaulted to 2.00, quietly opting every player into auto cashout. It now starts empty ("Off"); the first click on either stepper arrow lands on the classic 2.00 default, then steps by 0.5 as before.
- The middle buttons of both input groups (half and the down arrow) declared no radius, so they inherited the global 8px button radius from the scaffold css and looked rounded mid-group. They are now `rounded-none`, leaving only the group's right edge rounded.

Tests: unit, lint and build green.
