### PR TITLE
Dice game: provably-fair over/under with backoffice + auto

### DIFF
--- a/backend/__tests__/integration/dicePF.test.js
+++ b/backend/__tests__/integration/dicePF.test.js
@@ -1,0 +1,127 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Roll = require("../../models/Roll");
+const Seed = require("../../models/Seed");
+const Transaction = require("../../models/Transaction");
+const { TX } = require("../../utils/economy");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  await Promise.all([Seed.syncIndexes(), Roll.syncIndexes()]);
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(walletBalance = 1000) {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+}
+
+const rollDice = (auth, body) => request(app).post("/games/dice").set(auth).send(body);
+
+test("a roll charges the bet, settles the outcome, and records a dice roll", async () => {
+  const u = await makeUser(1000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const res = await rollDice(auth, { betAmount: 100, target: 5050, direction: "over" });
+  expect(res.status).toBe(200);
+  expect(res.body.rollId).toMatch(/^R\d+$/);
+  expect(res.body.result).toBeGreaterThanOrEqual(0);
+  expect(res.body.result).toBeLessThanOrEqual(9999);
+  expect(res.body.multiplier).toBe(2); // over 50.50 -> 49.5% -> 2.0000x
+  // the result decides win/loss, and the payout follows exactly
+  expect(res.body.won).toBe(res.body.result >= 5050);
+  expect(res.body.payout).toBe(res.body.won ? 200 : 0);
+
+  const roll = await Roll.findOne({ userId: u._id, game: "dice" });
+  expect(roll).toBeTruthy();
+  expect(roll.outcome.result).toBe(res.body.result);
+  expect(roll.outcome.payout).toBe(res.body.payout);
+  expect((await Seed.findOne({ userId: u._id, active: true })).nonce).toBe(1);
+
+  const after = await User.findById(u._id);
+  expect(after.walletBalance).toBeCloseTo(1000 - 100 + res.body.payout, 10);
+
+  const bet = await Transaction.findOne({ userId: u._id, type: TX.DICE_BET });
+  expect(bet.amount).toBe(100);
+  const win = await Transaction.findOne({ userId: u._id, type: TX.DICE_WIN });
+  if (res.body.won) expect(win.amount).toBe(200);
+  else expect(win).toBeNull();
+});
+
+test("an insufficient balance answers 400 and moves no money", async () => {
+  const u = await makeUser(5);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const res = await rollDice(auth, { betAmount: 100, target: 5000, direction: "under" });
+  expect(res.status).toBe(400);
+  expect((await User.findById(u._id)).walletBalance).toBe(5);
+  expect(await Roll.findOne({ userId: u._id, game: "dice" })).toBeNull();
+});
+
+test("bad inputs are rejected before any money moves", async () => {
+  const u = await makeUser(100000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const bad = [
+    { betAmount: 10, target: 5000 }, // missing direction
+    { betAmount: 10, target: 5000, direction: "sideways" },
+    { betAmount: 10, target: 100, direction: "under" }, // winCount 100, under 2%
+    { betAmount: 10, target: 9900, direction: "under" }, // over 98%
+    { betAmount: 10, target: 0, direction: "over" },
+    { betAmount: 10, target: 50.5, direction: "over" }, // not an integer unit
+    { betAmount: 10.5, target: 5000, direction: "over" },
+    { betAmount: 0, target: 5000, direction: "over" },
+    { betAmount: 30000, target: 5000, direction: "over" }, // over the bet cap
+    { betAmount: "10", target: 5000, direction: "over" },
+  ];
+  for (const body of bad) {
+    const res = await rollDice(auth, body);
+    expect(res.status).toBe(400);
+  }
+  expect((await User.findById(u._id)).walletBalance).toBe(100000);
+  expect(await Roll.findOne({ userId: u._id, game: "dice" })).toBeNull();
+});
+
+test("concurrent rolls reserve distinct nonces", async () => {
+  const u = await makeUser(1000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const [a, b] = await Promise.all([
+    rollDice(auth, { betAmount: 10, target: 5000, direction: "over" }),
+    rollDice(auth, { betAmount: 10, target: 5000, direction: "over" }),
+  ]);
+  expect(a.status).toBe(200);
+  expect(b.status).toBe(200);
+
+  const nonces = (await Roll.find({ userId: u._id, game: "dice" })).map((r) => r.nonce).sort();
+  expect(nonces).toEqual([0, 1]);
+});
+
+test("a rotated seed lets the verifier reproduce the roll", async () => {
+  const u = await makeUser(1000);
+  const auth = { Authorization: `Bearer ${tokenFor(u)}` };
+
+  const roll = await rollDice(auth, { betAmount: 50, target: 2500, direction: "under" });
+  expect(roll.status).toBe(200);
+
+  // still hidden: the active seed must not verify
+  const early = await request(app).get(`/fair/roll/${roll.body.rollId}/verify`);
+  expect(early.body.ok).toBe(false);
+
+  await request(app).post("/fair/rotate").set(auth).send({});
+
+  const verified = await request(app).get(`/fair/roll/${roll.body.rollId}/verify`);
+  expect(verified.body.ok).toBe(true);
+  expect(verified.body.commitmentValid).toBe(true);
+  expect(verified.body.recomputedResult).toBe(roll.body.resultValue);
+  expect(verified.body.recomputedWon).toBe(roll.body.won);
+  expect(verified.body.recomputedPayout).toBe(roll.body.payout);
+});

--- a/backend/__tests__/unit/diceMath.test.js
+++ b/backend/__tests__/unit/diceMath.test.js
@@ -1,0 +1,92 @@
+const {
+  OUTCOMES,
+  resultFromFloat,
+  winCountFor,
+  isWin,
+  multiplierFor,
+  winChanceFor,
+  payoutCentsFor,
+  normalizeTarget,
+  validBet,
+  resolveRoll,
+} = require("../../utils/diceMath");
+
+describe("dice math", () => {
+  test("result maps a float to 0..9999", () => {
+    expect(resultFromFloat(0)).toBe(0);
+    expect(resultFromFloat(0.99999)).toBe(9999);
+    expect(resultFromFloat(0.5)).toBe(5000);
+  });
+
+  test("under and over win conditions are exactly complementary", () => {
+    const target = 5050;
+    for (const result of [0, 5049, 5050, 9999]) {
+      expect(isWin(result, target, "under")).toBe(result < target);
+      expect(isWin(result, target, "over")).toBe(result >= target);
+      // every outcome wins exactly one side
+      expect(isWin(result, target, "under")).not.toBe(isWin(result, target, "over"));
+    }
+    expect(winCountFor(target, "under") + winCountFor(target, "over")).toBe(OUTCOMES);
+  });
+
+  test("multiplier and win chance reproduce the Stake table (99% RTP)", () => {
+    const cases = [
+      { winCount: 4950, chance: 49.5, mult: 2 },
+      { winCount: 200, chance: 2, mult: 49.5 },
+      { winCount: 2000, chance: 20, mult: 4.95 },
+      { winCount: 6500, chance: 65, mult: 1.5231 },
+      { winCount: 8000, chance: 80, mult: 1.2375 },
+      { winCount: 9800, chance: 98, mult: 1.0102 },
+    ];
+    for (const c of cases) {
+      expect(winChanceFor(c.winCount)).toBeCloseTo(c.chance, 6);
+      expect(multiplierFor(c.winCount)).toBeCloseTo(c.mult, 4);
+      // the realized RTP is 99% at every win chance
+      expect((c.winCount / OUTCOMES) * multiplierFor(c.winCount)).toBeCloseTo(0.99, 3);
+    }
+  });
+
+  test("payout is exact integer cents, zero on a loss", () => {
+    expect(payoutCentsFor(100, 4950, true)).toBe(20000); // 100 * 2.0000
+    expect(payoutCentsFor(100, 4950, false)).toBe(0);
+    expect(payoutCentsFor(200, 200, true)).toBe(990000); // 200 * 49.50 = 9900.00
+  });
+
+  test("targets outside the 2%..98% band are refused", () => {
+    expect(normalizeTarget(5050, "under")).toBe(5050);
+    expect(normalizeTarget(5050, "over")).toBe(5050);
+    expect(normalizeTarget(200, "under")).toBe(200); // exactly 2% win chance
+    expect(normalizeTarget(9800, "under")).toBe(9800); // exactly 98%
+    expect(normalizeTarget(199, "under")).toBe(null); // under 2%
+    expect(normalizeTarget(9801, "under")).toBe(null); // over 98%
+    expect(normalizeTarget(9801, "over")).toBe(null); // winCount 199, under 2%
+    expect(normalizeTarget(0, "under")).toBe(null);
+    expect(normalizeTarget(10000, "under")).toBe(null);
+    expect(normalizeTarget(50.5, "under")).toBe(null); // not an integer 0.01 unit
+    expect(normalizeTarget(5000, "sideways")).toBe(null);
+  });
+
+  test("bet bounds are whole coins 1..20000", () => {
+    expect(validBet(1)).toBe(true);
+    expect(validBet(20000)).toBe(true);
+    expect(validBet(0)).toBe(false);
+    expect(validBet(20001)).toBe(false);
+    expect(validBet(10.5)).toBe(false);
+    expect(validBet("100")).toBe(false);
+  });
+
+  test("resolveRoll ties result, win, and payout together", () => {
+    // float 0.75 -> result 7500; over 5050 wins (7500 >= 5050)
+    const win = resolveRoll(0.75, 100, 5050, "over");
+    expect(win.result).toBe(7500);
+    expect(win.resultValue).toBe(75);
+    expect(win.won).toBe(true);
+    expect(win.multiplier).toBe(2);
+    expect(win.payout).toBe(200);
+
+    // same roll, under 5050 loses (7500 is not < 5050)
+    const loss = resolveRoll(0.75, 100, 5050, "under");
+    expect(loss.won).toBe(false);
+    expect(loss.payout).toBe(0);
+  });
+});

--- a/backend/games/dice.js
+++ b/backend/games/dice.js
@@ -1,0 +1,106 @@
+const { chargeUser, creditUser, TX } = require("../utils/economy");
+const seeds = require("../utils/seeds");
+const rolls = require("../utils/rolls");
+const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const { DICE_ALGO_VERSION, normalizeTarget, validBet, resolveRoll } = require("../utils/diceMath");
+
+function httpError(status, message) {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+}
+
+class DiceGameController {
+  static async roll(userId, betAmount, target, direction, io) {
+    if (!validBet(betAmount)) {
+      throw httpError(400, "Invalid bet amount");
+    }
+    const cleanTarget = normalizeTarget(target, direction);
+    if (cleanTarget === null) {
+      throw httpError(400, "Invalid target");
+    }
+
+    // reserve the provably-fair nonce up front (atomic, never rolled back)
+    const reserved = await seeds.reserveNonces(userId, 1);
+    const nonce = reserved.startNonce;
+
+    // atomically take the stake, rejecting if the balance can't cover it
+    const player = await chargeUser(userId, betAmount, {
+      type: TX.DICE_BET,
+      meta: { betAmount, target: cleanTarget, direction },
+    });
+    if (!player) {
+      throw httpError(400, "Insufficient balance");
+    }
+
+    const float = rollFloat(reserved.serverSeed, reserved.clientSeed, nonce, 0);
+    const outcome = resolveRoll(float, betAmount, cleanTarget, direction);
+
+    // pay out winnings atomically; a rolled-back credit is settled manually from the roll
+    let balanceAfter = player.walletBalance;
+    let credited = null;
+    if (outcome.payout > 0) {
+      credited = await creditUser(userId, outcome.payout, outcome.payout, {
+        type: TX.DICE_WIN,
+        meta: { betAmount, target: cleanTarget, direction, multiplier: outcome.multiplier, payout: outcome.payout },
+      });
+      if (credited) balanceAfter = credited.walletBalance;
+    }
+    const payoutFailed = outcome.payout > 0 && !credited;
+
+    io.to(userId.toString()).emit("userDataUpdated", {
+      walletBalance: balanceAfter,
+      xp: player.xp,
+      level: player.level,
+    });
+
+    // record the provably-fair audit roll (the result and payout reproduce from the seed);
+    // money is already settled, so a failed record must not turn the roll into an error
+    let rec = null;
+    try {
+      rec = await rolls.recordRoll({
+        game: "dice",
+        userId,
+        seedId: reserved.seedId,
+        clientSeed: reserved.clientSeed,
+        serverSeedHash: reserved.serverSeedHash,
+        nonce,
+        roll: Math.floor(float * TOTAL) + 1,
+        total: TOTAL,
+        outcome: {
+          betAmount,
+          target: cleanTarget,
+          direction,
+          result: outcome.result,
+          multiplier: outcome.multiplier,
+          winChance: outcome.winChance,
+          won: outcome.won,
+          payout: outcome.payout,
+          algoVersion: DICE_ALGO_VERSION,
+        },
+      });
+    } catch (recordError) {
+      console.error("dice roll record failed", recordError);
+    }
+
+    if (payoutFailed) {
+      throw httpError(500, "Payout failed, contact support");
+    }
+
+    return {
+      betAmount,
+      target: cleanTarget,
+      direction,
+      result: outcome.result,
+      resultValue: outcome.resultValue,
+      multiplier: outcome.multiplier,
+      winChance: outcome.winChance,
+      won: outcome.won,
+      payout: outcome.payout,
+      balance: balanceAfter,
+      rollId: rec ? rec.rollId : null,
+    };
+  }
+}
+
+module.exports = DiceGameController;

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -48,4 +48,16 @@ const plinkoDropLimiter = rateLimit({
   message: { message: "Too many drops, slow down a little." },
 });
 
-module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter };
+// dice rolls are one request each and fire fast on autobet; keyed per user (after auth)
+const diceRollLimiter = rateLimit({
+  windowMs: 10 * 1000,
+  max: 40,
+  keyGenerator: (req) => String(req.user._id),
+  skip: skipInTests,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  message: { message: "Too many rolls, slow down a little." },
+});
+
+module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter, diceRollLimiter };

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -8,7 +8,7 @@ const RollSchema = new mongoose.Schema(
   {
     rollId: { type: String, required: true, unique: true }, // public short id, e.g. R821872881
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack"], required: true },
+    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice"], required: true },
 
     seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
     clientSeed: { type: String, required: true },

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
-const { plinkoDropLimiter } = require("../middleware/rateLimit");
+const { plinkoDropLimiter, diceRollLimiter } = require("../middleware/rateLimit");
 
 const User = require("../models/User");
 const Case = require("../models/Case");
@@ -10,6 +10,7 @@ const upgradeItems = require("../games/upgrade");
 const SlotGameController = require("../games/slot");
 const PlinkoGameController = require("../games/plinko");
 const BlackjackGameController = require("../games/blackjack");
+const DiceGameController = require("../games/dice");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const referrals = require("../utils/referrals");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
@@ -207,6 +208,23 @@ module.exports = (io) => {
       const { betAmount, risk } = req.body;
 
       const result = await PlinkoGameController.drop(user._id, betAmount, risk, io);
+      res.json(result);
+    } catch (error) {
+      // statused errors are intentional answers; anything else stays generic
+      if (error.status) return res.status(error.status).json({ message: error.message });
+      console.error(error);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  });
+
+  // roll the dice
+  router.post('/dice', isAuthenticated, diceRollLimiter, async (req, res) => {
+    const user = req.user;
+
+    try {
+      const { betAmount, target, direction } = req.body;
+
+      const result = await DiceGameController.roll(user._id, betAmount, target, direction, io);
       res.json(result);
     } catch (error) {
       // statused errors are intentional answers; anything else stays generic

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -39,6 +39,8 @@ const COUNTERPARTY_FOR_TYPE = {
   blackjack_win: HOUSE,
   blackjack_push: HOUSE,
   blackjack_refund: HOUSE,
+  dice_bet: HOUSE,
+  dice_win: HOUSE,
   item_sell: HOUSE,
   market_order: ESCROW,
   market_order_refund: ESCROW,

--- a/backend/utils/adminStats.js
+++ b/backend/utils/adminStats.js
@@ -8,12 +8,12 @@ const { HOUSE, MINT, ESCROW, GENESIS } = require("./accounts");
 const PAGE_SIZE = 20;
 
 // KP-paying game wins and stake returns, for daily series and big-win surfacing
-const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 const REFUND_TYPES = [TX.CRASH_REFUND, TX.COINFLIP_REFUND, TX.BATTLE_REFUND, TX.BLACKJACK_PUSH, TX.BLACKJACK_REFUND];
 // KP printed to players outside the games
 const FAUCET_TYPES = [TX.SIGNUP, TX.BONUS, TX.MISSION_REWARD, TX.REFERRAL_BONUS, TX.REFERRAL_MILESTONE, TX.AD_REWARD];
 // designed edges per game, so the realized return can be judged against intent
-const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, blackjack: 0.9943, cases: 0.9, battles: 0.9 };
+const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, blackjack: 0.9943, dice: 0.99, cases: 0.9, battles: 0.9 };
 
 // window start, or null for all-time
 const sinceFor = (days) => {
@@ -48,6 +48,7 @@ const GAME_LINES = [
   { game: "slots", bets: [TX.SLOT_BET], outs: [TX.SLOT_WIN] },
   { game: "plinko", bets: [TX.PLINKO_BET], outs: [TX.PLINKO_WIN] },
   { game: "blackjack", bets: [TX.BLACKJACK_BET], outs: [TX.BLACKJACK_WIN, TX.BLACKJACK_PUSH, TX.BLACKJACK_REFUND] },
+  { game: "dice", bets: [TX.DICE_BET], outs: [TX.DICE_WIN] },
   { game: "cases", bets: [TX.CASE_OPEN], outs: [] },
   { game: "battles", bets: [TX.BATTLE_ENTRY], outs: [TX.BATTLE_REFUND] },
 ];

--- a/backend/utils/diceMath.js
+++ b/backend/utils/diceMath.js
@@ -1,0 +1,110 @@
+// pure dice math: one roll maps a provably-fair float to a 0.00-99.99 result, and a
+// (target, direction) win condition prices the payout. the game controller and the
+// verifier both fold through this, so they can never disagree.
+const DICE_ALGO_VERSION = 1;
+
+// 10000 equally likely outcomes 0..9999, displayed as result/100 (0.00..99.99)
+const OUTCOMES = 10000;
+
+// win chance is capped 2%..98%, so the multiplier tops out at 49.50x (the Stake cap)
+const MIN_WIN_COUNT = 200;
+const MAX_WIN_COUNT = 9800;
+
+const MIN_BET = 1;
+// keeps the max payout at 990,000 (MAX_BET * 49.5x), in line with the other games
+const MAX_BET = 20000;
+
+// 99% RTP: multiplier = 0.99 / winChance = 0.99 * OUTCOMES / winCount. kept as
+// 4-decimal fixed point (multiplier * MULT_SCALE) so the payout is exact integer
+// arithmetic, never a float. numerator = 0.99 * OUTCOMES * MULT_SCALE.
+const MULT_SCALE = 10000;
+const RTP_NUMERATOR = (99 * OUTCOMES * MULT_SCALE) / 100; // = 99,000,000
+
+const isDirection = (d) => d === "over" || d === "under";
+
+// the integer result in [0, 9999] for a single provably-fair float
+function resultFromFloat(float) {
+  return Math.floor(float * OUTCOMES);
+}
+
+// winning outcomes for a threshold: under wins below it, over wins at or above it,
+// so the two directions are exactly complementary and every chance is exact
+function winCountFor(target, direction) {
+  return direction === "under" ? target : OUTCOMES - target;
+}
+
+function isWin(result, target, direction) {
+  return direction === "under" ? result < target : result >= target;
+}
+
+// multiplier as 4-decimal fixed point (multiplier * MULT_SCALE); 4950 winning outcomes -> 20000 (2.0000x)
+function multiplierBP(winCount) {
+  return Math.round(RTP_NUMERATOR / winCount);
+}
+
+function multiplierFor(winCount) {
+  return multiplierBP(winCount) / MULT_SCALE;
+}
+
+// win chance as a percent (winCount 4950 -> 49.5)
+function winChanceFor(winCount) {
+  return (winCount / OUTCOMES) * 100;
+}
+
+// payout in whole cents; integer bet times integer fixed-point multiplier, so exact.
+// dividing the 4-decimal multiplier by (MULT_SCALE/100) lands on 2-decimal cents.
+function payoutCentsFor(betAmount, winCount, won) {
+  return won ? Math.floor((betAmount * multiplierBP(winCount)) / (MULT_SCALE / 100)) : 0;
+}
+
+// a target off the wire: integer 0.01 units, and the winCount it implies must sit in
+// the 2%..98% band. returns null on anything invalid.
+function normalizeTarget(target, direction) {
+  if (!isDirection(direction)) return null;
+  if (!Number.isInteger(target) || target < 1 || target > OUTCOMES - 1) return null;
+  const winCount = winCountFor(target, direction);
+  if (winCount < MIN_WIN_COUNT || winCount > MAX_WIN_COUNT) return null;
+  return target;
+}
+
+function validBet(betAmount) {
+  return Number.isInteger(betAmount) && betAmount >= MIN_BET && betAmount <= MAX_BET;
+}
+
+// resolve a whole bet from its float; the single source both the game and verifier use
+function resolveRoll(float, betAmount, target, direction) {
+  const result = resultFromFloat(float);
+  const winCount = winCountFor(target, direction);
+  const won = isWin(result, target, direction);
+  const payoutCents = payoutCentsFor(betAmount, winCount, won);
+  return {
+    result, // 0..9999
+    resultValue: result / 100, // 0.00..99.99, for display
+    target,
+    direction,
+    winCount,
+    winChance: winChanceFor(winCount),
+    multiplier: multiplierFor(winCount),
+    won,
+    payout: payoutCents / 100,
+  };
+}
+
+module.exports = {
+  DICE_ALGO_VERSION,
+  OUTCOMES,
+  MIN_WIN_COUNT,
+  MAX_WIN_COUNT,
+  MIN_BET,
+  MAX_BET,
+  resultFromFloat,
+  winCountFor,
+  isWin,
+  multiplierBP,
+  multiplierFor,
+  winChanceFor,
+  payoutCentsFor,
+  normalizeTarget,
+  validBet,
+  resolveRoll,
+};

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -27,6 +27,8 @@ const TX = {
   BLACKJACK_WIN: "blackjack_win",
   BLACKJACK_PUSH: "blackjack_push", // stake returned on a tie, not a win
   BLACKJACK_REFUND: "blackjack_refund", // stake returned when a deal is voided
+  DICE_BET: "dice_bet",
+  DICE_WIN: "dice_win",
   MARKET_BUY: "market_buy",
   MARKET_SALE: "market_sale",
   MARKET_FEE: "market_fee", // the house cut on a settled trade, credited to HOUSE
@@ -44,7 +46,7 @@ const TX = {
 };
 
 // every KP put at risk on a game; missions and referral commission both count these
-const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BLACKJACK_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
+const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BLACKJACK_BET, TX.DICE_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 function calculateXPForLevel(level) {
   return Math.floor(BASE_XP * Math.pow(GROWTH_RATE, level - 1));

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -8,7 +8,7 @@ const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
 const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 
 // a "big win" is any single game payout; pushes and refunds are returned stakes, not wins
-const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 
 // missions currently offered; a disabled one (active:false) stays defined but is
 // never shown, announced, or claimable

--- a/backend/utils/rolls.js
+++ b/backend/utils/rolls.js
@@ -5,6 +5,8 @@ const CaseConfig = require("../models/CaseConfig");
 const { roll: computeRoll, pickFromRanges, hashServerSeed } = require("./provablyFair");
 const { PAYOUTS: PLINKO_PAYOUTS, PLINKO_ALGO_VERSION, derivePath, binFromPath } = require("./plinkoMath");
 const { BLACKJACK_ALGO_VERSION, replayHand } = require("./blackjackMath");
+const { DICE_ALGO_VERSION, resolveRoll: resolveDiceRoll } = require("./diceMath");
+const { rollFloat } = require("./provablyFair");
 
 function generateRollId() {
   return "R" + crypto.randomInt(100000000, 1000000000).toString(); // "R" + 9 digits
@@ -194,6 +196,42 @@ async function verifyBlackjackRoll(rollId) {
   };
 }
 
+// recompute a dice roll's result and payout from its public inputs; folds through the
+// same diceMath the game uses, so verification and the live roll cannot disagree
+async function verifyDiceRoll(rollId) {
+  const v = await getRollForVerify(rollId);
+  if (!v || v.game !== "dice") return { ok: false, reason: "not a dice roll" };
+  if (!v.serverSeed) return { ok: false, reason: "server seed not revealed yet" };
+
+  const outcome = v.outcome || {};
+  if (outcome.algoVersion !== DICE_ALGO_VERSION) {
+    return { ok: false, reason: "algorithm version superseded" };
+  }
+
+  const commitmentValid = hashServerSeed(v.serverSeed) === v.serverSeedHash;
+  const float = rollFloat(v.serverSeed, v.clientSeed, v.nonce, 0);
+  const replayed = resolveDiceRoll(float, outcome.betAmount, outcome.target, outcome.direction);
+  const ok =
+    commitmentValid &&
+    replayed.result === outcome.result &&
+    replayed.won === outcome.won &&
+    replayed.multiplier === outcome.multiplier &&
+    replayed.payout === outcome.payout;
+
+  return {
+    ok,
+    commitmentValid,
+    recomputedResult: replayed.resultValue,
+    recomputedMultiplier: replayed.multiplier,
+    recomputedWon: replayed.won,
+    recomputedPayout: replayed.payout,
+    expectedResult: outcome.result / 100,
+    expectedMultiplier: outcome.multiplier,
+    expectedWon: outcome.won,
+    expectedPayout: outcome.payout,
+  };
+}
+
 // route a verify request to the game's reference verifier
 async function verifyRoll(rollId) {
   const r = await Roll.findOne({ rollId }).select("game").lean();
@@ -201,6 +239,7 @@ async function verifyRoll(rollId) {
   if (r.game === "case") return verifyCaseRoll(rollId);
   if (r.game === "plinko") return verifyPlinkoRoll(rollId);
   if (r.game === "blackjack") return verifyBlackjackRoll(rollId);
+  if (r.game === "dice") return verifyDiceRoll(rollId);
   return { ok: false, reason: "no server-side verifier for this game" };
 }
 
@@ -212,5 +251,6 @@ module.exports = {
   verifyCaseRoll,
   verifyPlinkoRoll,
   verifyBlackjackRoll,
+  verifyDiceRoll,
   verifyRoll,
 };

--- a/public/images/dice.svg
+++ b/public/images/dice.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 348">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#221f3d"/>
+      <stop offset="1" stop-color="#151225"/>
+    </linearGradient>
+    <linearGradient id="die" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffe680"/>
+      <stop offset="1" stop-color="#f2b705"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="348" rx="14" fill="url(#bg)"/>
+  <g>
+    <rect x="60" y="118" width="88" height="88" rx="16" fill="#2a2740" transform="rotate(-12 104 162)"/>
+    <g fill="#cfccdf" transform="rotate(-12 104 162)">
+      <circle cx="84" cy="142" r="7"/><circle cx="124" cy="142" r="7"/>
+      <circle cx="104" cy="162" r="7"/>
+      <circle cx="84" cy="182" r="7"/><circle cx="124" cy="182" r="7"/>
+    </g>
+    <rect x="120" y="100" width="82" height="82" rx="15" fill="url(#die)" stroke="#151225" stroke-width="3" transform="rotate(10 161 141)"/>
+    <g fill="#151225" transform="rotate(10 161 141)">
+      <circle cx="142" cy="122" r="7"/><circle cx="180" cy="122" r="7"/>
+      <circle cx="142" cy="160" r="7"/><circle cx="180" cy="160" r="7"/>
+    </g>
+  </g>
+  <g>
+    <rect x="46" y="256" width="24" height="26" rx="4" fill="#DF3D6E"/>
+    <rect x="74" y="256" width="24" height="26" rx="4" fill="#DF3D6E"/>
+    <rect x="102" y="256" width="24" height="26" rx="4" fill="#22C55E"/>
+    <rect x="130" y="256" width="24" height="26" rx="4" fill="#22C55E"/>
+    <rect x="158" y="256" width="24" height="26" rx="4" fill="#22C55E"/>
+    <rect x="186" y="256" width="24" height="26" rx="4" fill="#22C55E"/>
+  </g>
+  <text x="128" y="326" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="bold" fill="#e1dde9" letter-spacing="6">DICE</text>
+</svg>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -9,6 +9,7 @@ import Upgrade from "./pages/Upgrade/Upgrade";
 import Slot from "./pages/Slot/Slot";
 import Plinko from "./pages/Plinko";
 import Blackjack from "./pages/Blackjack";
+import Dice from "./pages/Dice";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
 import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
@@ -30,6 +31,7 @@ const defaultRoutes = (
     <Route path="/slot" element={<Slot />} />
     <Route path="/plinko" element={<Plinko />} />
     <Route path="/blackjack" element={<Blackjack />} />
+    <Route path="/dice" element={<Dice />} />
     <Route path="/battles" element={<Battles />} />
     <Route path="/battles/:id" element={<BattleRoom />} />
     <Route path="/provably-fair" element={<ProvablyFair />} />

--- a/src/pages/Dice/Dice.services.ts
+++ b/src/pages/Dice/Dice.services.ts
@@ -1,0 +1,161 @@
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import UserContext from "../../UserContext";
+import { rollDice } from "../../services/games/GamesServices";
+import {
+  Direction,
+  MAX_BET,
+  MIN_BET,
+  clampTarget,
+  controlsFor,
+  targetForMultiplier,
+  targetForWinChance,
+} from "./diceControls";
+import { DiceHistoryEntry, DiceRollResult } from "./Dice.types";
+
+const DEFAULT_BET = 10;
+const DEFAULT_TARGET = 5050; // over 50.50 -> 2.0000x, the classic starting point
+const HISTORY_SIZE = 12;
+const AUTO_INTERVAL_MS = 550; // paced so an auto run reads as a sequence, not a burst
+export const AUTO_COUNTS = [10, 25, 50, 100];
+
+export const useDiceServices = () => {
+  const { userData, toogleUserFlow } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
+  const [target, setTarget] = useState<number>(DEFAULT_TARGET);
+  const [direction, setDirection] = useState<Direction>("over");
+  const [mode, setMode] = useState<"manual" | "auto">("manual");
+  const [autoCount, setAutoCount] = useState<number>(AUTO_COUNTS[0]);
+  const [autoRunning, setAutoRunning] = useState(false);
+  const [autoLeft, setAutoLeft] = useState(0);
+  const [rolling, setRolling] = useState(false);
+  const [last, setLast] = useState<DiceRollResult | null>(null);
+  const [history, setHistory] = useState<DiceHistoryEntry[]>([]);
+
+  const rollSeq = useRef(0);
+  const autoLeftRef = useRef(0);
+  const autoTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const controls = controlsFor(target, direction);
+  const betValue = Math.min(Math.max(Math.floor(Number(betInput)) || MIN_BET, MIN_BET), MAX_BET);
+  const profitOnWin = controls.payoutOnWin(betValue) - betValue;
+
+  // the slider and the three number fields all drive the same target
+  const changeTarget = (next: number) => setTarget(clampTarget(next, direction));
+  const changeWinChance = (chance: number) => {
+    if (Number.isFinite(chance)) setTarget(targetForWinChance(chance, direction));
+  };
+  const changeMultiplier = (mult: number) => {
+    if (Number.isFinite(mult) && mult > 0) setTarget(targetForMultiplier(mult, direction));
+  };
+  // flipping direction keeps the same win chance by mirroring the target
+  const toggleDirection = () => {
+    const nextDir: Direction = direction === "over" ? "under" : "over";
+    setTarget(targetForWinChance(controls.winChance, nextDir));
+    setDirection(nextDir);
+  };
+
+  const fireRoll = async (): Promise<boolean> => {
+    if (userData == null) {
+      toogleUserFlow(true);
+      return false;
+    }
+    if (userData.walletBalance < betValue) {
+      toast.error("Insufficient funds", { theme: "dark" });
+      return false;
+    }
+    setRolling(true);
+    try {
+      const result: DiceRollResult = await rollDice(betValue, target, direction);
+      rollSeq.current += 1;
+      setLast(result);
+      setHistory((h) =>
+        [
+          {
+            key: `d${rollSeq.current}`,
+            resultValue: result.resultValue,
+            won: result.won,
+            multiplier: result.multiplier,
+            rollId: result.rollId,
+          },
+          ...h,
+        ].slice(0, HISTORY_SIZE)
+      );
+      return true;
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Could not roll", { theme: "dark" });
+      return false;
+    } finally {
+      setRolling(false);
+    }
+  };
+
+  // the auto interval reads through a ref so it always sees the current bet and target
+  const fireRollRef = useRef(fireRoll);
+  fireRollRef.current = fireRoll;
+
+  const stopAuto = useCallback(() => {
+    if (autoTimer.current) clearInterval(autoTimer.current);
+    autoTimer.current = null;
+    autoLeftRef.current = 0;
+    setAutoLeft(0);
+    setAutoRunning(false);
+  }, []);
+
+  const startAuto = () => {
+    if (autoRunning) return;
+    if (userData == null) {
+      toogleUserFlow(true);
+      return;
+    }
+    setAutoRunning(true);
+    autoLeftRef.current = autoCount;
+    setAutoLeft(autoCount);
+    const tick = async () => {
+      if (autoLeftRef.current <= 0) return stopAuto();
+      autoLeftRef.current -= 1;
+      setAutoLeft(autoLeftRef.current);
+      const ok = await fireRollRef.current();
+      if (!ok || autoLeftRef.current <= 0) stopAuto();
+    };
+    tick();
+    autoTimer.current = setInterval(tick, AUTO_INTERVAL_MS);
+  };
+
+  useEffect(() => () => stopAuto(), [stopAuto]);
+
+  return {
+    isLogged: userData != null,
+    walletBalance: userData?.walletBalance ?? 0,
+    betInput,
+    betValue,
+    setBetInput,
+    normalizeBet: () => setBetInput(String(betValue)),
+    halveBet: () => setBetInput(String(Math.max(MIN_BET, Math.floor(betValue / 2)))),
+    doubleBet: () => setBetInput(String(Math.min(MAX_BET, betValue * 2))),
+    target,
+    direction,
+    controls,
+    profitOnWin,
+    changeTarget,
+    changeWinChance,
+    changeMultiplier,
+    toggleDirection,
+    mode,
+    setMode,
+    autoCount,
+    setAutoCount,
+    autoRunning,
+    autoLeft,
+    startAuto,
+    stopAuto,
+    rolling,
+    roll: fireRoll,
+    last,
+    history,
+    openRoll: (rollId: string) => navigate(`/provably-fair?roll=${rollId}`),
+  };
+};

--- a/src/pages/Dice/Dice.services.ts
+++ b/src/pages/Dice/Dice.services.ts
@@ -7,6 +7,7 @@ import {
   Direction,
   MAX_BET,
   MIN_BET,
+  OUTCOMES,
   clampTarget,
   controlsFor,
   targetForMultiplier,
@@ -38,6 +39,7 @@ export const useDiceServices = () => {
   const rollSeq = useRef(0);
   const autoLeftRef = useRef(0);
   const autoTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [dragging, setDragging] = useState(false);
 
   const controls = controlsFor(target, direction);
   const betValue = Math.min(Math.max(Math.floor(Number(betInput)) || MIN_BET, MIN_BET), MAX_BET);
@@ -45,6 +47,34 @@ export const useDiceServices = () => {
 
   // the slider and the three number fields all drive the same target
   const changeTarget = (next: number) => setTarget(clampTarget(next, direction));
+
+  // dragging the handle on the bar: map the pointer x within the track to a target.
+  // pointer capture (set on pointerdown) keeps the events coming even off the element,
+  // so getBoundingClientRect on the currentTarget stays the track the whole drag.
+  const targetFromPointer = (clientX: number, rect: DOMRect) => {
+    const pct = Math.min(Math.max((clientX - rect.left) / rect.width, 0), 1);
+    return clampTarget(Math.round(pct * OUTCOMES), direction);
+  };
+  const trackHandlers = {
+    onPointerDown: (e: React.PointerEvent) => {
+      if (autoRunning) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      setDragging(true);
+      setTarget(targetFromPointer(e.clientX, e.currentTarget.getBoundingClientRect()));
+    },
+    onPointerMove: (e: React.PointerEvent) => {
+      if (!dragging) return;
+      setTarget(targetFromPointer(e.clientX, e.currentTarget.getBoundingClientRect()));
+    },
+    onPointerUp: (e: React.PointerEvent) => {
+      setDragging(false);
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // capture may already be gone; nothing to release
+      }
+    },
+  };
   const changeWinChance = (chance: number) => {
     if (Number.isFinite(chance)) setTarget(targetForWinChance(chance, direction));
   };
@@ -144,6 +174,8 @@ export const useDiceServices = () => {
     changeWinChance,
     changeMultiplier,
     toggleDirection,
+    dragging,
+    trackHandlers,
     mode,
     setMode,
     autoCount,

--- a/src/pages/Dice/Dice.types.ts
+++ b/src/pages/Dice/Dice.types.ts
@@ -1,0 +1,26 @@
+import { useDiceServices } from "./Dice.services";
+import { Direction } from "./diceControls";
+
+export interface DiceRollResult {
+  betAmount: number;
+  target: number;
+  direction: Direction;
+  result: number; // 0..9999
+  resultValue: number; // 0.00..99.99
+  multiplier: number;
+  winChance: number;
+  won: boolean;
+  payout: number;
+  balance: number;
+  rollId: string | null;
+}
+
+export interface DiceHistoryEntry {
+  key: string;
+  resultValue: number;
+  won: boolean;
+  multiplier: number;
+  rollId: string | null;
+}
+
+export type DiceViewProps = ReturnType<typeof useDiceServices>;

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -157,39 +157,43 @@ const DiceView: React.FC<DiceViewProps> = ({
             ))}
           </div>
 
-          {/* the track: the bar itself is the target control, and the die rides just
-              above it, sliding to the result when a roll lands */}
+          {/* the track: the bar itself is the target control, wrapped in a thick dark
+              housing, with the result number + die riding over it */}
           <div className="px-2 pt-14 pb-1">
-            <div className="flex justify-between text-xs text-ink-muted mb-2 font-semibold">
+            <div className="flex justify-between text-xs text-ink-muted mb-2 font-semibold px-3">
               {TICKS.map((t) => (
                 <span key={t}>{t}</span>
               ))}
             </div>
-            <div
-              {...trackHandlers}
-              className="relative h-4 rounded-full cursor-pointer touch-none select-none"
-              style={{ background: winGradient }}
-            >
-              {/* the result die appears only after the first roll, sitting just over the bar */}
-              {last && (
-                <div
-                  className={`absolute bottom-full mb-2 -translate-x-1/2 flex flex-col items-center ${dragging ? "" : "transition-all duration-500 ease-out"}`}
-                  style={{ left: `${markerPct}%` }}
-                >
+            {/* thick rounded housing around the bar */}
+            <div className="bg-surface-deep rounded-full p-2.5 border border-line shadow-inner">
+              <div
+                {...trackHandlers}
+                className="relative h-3.5 rounded-full cursor-pointer touch-none select-none"
+                style={{ background: winGradient }}
+              >
+                {/* the result number + die appear only after the first roll, over the housing */}
+                {last && (
                   <div
-                    className={`w-12 h-12 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last.won ? "bg-green-500" : "bg-red-500"}`}
+                    className={`absolute bottom-full mb-3 -translate-x-1/2 flex flex-col items-center pointer-events-none ${dragging ? "" : "transition-all duration-500 ease-out"}`}
+                    style={{ left: `${markerPct}%` }}
                   >
-                    <span className="-rotate-45 text-white font-extrabold text-xs">
+                    <span
+                      className={`text-base font-extrabold leading-none mb-1 ${last.won ? "text-green-400" : "text-red-400"}`}
+                    >
                       {last.resultValue.toFixed(2)}
                     </span>
+                    <div
+                      className={`w-4 h-4 rotate-45 shadow ${last.won ? "bg-green-400" : "bg-red-400"}`}
+                    />
                   </div>
-                </div>
-              )}
-              {/* the draggable target handle, grabbable on the bar */}
-              <div
-                className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-9 bg-accent rounded shadow-md border-2 border-white/80 ${dragging ? "cursor-grabbing scale-110" : "cursor-grab"} transition-transform`}
-                style={{ left: `${targetPct}%` }}
-              />
+                )}
+                {/* the draggable target handle, grabbable on the bar */}
+                <div
+                  className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-8 bg-accent rounded shadow-md border-2 border-white/80 ${dragging ? "cursor-grabbing scale-110" : "cursor-grab"} transition-transform`}
+                  style={{ left: `${targetPct}%` }}
+                />
+              </div>
             </div>
           </div>
 

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -172,20 +172,19 @@ const DiceView: React.FC<DiceViewProps> = ({
                 className="relative h-3.5 rounded-full cursor-pointer touch-none select-none"
                 style={{ background: winGradient }}
               >
-                {/* the result number + die appear only after the first roll, over the housing */}
+                {/* the result die appears only after the first roll, over the housing */}
                 {last && (
                   <div
-                    className={`absolute bottom-full mb-3 -translate-x-1/2 flex flex-col items-center pointer-events-none ${dragging ? "" : "transition-all duration-500 ease-out"}`}
+                    className={`absolute bottom-full mb-2 -translate-x-1/2 flex flex-col items-center pointer-events-none ${dragging ? "" : "transition-all duration-500 ease-out"}`}
                     style={{ left: `${markerPct}%` }}
                   >
-                    <span
-                      className={`text-base font-extrabold leading-none mb-1 ${last.won ? "text-green-400" : "text-red-400"}`}
-                    >
-                      {last.resultValue.toFixed(2)}
-                    </span>
                     <div
-                      className={`w-4 h-4 rotate-45 shadow ${last.won ? "bg-green-400" : "bg-red-400"}`}
-                    />
+                      className={`w-12 h-12 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last.won ? "bg-green-500" : "bg-red-500"}`}
+                    >
+                      <span className="-rotate-45 text-white font-extrabold text-xs">
+                        {last.resultValue.toFixed(2)}
+                      </span>
+                    </div>
                   </div>
                 )}
                 {/* the draggable target handle, grabbable on the bar */}

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -1,0 +1,256 @@
+import Title from "../../components/Title";
+import Monetary from "../../components/Monetary";
+import { AUTO_COUNTS } from "./Dice.services";
+import { MAX_BET } from "./diceControls";
+import { DiceViewProps } from "./Dice.types";
+
+const TICKS = [0, 25, 50, 75, 100];
+const GREEN = "#22C55E";
+const RED = "#EF4444";
+
+// the marker sits at result/100 across the track; the win zone is green, the rest red
+const DiceView: React.FC<DiceViewProps> = ({
+  isLogged,
+  walletBalance,
+  betInput,
+  betValue,
+  setBetInput,
+  normalizeBet,
+  halveBet,
+  doubleBet,
+  target,
+  direction,
+  controls,
+  profitOnWin,
+  changeTarget,
+  changeWinChance,
+  changeMultiplier,
+  toggleDirection,
+  mode,
+  setMode,
+  autoCount,
+  setAutoCount,
+  autoRunning,
+  autoLeft,
+  startAuto,
+  stopAuto,
+  rolling,
+  roll,
+  last,
+  history,
+  openRoll,
+}) => {
+  const targetPct = target / 100;
+  const markerPct = last ? last.resultValue : 50;
+  // green fills the winning side: right of the target for "over", left for "under"
+  const winGradient =
+    direction === "over"
+      ? `linear-gradient(to right, ${RED} 0%, ${RED} ${targetPct}%, ${GREEN} ${targetPct}%, ${GREEN} 100%)`
+      : `linear-gradient(to right, ${GREEN} 0%, ${GREEN} ${targetPct}%, ${RED} ${targetPct}%, ${RED} 100%)`;
+
+  return (
+    <div className="w-screen flex flex-col items-center py-6 gap-6 px-4">
+      <Title title="Dice" />
+
+      <div className="flex flex-col lg:flex-row w-full max-w-[1100px] bg-surface rounded-lg overflow-hidden border border-line">
+        {/* control panel */}
+        <div className="lg:w-[320px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
+          <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
+            <button
+              onClick={() => setMode("manual")}
+              className={`flex-1 py-1.5 rounded ${mode === "manual" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
+            >
+              Manual
+            </button>
+            <button
+              onClick={() => setMode("auto")}
+              className={`flex-1 py-1.5 rounded ${mode === "auto" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
+            >
+              Auto
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
+            <span>Bet Amount</span>
+            <span><Monetary value={betValue} /></span>
+          </div>
+          <div className="flex">
+            <input
+              type="number"
+              value={betInput}
+              max={MAX_BET}
+              onChange={(e) => setBetInput(e.target.value.replace(/[^0-9]/g, ""))}
+              onBlur={normalizeBet}
+              disabled={autoRunning}
+              className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm disabled:opacity-50"
+            />
+            <button
+              onClick={halveBet}
+              disabled={autoRunning}
+              className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold disabled:opacity-50"
+            >
+              ½
+            </button>
+            <button
+              onClick={doubleBet}
+              disabled={autoRunning}
+              className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold disabled:opacity-50"
+            >
+              2×
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-1">
+            <span>Profit on Win</span>
+            <span className="text-accent-gold"><Monetary value={profitOnWin} showFraction /></span>
+          </div>
+
+          {mode === "auto" && (
+            <div className="flex flex-col gap-2 mt-1">
+              <span className="text-xs font-semibold text-ink-muted">Number of Bets</span>
+              <div className="grid grid-cols-4 gap-1">
+                {AUTO_COUNTS.map((n) => (
+                  <button
+                    key={n}
+                    onClick={() => setAutoCount(n)}
+                    disabled={autoRunning}
+                    className={`py-1.5 rounded text-sm font-semibold ${autoCount === n ? "bg-surface-raised text-white" : "bg-surface-nav text-ink-muted"} disabled:opacity-50`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {mode === "manual" ? (
+            <button
+              onClick={roll}
+              disabled={rolling}
+              className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full mt-2 disabled:opacity-40 transition-colors"
+            >
+              {isLogged ? "Roll Dice" : "Sign in to play"}
+            </button>
+          ) : (
+            <button
+              onClick={autoRunning ? stopAuto : startAuto}
+              className={`p-3 rounded font-bold w-full mt-2 transition-colors ${autoRunning ? "bg-red-500 hover:bg-red-400 text-white" : "bg-green-500 hover:bg-green-400 text-[#10241A]"}`}
+            >
+              {autoRunning ? `Stop (${autoLeft} left)` : isLogged ? `Start ${autoCount} Bets` : "Sign in to play"}
+            </button>
+          )}
+        </div>
+
+        {/* board */}
+        <div className="flex-1 flex flex-col p-6 gap-6">
+          {/* history chips */}
+          <div className="flex items-center justify-end gap-2 h-8 overflow-hidden">
+            {history.map((h) => (
+              <button
+                key={h.key}
+                onClick={() => h.rollId && openRoll(h.rollId)}
+                className={`px-2 py-1 rounded text-xs font-bold shrink-0 ${h.won ? "bg-green-500/20 text-green-400" : "bg-red-500/20 text-red-400"}`}
+              >
+                {h.resultValue.toFixed(2)}
+              </button>
+            ))}
+          </div>
+
+          {/* the die marker + result */}
+          <div className="relative h-24">
+            <div
+              className="absolute -translate-x-1/2 flex flex-col items-center transition-all duration-500 ease-out"
+              style={{ left: `${markerPct}%`, top: 0 }}
+            >
+              <div
+                className={`w-14 h-14 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last ? (last.won ? "bg-green-500" : "bg-red-500") : "bg-surface-raised"}`}
+              >
+                <span className="-rotate-45 text-white font-extrabold text-sm">
+                  {last ? last.resultValue.toFixed(2) : "?"}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* the track */}
+          <div className="px-2">
+            <div className="flex justify-between text-xs text-ink-muted mb-2 font-semibold">
+              {TICKS.map((t) => (
+                <span key={t}>{t}</span>
+              ))}
+            </div>
+            <div
+              className="relative h-3 rounded-full"
+              style={{ background: winGradient }}
+            >
+              {/* the target handle */}
+              <div
+                className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-4 h-7 bg-accent rounded shadow-md border-2 border-white/70"
+                style={{ left: `${targetPct}%` }}
+              />
+            </div>
+          </div>
+
+          {/* the three interlinked fields, Stake-style */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold text-ink-muted">Multiplier</span>
+              <input
+                type="number"
+                step="0.0001"
+                value={controls.multiplier}
+                onChange={(e) => changeMultiplier(Number(e.target.value))}
+                disabled={autoRunning}
+                className="p-2 bg-surface-nav border border-line rounded text-sm disabled:opacity-50"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold text-ink-muted">
+                Roll {direction === "over" ? "Over" : "Under"}
+              </span>
+              <button
+                onClick={toggleDirection}
+                disabled={autoRunning}
+                className="p-2 bg-surface-nav border border-line rounded text-sm flex items-center justify-between hover:bg-surface-raised disabled:opacity-50"
+              >
+                <span>{(target / 100).toFixed(2)}</span>
+                <span className="text-ink-muted text-xs">⇄</span>
+              </button>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold text-ink-muted">Win Chance</span>
+              <div className="relative">
+                <input
+                  type="number"
+                  step="0.01"
+                  value={Number(controls.winChance.toFixed(2))}
+                  onChange={(e) => changeWinChance(Number(e.target.value))}
+                  disabled={autoRunning}
+                  className="p-2 pr-7 bg-surface-nav border border-line rounded text-sm w-full disabled:opacity-50"
+                />
+                <span className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-muted text-xs">%</span>
+              </div>
+            </div>
+          </div>
+
+          {/* drag the target line directly (0.01 units; the 2%..98% band is [200, 9800]) */}
+          <input
+            type="range"
+            min={200}
+            max={9800}
+            value={target}
+            onChange={(e) => changeTarget(Number(e.target.value))}
+            disabled={autoRunning}
+            className="w-full accent-accent disabled:opacity-50"
+          />
+        </div>
+      </div>
+
+      <p className="text-ink-muted text-xs max-w-[640px] text-center">
+        Balance: <Monetary value={walletBalance} />. Every roll is provably fair. 99% RTP, 1% house edge.
+      </p>
+    </div>
+  );
+};
+
+export default DiceView;

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -8,7 +8,6 @@ const TICKS = [0, 25, 50, 75, 100];
 const GREEN = "#22C55E";
 const RED = "#EF4444";
 
-// the marker sits at result/100 across the track; the win zone is green, the rest red
 const DiceView: React.FC<DiceViewProps> = ({
   isLogged,
   walletBalance,
@@ -54,7 +53,6 @@ const DiceView: React.FC<DiceViewProps> = ({
       <Title title="Dice" />
 
       <div className="flex flex-col lg:flex-row w-full max-w-[1100px] bg-surface rounded-lg overflow-hidden border border-line">
-        {/* control panel */}
         <div className="lg:w-[320px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
           <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
             <button
@@ -142,9 +140,7 @@ const DiceView: React.FC<DiceViewProps> = ({
           )}
         </div>
 
-        {/* board */}
         <div className="flex-1 flex flex-col p-6 gap-6">
-          {/* history chips */}
           <div className="flex items-center justify-end gap-2 h-8 overflow-hidden">
             {history.map((h) => (
               <button
@@ -157,22 +153,18 @@ const DiceView: React.FC<DiceViewProps> = ({
             ))}
           </div>
 
-          {/* the track: the bar itself is the target control, wrapped in a thick dark
-              housing, with the result number + die riding over it */}
           <div className="px-2 pt-14 pb-1">
             <div className="flex justify-between text-xs text-ink-muted mb-2 font-semibold px-3">
               {TICKS.map((t) => (
                 <span key={t}>{t}</span>
               ))}
             </div>
-            {/* thick rounded housing around the bar */}
             <div className="bg-surface-deep rounded-full p-2.5 border border-line shadow-inner">
               <div
                 {...trackHandlers}
                 className="relative h-3.5 rounded-full cursor-pointer touch-none select-none"
                 style={{ background: winGradient }}
               >
-                {/* the result die appears only after the first roll, over the housing */}
                 {last && (
                   <div
                     className={`absolute bottom-full mb-2 -translate-x-1/2 flex flex-col items-center pointer-events-none ${dragging ? "" : "transition-all duration-500 ease-out"}`}
@@ -187,7 +179,6 @@ const DiceView: React.FC<DiceViewProps> = ({
                     </div>
                   </div>
                 )}
-                {/* the draggable target handle, grabbable on the bar */}
                 <div
                   className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-8 bg-accent rounded shadow-md border-2 border-white/80 ${dragging ? "cursor-grabbing scale-110" : "cursor-grab"} transition-transform`}
                   style={{ left: `${targetPct}%` }}
@@ -196,7 +187,6 @@ const DiceView: React.FC<DiceViewProps> = ({
             </div>
           </div>
 
-          {/* the three interlinked fields, Stake-style */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div className="flex flex-col gap-1">
               <span className="text-xs font-semibold text-ink-muted">Multiplier</span>

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -22,10 +22,11 @@ const DiceView: React.FC<DiceViewProps> = ({
   direction,
   controls,
   profitOnWin,
-  changeTarget,
   changeWinChance,
   changeMultiplier,
   toggleDirection,
+  dragging,
+  trackHandlers,
   mode,
   setMode,
   autoCount,
@@ -156,36 +157,35 @@ const DiceView: React.FC<DiceViewProps> = ({
             ))}
           </div>
 
-          {/* the die marker + result */}
-          <div className="relative h-24">
-            <div
-              className="absolute -translate-x-1/2 flex flex-col items-center transition-all duration-500 ease-out"
-              style={{ left: `${markerPct}%`, top: 0 }}
-            >
-              <div
-                className={`w-14 h-14 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last ? (last.won ? "bg-green-500" : "bg-red-500") : "bg-surface-raised"}`}
-              >
-                <span className="-rotate-45 text-white font-extrabold text-sm">
-                  {last ? last.resultValue.toFixed(2) : "?"}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* the track */}
-          <div className="px-2">
+          {/* the track: the bar itself is the target control, and the die rides just
+              above it, sliding to the result when a roll lands */}
+          <div className="px-2 pt-14 pb-1">
             <div className="flex justify-between text-xs text-ink-muted mb-2 font-semibold">
               {TICKS.map((t) => (
                 <span key={t}>{t}</span>
               ))}
             </div>
             <div
-              className="relative h-3 rounded-full"
+              {...trackHandlers}
+              className="relative h-4 rounded-full cursor-pointer touch-none select-none"
               style={{ background: winGradient }}
             >
-              {/* the target handle */}
+              {/* the result die, sitting just over the bar */}
               <div
-                className="absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-4 h-7 bg-accent rounded shadow-md border-2 border-white/70"
+                className={`absolute bottom-full mb-2 -translate-x-1/2 flex flex-col items-center ${dragging ? "" : "transition-all duration-500 ease-out"}`}
+                style={{ left: `${markerPct}%` }}
+              >
+                <div
+                  className={`w-12 h-12 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last ? (last.won ? "bg-green-500" : "bg-red-500") : "bg-surface-raised"}`}
+                >
+                  <span className="-rotate-45 text-white font-extrabold text-xs">
+                    {last ? last.resultValue.toFixed(2) : "?"}
+                  </span>
+                </div>
+              </div>
+              {/* the draggable target handle, grabbable on the bar */}
+              <div
+                className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-9 bg-accent rounded shadow-md border-2 border-white/80 ${dragging ? "cursor-grabbing scale-110" : "cursor-grab"} transition-transform`}
                 style={{ left: `${targetPct}%` }}
               />
             </div>
@@ -233,16 +233,6 @@ const DiceView: React.FC<DiceViewProps> = ({
             </div>
           </div>
 
-          {/* drag the target line directly (0.01 units; the 2%..98% band is [200, 9800]) */}
-          <input
-            type="range"
-            min={200}
-            max={9800}
-            value={target}
-            onChange={(e) => changeTarget(Number(e.target.value))}
-            disabled={autoRunning}
-            className="w-full accent-accent disabled:opacity-50"
-          />
         </div>
       </div>
 

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -170,19 +170,21 @@ const DiceView: React.FC<DiceViewProps> = ({
               className="relative h-4 rounded-full cursor-pointer touch-none select-none"
               style={{ background: winGradient }}
             >
-              {/* the result die, sitting just over the bar */}
-              <div
-                className={`absolute bottom-full mb-2 -translate-x-1/2 flex flex-col items-center ${dragging ? "" : "transition-all duration-500 ease-out"}`}
-                style={{ left: `${markerPct}%` }}
-              >
+              {/* the result die appears only after the first roll, sitting just over the bar */}
+              {last && (
                 <div
-                  className={`w-12 h-12 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last ? (last.won ? "bg-green-500" : "bg-red-500") : "bg-surface-raised"}`}
+                  className={`absolute bottom-full mb-2 -translate-x-1/2 flex flex-col items-center ${dragging ? "" : "transition-all duration-500 ease-out"}`}
+                  style={{ left: `${markerPct}%` }}
                 >
-                  <span className="-rotate-45 text-white font-extrabold text-xs">
-                    {last ? last.resultValue.toFixed(2) : "?"}
-                  </span>
+                  <div
+                    className={`w-12 h-12 rounded-lg rotate-45 flex items-center justify-center shadow-lg ${last.won ? "bg-green-500" : "bg-red-500"}`}
+                  >
+                    <span className="-rotate-45 text-white font-extrabold text-xs">
+                      {last.resultValue.toFixed(2)}
+                    </span>
+                  </div>
                 </div>
-              </div>
+              )}
               {/* the draggable target handle, grabbable on the bar */}
               <div
                 className={`absolute top-1/2 -translate-y-1/2 -translate-x-1/2 w-5 h-9 bg-accent rounded shadow-md border-2 border-white/80 ${dragging ? "cursor-grabbing scale-110" : "cursor-grab"} transition-transform`}

--- a/src/pages/Dice/diceControls.test.ts
+++ b/src/pages/Dice/diceControls.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+    OUTCOMES,
+    winCountFor,
+    winChanceFor,
+    multiplierFor,
+    clampTarget,
+    targetForWinChance,
+    targetForMultiplier,
+    controlsFor,
+} from "./diceControls";
+
+describe("dice controls", () => {
+    it("win chance and multiplier match the Stake table", () => {
+        expect(multiplierFor(4950)).toBe(2);
+        expect(winChanceFor(4950)).toBeCloseTo(49.5, 6);
+        expect(multiplierFor(200)).toBe(49.5);
+        expect(multiplierFor(2000)).toBe(4.95);
+        expect(multiplierFor(6500)).toBeCloseTo(1.5231, 4);
+    });
+
+    it("over and under targets are complementary about OUTCOMES", () => {
+        expect(winCountFor(5050, "over")).toBe(OUTCOMES - 5050);
+        expect(winCountFor(5050, "under")).toBe(5050);
+    });
+
+    it("targets round-trip through win chance and multiplier", () => {
+        const c = controlsFor(5050, "over");
+        expect(targetForWinChance(c.winChance, "over")).toBe(5050);
+        expect(targetForMultiplier(c.multiplier, "over")).toBe(5050);
+    });
+
+    it("clamps targets into the 2%..98% band per direction", () => {
+        // under: winCount == target, so [200, 9800]
+        expect(clampTarget(50, "under")).toBe(200);
+        expect(clampTarget(9999, "under")).toBe(9800);
+        // over: winCount == OUTCOMES - target, so target in [200, 9800] too
+        expect(clampTarget(50, "over")).toBe(200);
+        expect(clampTarget(9999, "over")).toBe(9800);
+    });
+
+    it("derived controls expose an exact payout-on-win", () => {
+        const c = controlsFor(5050, "over");
+        expect(c.multiplier).toBe(2);
+        expect(c.payoutOnWin(100)).toBe(200);
+    });
+});

--- a/src/pages/Dice/diceControls.ts
+++ b/src/pages/Dice/diceControls.ts
@@ -1,0 +1,64 @@
+// client mirror of backend/utils/diceMath.js: the same 10000-outcome space and 99% RTP
+// multiplier, so what the panel shows is exactly what the server will settle.
+export type Direction = "over" | "under";
+
+export const OUTCOMES = 10000;
+export const MIN_WIN_COUNT = 200; // 2% win chance
+export const MAX_WIN_COUNT = 9800; // 98% win chance
+export const MIN_BET = 1;
+export const MAX_BET = 20000;
+
+// target is stored in 0.01 units (50.50 -> 5050); this is the value the slider carries
+export const winCountFor = (target: number, direction: Direction) =>
+    direction === "under" ? target : OUTCOMES - target;
+
+export const targetForWinCount = (winCount: number, direction: Direction) =>
+    direction === "under" ? winCount : OUTCOMES - winCount;
+
+export const winChanceFor = (winCount: number) => (winCount / OUTCOMES) * 100;
+
+// 4-decimal multiplier, matching the server's fixed-point rounding to the cent
+export const multiplierFor = (winCount: number) =>
+    Math.round((99 * OUTCOMES * 10000) / 100 / winCount) / 10000;
+
+export const clampTarget = (target: number, direction: Direction) => {
+    const min = targetForWinCount(direction === "under" ? MIN_WIN_COUNT : MAX_WIN_COUNT, direction);
+    const max = targetForWinCount(direction === "under" ? MAX_WIN_COUNT : MIN_WIN_COUNT, direction);
+    return Math.min(Math.max(Math.round(target), Math.min(min, max)), Math.max(min, max));
+};
+
+// derive a target (0.01 units) from a desired win chance percent, clamped to the band
+export const targetForWinChance = (chancePercent: number, direction: Direction) => {
+    const winCount = Math.round((chancePercent / 100) * OUTCOMES);
+    const bounded = Math.min(Math.max(winCount, MIN_WIN_COUNT), MAX_WIN_COUNT);
+    return targetForWinCount(bounded, direction);
+};
+
+// derive a target from a desired multiplier (inverse of multiplierFor), clamped
+export const targetForMultiplier = (multiplier: number, direction: Direction) => {
+    const winCount = Math.round((99 * OUTCOMES) / 100 / multiplier);
+    const bounded = Math.min(Math.max(winCount, MIN_WIN_COUNT), MAX_WIN_COUNT);
+    return targetForWinCount(bounded, direction);
+};
+
+export interface DiceControlState {
+    target: number; // 0.01 units
+    direction: Direction;
+    winCount: number;
+    winChance: number; // percent
+    multiplier: number;
+    payoutOnWin: (bet: number) => number;
+}
+
+export const controlsFor = (target: number, direction: Direction): DiceControlState => {
+    const winCount = winCountFor(target, direction);
+    const multiplier = multiplierFor(winCount);
+    return {
+        target,
+        direction,
+        winCount,
+        winChance: winChanceFor(winCount),
+        multiplier,
+        payoutOnWin: (bet) => Math.floor(bet * multiplier * 100) / 100,
+    };
+};

--- a/src/pages/Dice/index.tsx
+++ b/src/pages/Dice/index.tsx
@@ -1,0 +1,9 @@
+import DiceView from "./Dice.view";
+import { useDiceServices } from "./Dice.services";
+
+const Dice = () => {
+  const service = useDiceServices();
+  return <DiceView {...service} />;
+};
+
+export default Dice;

--- a/src/pages/Home/GamesListing.tsx
+++ b/src/pages/Home/GamesListing.tsx
@@ -49,6 +49,12 @@ const GameListing: React.FC<GameListingProps> = ({ name, description }) => {
       image: "/images/blackjack.svg",
       link: "/blackjack",
     },
+    {
+      id: "8",
+      title: "Dice",
+      image: "/images/dice.svg",
+      link: "/dice",
+    },
   ];
   return (
     <section className="w-full flex flex-col py-6 items-center">

--- a/src/pages/ProvablyFair/ProvablyFair.view.tsx
+++ b/src/pages/ProvablyFair/ProvablyFair.view.tsx
@@ -32,7 +32,7 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
     <Title title="Provably Fair" />
 
     <p className="text-[#84819a] text-sm max-w-[640px] text-center">
-      Every case, upgrade, slot, plinko and blackjack roll is HMAC-SHA256 of your
+      Every case, upgrade, slot, plinko, blackjack and dice roll is HMAC-SHA256 of your
       client seed, a nonce, and a secret server seed we commit to up front.
     </p>
 
@@ -63,11 +63,11 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
           </span>
           <button
             onClick={doVerify}
-            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack")}
+            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice")}
             className="px-4 py-1.5 rounded bg-green-700 hover:bg-green-600 text-sm font-semibold disabled:opacity-50"
             title={
-              roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack"
-                ? "Auto-verify supported for case, plinko and blackjack rolls"
+              roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice"
+                ? "Auto-verify supported for case, plinko, blackjack and dice rolls"
                 : ""
             }
           >
@@ -118,7 +118,9 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
                 ? `Verified: the recomputed path lands in bin ${verify.recomputedBin} at x${verify.recomputedMultiplier}.`
                 : verify.recomputedDealerCards
                   ? `Verified: ${verify.recomputedPlayerCards?.length} player and ${verify.recomputedDealerCards.length} dealer cards replay to dealer ${verify.recomputedDealerTotal}, ${verify.recomputedOutcome}, payout ${verify.recomputedPayout}.`
-                  : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
+                  : verify.recomputedResult !== undefined
+                    ? `Verified: the recomputed roll is ${verify.recomputedResult}, a ${verify.recomputedWon ? "win" : "loss"} at x${verify.recomputedMultiplier}, payout ${verify.recomputedPayout}.`
+                    : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
               : `Not verified${verify.reason ? `: ${verify.reason}` : ""}.`}
           </div>
         )}

--- a/src/seo/routes.json
+++ b/src/seo/routes.json
@@ -44,6 +44,10 @@
       "title": "Plinko | KaniCasino",
       "description": "Drop a ball down the pegs and chase the golden edge bins. Provably fair, no real money involved."
     },
+    "/dice": {
+      "title": "Dice | KaniCasino",
+      "description": "Set your target, roll over or under, and chase up to 49.50x. Provably fair, no real money involved."
+    },
     "/battles": {
       "title": "Case Battles | KaniCasino",
       "description": "Open cases head to head against other players. Best total value takes the pot."

--- a/src/services/fair/FairServices.ts
+++ b/src/services/fair/FairServices.ts
@@ -22,7 +22,7 @@ export interface RollRange {
 
 export interface RollView {
   rollId: string;
-  game: "case" | "upgrade" | "slots" | "battle" | "plinko" | "blackjack";
+  game: "case" | "upgrade" | "slots" | "battle" | "plinko" | "blackjack" | "dice";
   clientSeed: string;
   serverSeedHash: string;
   serverSeed: string | null;
@@ -57,6 +57,11 @@ export interface VerifyResult {
   recomputedDealerTotal?: number;
   recomputedOutcome?: string;
   recomputedPayout?: number;
+  recomputedResult?: number;
+  recomputedWon?: boolean;
+  expectedResult?: number;
+  expectedWon?: boolean;
+  expectedPayout?: number;
 }
 
 export const getSeed = () => api.get<SeedState>("/fair/seed").then((r) => r.data);

--- a/src/services/games/GamesServices.ts
+++ b/src/services/games/GamesServices.ts
@@ -29,6 +29,11 @@ export async function dropPlinko(betAmount: number, risk: string) {
     return response.data;
 }
 
+export async function rollDice(betAmount: number, target: number, direction: "over" | "under") {
+    const response = await api.post(`/games/dice/`, { betAmount, target, direction });
+    return response.data;
+}
+
 export async function dealBlackjack(betAmount: number) {
     const response = await api.post(`/games/blackjack/deal`, { betAmount });
     return response.data;


### PR DESCRIPTION
A new Stake-style Dice game: pick a target 0-100, bet roll over or under, and chase up to 49.50x. HTTP single-request game modelled on Plinko.

## Game
- One provably-fair draw per bet: `result = floor(rollFloat * 10000)` (0.00-99.99). Under wins below the target, over wins at or above it, so the two directions are exactly complementary and every win chance is exact.
- 99% RTP at every setting (multiplier = 0.99 / win chance), win chance capped 2%-98% so the multiplier tops out at 49.50x. Payouts computed in integer cents, never a float. Reproduces the Stake multiplier table exactly.
- UI: an animated die that slides to the result along a red/green target track, plus the three interlinked controls (Multiplier / Roll Over-Under / Win Chance) and a draggable target. Manual play plus a simple auto-count (10/25/50/100), matching Plinko. Full autobet (on-win/on-loss/stop-on-profit/loss) is a planned follow-up.

## Everything a new game must touch
- Provably fair: nonce reserved up front, `Roll` recorded with `game: "dice"`, `DICE_ALGO_VERSION`, and a `verifyDiceRoll` that folds through the same `diceMath` the game uses, wired into the fair page's Verify button.
- Money: `chargeUser` before the roll, `creditUser` after, new `DICE_BET` / `DICE_WIN` types.
- All ledger consumers: `STAKE_TYPES`, missions and adminStats `WIN_TYPES`, `accounts` counterparty map, and the backoffice per-game P&L (`GAME_LINES` + `THEO_RTP` 0.99).
- Route with a per-user rate limiter, MVVM frontend page, `Routes.tsx`, home games listing (with a new dice icon), and SEO route meta.

## Tests
- Backend: `diceMath` unit (Stake table, complementary win conditions, exact payouts, validation band) and a `dicePF` integration suite (charge/settle/record, insufficient balance, bad inputs, distinct nonces, rotated-seed verify). Full backend suite green: 61 suites, 439 tests.
- Frontend: `diceControls` unit (round-trips, clamping). Unit, e2e, lint and build all green.
