### PR TITLE
Mines game: provably-fair grid with backoffice + danmaku theme

### DIFF
--- a/backend/__tests__/integration/minesPF.test.js
+++ b/backend/__tests__/integration/minesPF.test.js
@@ -1,0 +1,144 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Roll = require("../../models/Roll");
+const Seed = require("../../models/Seed");
+const Transaction = require("../../models/Transaction");
+const MinesGame = require("../../models/MinesGame");
+const { TX } = require("../../utils/economy");
+const { TILES, multiplierFor } = require("../../utils/minesMath");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  await Promise.all([Seed.syncIndexes(), Roll.syncIndexes(), MinesGame.syncIndexes()]);
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(walletBalance = 1000) {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+}
+
+const auth = (u) => ({ Authorization: `Bearer ${tokenFor(u)}` });
+const safeTilesOf = (mineSet) => {
+  const out = [];
+  for (let t = 0; t < TILES; t++) if (!mineSet.includes(t)) out.push(t);
+  return out;
+};
+
+test("start charges the bet, hides the mines, and one gem raises the multiplier", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+
+  const start = await request(app).post("/games/mines/start").set(h).send({ betAmount: 100, mineCount: 3 });
+  expect(start.status).toBe(200);
+  expect(start.body.mineSet).toBeNull(); // never leaks while active
+  expect(start.body.multiplier).toBe(1);
+  expect(start.body.canCashout).toBe(false);
+  expect((await User.findById(u._id)).walletBalance).toBe(900);
+
+  const game = await MinesGame.findOne({ userId: u._id, status: "active" });
+  const safe = safeTilesOf(game.mineSet)[0];
+
+  const reveal = await request(app).post("/games/mines/reveal").set(h).send({ tile: safe });
+  expect(reveal.status).toBe(200);
+  expect(reveal.body.gems).toBe(1);
+  expect(reveal.body.multiplier).toBeCloseTo(multiplierFor(3, 1), 8);
+  expect(reveal.body.canCashout).toBe(true);
+});
+
+test("cashing out pays bet times the multiplier and records a mines roll", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/mines/start").set(h).send({ betAmount: 100, mineCount: 3 });
+  const game = await MinesGame.findOne({ userId: u._id, status: "active" });
+  const [t1, t2] = safeTilesOf(game.mineSet);
+
+  await request(app).post("/games/mines/reveal").set(h).send({ tile: t1 });
+  await request(app).post("/games/mines/reveal").set(h).send({ tile: t2 });
+  const cash = await request(app).post("/games/mines/cashout").set(h).send({});
+  expect(cash.status).toBe(200);
+  expect(cash.body.status).toBe("cashed");
+  const expected = Math.round(100 * multiplierFor(3, 2) * 100) / 100;
+  expect(cash.body.payout).toBeCloseTo(expected, 6);
+  expect(cash.body.mineSet).toHaveLength(3); // revealed after the game ends
+
+  const after = await User.findById(u._id);
+  expect(after.walletBalance).toBeCloseTo(900 + expected, 6);
+  const win = await Transaction.findOne({ userId: u._id, type: TX.MINES_WIN });
+  expect(win.amount).toBeCloseTo(expected, 6);
+  expect(await Roll.findOne({ userId: u._id, game: "mines" })).toBeTruthy();
+});
+
+test("hitting a mine busts the game and pays nothing", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/mines/start").set(h).send({ betAmount: 100, mineCount: 5 });
+  const game = await MinesGame.findOne({ userId: u._id, status: "active" });
+
+  const bust = await request(app).post("/games/mines/reveal").set(h).send({ tile: game.mineSet[0] });
+  expect(bust.status).toBe(200);
+  expect(bust.body.status).toBe("busted");
+  expect(bust.body.payout).toBe(0);
+  expect(bust.body.bustTile).toBe(game.mineSet[0]);
+  expect((await User.findById(u._id)).walletBalance).toBe(900); // bet lost, nothing back
+  expect(await Transaction.findOne({ userId: u._id, type: TX.MINES_WIN })).toBeNull();
+});
+
+test("cashing out before any reveal is refused", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/mines/start").set(h).send({ betAmount: 100, mineCount: 3 });
+  const cash = await request(app).post("/games/mines/cashout").set(h).send({});
+  expect(cash.status).toBe(400);
+  expect((await MinesGame.findOne({ userId: u._id })).status).toBe("active");
+});
+
+test("only one active game per user, and bad inputs are refused", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/mines/start").set(h).send({ betAmount: 100, mineCount: 3 });
+  const second = await request(app).post("/games/mines/start").set(h).send({ betAmount: 100, mineCount: 3 });
+  expect(second.status).toBe(409);
+
+  const bad = await makeUser(1000);
+  const hb = auth(bad);
+  for (const body of [
+    { betAmount: 100, mineCount: 0 },
+    { betAmount: 100, mineCount: 25 },
+    { betAmount: 0, mineCount: 3 },
+    { betAmount: 20000, mineCount: 3 },
+    { betAmount: 10.5, mineCount: 3 },
+  ]) {
+    expect((await request(app).post("/games/mines/start").set(hb).send(body)).status).toBe(400);
+  }
+  expect((await User.findById(bad._id)).walletBalance).toBe(1000);
+});
+
+test("a rotated seed lets the verifier reproduce the game", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/mines/start").set(h).send({ betAmount: 50, mineCount: 4 });
+  const game = await MinesGame.findOne({ userId: u._id, status: "active" });
+  const [t1] = safeTilesOf(game.mineSet);
+  await request(app).post("/games/mines/reveal").set(h).send({ tile: t1 });
+  const cash = await request(app).post("/games/mines/cashout").set(h).send({});
+
+  const early = await request(app).get(`/fair/roll/${cash.body.rollId}/verify`);
+  expect(early.body.ok).toBe(false); // seed still hidden
+
+  await request(app).post("/fair/rotate").set(h).send({});
+
+  const verified = await request(app).get(`/fair/roll/${cash.body.rollId}/verify`);
+  expect(verified.body.ok).toBe(true);
+  expect(verified.body.commitmentValid).toBe(true);
+  expect(verified.body.recomputedMineSet).toEqual([...game.mineSet].sort((a, b) => a - b));
+  expect(verified.body.recomputedPayout).toBe(cash.body.payout);
+});

--- a/backend/__tests__/unit/minesMath.test.js
+++ b/backend/__tests__/unit/minesMath.test.js
@@ -1,0 +1,70 @@
+const {
+  TILES,
+  MAX_PAYOUT,
+  validMineCount,
+  validBet,
+  deriveMines,
+  multiplierFor,
+  payoutCentsFor,
+} = require("../../utils/minesMath");
+const { sha256 } = require("../../utils/hashChain");
+
+describe("mines math", () => {
+  test("mine derivation is deterministic and yields the right count of distinct tiles", () => {
+    const seed = sha256("mines-determinism");
+    const a = deriveMines(seed, "client", 0, 5);
+    const b = deriveMines(seed, "client", 0, 5);
+    expect(a).toEqual(b);
+    expect(a).toHaveLength(5);
+    expect(new Set(a).size).toBe(5);
+    expect(a.every((t) => t >= 0 && t < TILES)).toBe(true);
+    // sorted ascending
+    expect([...a].sort((x, y) => x - y)).toEqual(a);
+  });
+
+  test("mine counts stay within the grid across many seeds and counts", () => {
+    for (let i = 0; i < 200; i++) {
+      const seed = sha256(`mines:${i}`);
+      const count = 1 + (i % 24);
+      const mines = deriveMines(seed, "c", i, count);
+      expect(mines).toHaveLength(count);
+      expect(new Set(mines).size).toBe(count);
+    }
+  });
+
+  test("multiplier follows the Stake formula (99% RTP) and rises with each gem", () => {
+    expect(multiplierFor(3, 0)).toBe(1); // nothing revealed
+    // 3 mines, 1 gem: 0.99 * 25/22
+    expect(multiplierFor(3, 1)).toBeCloseTo(0.99 * (25 / 22), 8);
+    // 1 mine, revealing all 24 safe tiles telescopes to 0.99 * 25
+    expect(multiplierFor(1, 24)).toBeCloseTo(0.99 * 25, 6);
+    let prev = 0;
+    for (let g = 1; g <= 22; g++) {
+      const m = multiplierFor(3, g);
+      expect(m).toBeGreaterThan(prev);
+      prev = m;
+    }
+  });
+
+  test("payout is capped at the max win", () => {
+    // a mid config with many gems blows past the cap
+    const big = payoutCentsFor(10000, 12, 13);
+    expect(big).toBe(MAX_PAYOUT * 100);
+    // a modest one is not capped
+    const small = payoutCentsFor(100, 3, 1);
+    expect(small).toBe(Math.round(100 * multiplierFor(3, 1) * 100));
+  });
+
+  test("validation bounds", () => {
+    expect(validMineCount(1)).toBe(true);
+    expect(validMineCount(24)).toBe(true);
+    expect(validMineCount(0)).toBe(false);
+    expect(validMineCount(25)).toBe(false);
+    expect(validMineCount(3.5)).toBe(false);
+    expect(validBet(1)).toBe(true);
+    expect(validBet(10000)).toBe(true);
+    expect(validBet(0)).toBe(false);
+    expect(validBet(10001)).toBe(false);
+    expect(validBet(5.5)).toBe(false);
+  });
+});

--- a/backend/games/mines.js
+++ b/backend/games/mines.js
@@ -1,0 +1,344 @@
+const crypto = require("crypto");
+const MinesGame = require("../models/MinesGame");
+const Seed = require("../models/Seed");
+const Transaction = require("../models/Transaction");
+const { chargeUser, creditUser, TX } = require("../utils/economy");
+const seeds = require("../utils/seeds");
+const rolls = require("../utils/rolls");
+const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const {
+  MINES_ALGO_VERSION,
+  TILES,
+  validBet,
+  validMineCount,
+  deriveMines,
+  multiplierFor,
+  payoutCentsFor,
+} = require("../utils/minesMath");
+
+// a settled-but-unpaid cashout older than this is recovered from the ledger
+const PENDING_LEASE_MS = 60 * 1000;
+// a game idle this long is auto-abandoned by the sweep (it blocks deals and seed rotation)
+const STALE_GAME_MS = 30 * 60 * 1000;
+
+function httpError(status, message) {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+}
+
+function newGameId() {
+  return "MN" + String(crypto.randomInt(0, 1e9)).padStart(9, "0");
+}
+
+// the only serializer: the mine positions never leave the server while the game is
+// active; a finished game shows them for the reveal animation
+function publicView(game) {
+  const active = game.status === "active";
+  const gems = game.revealed.length;
+  return {
+    gameId: game.gameId,
+    status: game.status,
+    actionSeq: game.actionSeq,
+    betAmount: game.betAmount,
+    mineCount: game.mineCount,
+    revealed: game.revealed,
+    gems,
+    multiplier: game.multiplier,
+    // the next-gem multiplier drives the "reveal one more" hint in the ui
+    nextMultiplier: active ? multiplierFor(game.mineCount, gems + 1) : null,
+    canCashout: active && gems > 0,
+    mineSet: active ? null : game.mineSet,
+    bustTile: game.bustTile,
+    payout: active ? 0 : game.payout,
+    fair: {
+      clientSeed: game.clientSeed,
+      serverSeedHash: game.serverSeedHash,
+      nonce: game.nonce,
+    },
+    rollId: game.rollId || null,
+  };
+}
+
+async function loadActiveGame(userId) {
+  const game = await MinesGame.findOne({ userId, status: "active" });
+  if (!game) throw httpError(404, "No active game");
+  return game;
+}
+
+// credit a cashed game's payout exactly once, keyed on the ledger by meta.gameId, then
+// mark settlementDone. shared by the live cashout and the sweep.
+async function payCashout(game, io) {
+  if (game.payout > 0) {
+    const credited = await creditUser(game.userId, game.payout, game.payout, {
+      type: TX.MINES_WIN,
+      meta: { gameId: game.gameId, betAmount: game.betAmount, mineCount: game.mineCount, gems: game.revealed.length, payout: game.payout },
+    });
+    if (!credited) return false;
+    io.to(game.userId.toString()).emit("userDataUpdated", {
+      walletBalance: credited.walletBalance,
+      xp: credited.xp,
+      level: credited.level,
+    });
+  }
+  await MinesGame.updateOne({ _id: game._id }, { $set: { settlementDone: true } });
+  return true;
+}
+
+// audit record: written once at settlement, best-effort (money is already settled)
+async function recordGameRoll(game) {
+  try {
+    const seed = await Seed.findById(game.seedId).select("serverSeed");
+    const serverSeed = seed ? seed.serverSeed : null;
+    const rec = await rolls.recordRoll({
+      game: "mines",
+      userId: game.userId,
+      seedId: game.seedId,
+      clientSeed: game.clientSeed,
+      serverSeedHash: game.serverSeedHash,
+      nonce: game.nonce,
+      cursor: 0,
+      roll: serverSeed ? Math.floor(rollFloat(serverSeed, game.clientSeed, game.nonce, 0) * TOTAL) + 1 : 0,
+      total: TOTAL,
+      outcome: {
+        betAmount: game.betAmount,
+        mineCount: game.mineCount,
+        mineSet: game.mineSet,
+        revealed: game.revealed,
+        multiplier: game.multiplier,
+        payout: game.payout,
+        busted: game.status === "busted",
+        algoVersion: MINES_ALGO_VERSION,
+      },
+    });
+    await MinesGame.updateOne({ _id: game._id }, { $set: { rollId: rec.rollId } });
+    return rec.rollId;
+  } catch (recordError) {
+    console.error("mines roll record failed", recordError);
+    return null;
+  }
+}
+
+class MinesGameController {
+  static async start(userId, betAmount, mineCount, io) {
+    if (!validBet(betAmount)) throw httpError(400, "Invalid bet amount");
+    if (!validMineCount(mineCount)) throw httpError(400, "Invalid mine count");
+
+    // reserve the provably-fair nonce up front (atomic, never rolled back)
+    const reserved = await seeds.reserveNonces(userId, 1);
+    const nonce = reserved.startNonce;
+    const mineSet = deriveMines(reserved.serverSeed, reserved.clientSeed, nonce, mineCount);
+
+    // create before charging: an unfunded game is visible and the sweep voids it from
+    // the ledger, while a charge with no game would be silent lost money
+    let game = null;
+    for (let attempt = 0; attempt < 3 && !game; attempt++) {
+      try {
+        game = await MinesGame.create({
+          gameId: newGameId(),
+          userId,
+          betAmount,
+          mineCount,
+          mineSet,
+          seedId: reserved.seedId,
+          clientSeed: reserved.clientSeed,
+          serverSeedHash: reserved.serverSeedHash,
+          nonce,
+        });
+      } catch (e) {
+        if (e.code === 11000 && e.keyPattern && e.keyPattern.userId) {
+          throw httpError(409, "Game in progress");
+        }
+        if (e.code === 11000 && e.keyPattern && e.keyPattern.gameId) continue;
+        throw e;
+      }
+    }
+    if (!game) throw httpError(500, "Could not create game");
+
+    const player = await chargeUser(userId, betAmount, {
+      type: TX.MINES_BET,
+      meta: { gameId: game.gameId, betAmount, mineCount },
+    });
+    if (!player) {
+      await MinesGame.updateOne(
+        { _id: game._id, status: "active" },
+        { $set: { status: "voided", settlementDone: true } }
+      );
+      throw httpError(400, "Insufficient balance");
+    }
+
+    io.to(userId.toString()).emit("userDataUpdated", {
+      walletBalance: player.walletBalance,
+      xp: player.xp,
+      level: player.level,
+    });
+
+    return publicView(game);
+  }
+
+  static async reveal(userId, tile, io) {
+    if (!Number.isInteger(tile) || tile < 0 || tile >= TILES) {
+      throw httpError(400, "Invalid tile");
+    }
+    const game = await loadActiveGame(userId);
+    if (game.revealed.includes(tile) || game.mineSet.includes(tile)) {
+      // a mine, or an already-open tile: only a mine ends the game
+      if (game.mineSet.includes(tile) && !game.revealed.includes(tile)) {
+        const busted = await MinesGame.findOneAndUpdate(
+          { _id: game._id, status: "active", actionSeq: game.actionSeq },
+          {
+            $set: {
+              status: "busted",
+              bustTile: tile,
+              multiplier: 0,
+              payout: 0,
+              settledAt: new Date(),
+              settlementStartedAt: new Date(),
+              settlementDone: true, // a bust owes nothing
+            },
+            $inc: { actionSeq: 1 },
+          },
+          { new: true }
+        );
+        if (!busted) throw httpError(409, "Action already applied, refresh");
+        busted.rollId = await recordGameRoll(busted);
+        return publicView(busted);
+      }
+      throw httpError(400, "Tile already revealed");
+    }
+
+    const gems = game.revealed.length + 1;
+    const multiplier = multiplierFor(game.mineCount, gems);
+    // revealing every safe tile auto-cashes at the top multiplier
+    const allClear = gems === TILES - game.mineCount;
+    const update = allClear
+      ? {
+          $set: {
+            status: "cashed",
+            multiplier,
+            payout: payoutCentsFor(game.betAmount, game.mineCount, gems) / 100,
+            settledAt: new Date(),
+            settlementStartedAt: new Date(),
+          },
+          $push: { revealed: tile },
+          $inc: { actionSeq: 1 },
+        }
+      : { $set: { multiplier }, $push: { revealed: tile }, $inc: { actionSeq: 1 } };
+
+    const updated = await MinesGame.findOneAndUpdate(
+      { _id: game._id, status: "active", actionSeq: game.actionSeq },
+      update,
+      { new: true }
+    );
+    if (!updated) throw httpError(409, "Action already applied, refresh");
+
+    if (updated.status === "cashed") {
+      await payCashout(updated, io);
+      updated.rollId = await recordGameRoll(updated);
+    }
+    return publicView(updated);
+  }
+
+  static async cashout(userId, io) {
+    const game = await loadActiveGame(userId);
+    if (game.revealed.length === 0) throw httpError(400, "Reveal a tile before cashing out");
+
+    const payout = payoutCentsFor(game.betAmount, game.mineCount, game.revealed.length) / 100;
+    const cashed = await MinesGame.findOneAndUpdate(
+      { _id: game._id, status: "active", actionSeq: game.actionSeq },
+      {
+        $set: {
+          status: "cashed",
+          payout,
+          settledAt: new Date(),
+          settlementStartedAt: new Date(),
+        },
+        $inc: { actionSeq: 1 },
+      },
+      { new: true }
+    );
+    if (!cashed) throw httpError(409, "Action already applied, refresh");
+
+    await payCashout(cashed, io);
+    cashed.rollId = await recordGameRoll(cashed);
+    return publicView(cashed);
+  }
+
+  static async active(userId) {
+    const game = await MinesGame.findOne({ userId, status: "active" });
+    return game ? publicView(game) : null;
+  }
+}
+
+// recovery sweep, same lease + ledger discipline as the blackjack sweep: cashed-but-unpaid
+// games are paid from what the ledger is missing, missing rolls re-recorded, and long-idle
+// active games are abandoned (a bust owes nothing, so an idle game is just left as busted)
+async function sweepMinesGames(io) {
+  const now = Date.now();
+  const staleCutoff = new Date(now - STALE_GAME_MS);
+  const leaseCutoff = new Date(now - PENDING_LEASE_MS);
+  const ioSafe = io || { to: () => ({ emit: () => {} }) };
+
+  const unpaid = await MinesGame.find({
+    status: "cashed",
+    settlementDone: { $ne: true },
+    settlementStartedAt: { $lte: leaseCutoff },
+  }).limit(50);
+  for (const game of unpaid) {
+    try {
+      const alreadyPaid = await Transaction.exists({
+        userId: game.userId,
+        type: TX.MINES_WIN,
+        "meta.gameId": game.gameId,
+      });
+      if (alreadyPaid) {
+        await MinesGame.updateOne({ _id: game._id }, { $set: { settlementDone: true } });
+        continue;
+      }
+      await payCashout(game, ioSafe);
+    } catch (e) {
+      console.error("mines sweep (unpaid) failed", game.gameId, e);
+    }
+  }
+
+  const unrecorded = await MinesGame.find({
+    status: { $in: ["cashed", "busted"] },
+    settlementDone: true,
+    rollId: null,
+  }).limit(20);
+  for (const game of unrecorded) {
+    try {
+      await recordGameRoll(game);
+    } catch (e) {
+      console.error("mines sweep (roll) failed", game.gameId, e);
+    }
+  }
+
+  // a funded game left idle is abandoned as a bust; an unfunded one (crash between create
+  // and charge) is voided so nothing is owed
+  const stale = await MinesGame.find({ status: "active", updatedAt: { $lte: staleCutoff } }).limit(50);
+  for (const game of stale) {
+    try {
+      const funded = await Transaction.exists({
+        userId: game.userId,
+        type: TX.MINES_BET,
+        "meta.gameId": game.gameId,
+      });
+      const next = funded
+        ? { status: "busted", settledAt: new Date(), settlementStartedAt: new Date(), settlementDone: true }
+        : { status: "voided", settlementDone: true };
+      const swept = await MinesGame.findOneAndUpdate(
+        { _id: game._id, status: "active", actionSeq: game.actionSeq },
+        { $set: next, $inc: { actionSeq: 1 } },
+        { new: true }
+      );
+      if (swept && funded) await recordGameRoll(swept);
+    } catch (e) {
+      console.error("mines sweep (stale) failed", game.gameId, e);
+    }
+  }
+}
+
+module.exports = MinesGameController;
+module.exports.sweepMinesGames = sweepMinesGames;
+module.exports.publicView = publicView;

--- a/backend/index.js
+++ b/backend/index.js
@@ -73,6 +73,7 @@ const caseBattle = require("./games/caseBattle");
 const { recoverStuckRounds } = require("./utils/rounds");
 const { completeStuckBattles } = require("./games/battleEngine");
 const { sweepBlackjackHands } = require("./games/blackjack");
+const { sweepMinesGames } = require("./games/mines");
 const { probeTransactions, setTransactionsSupported } = require("./utils/economy");
 const userRoutes = require("./routes/userRoutes");
 const caseRoutes = require("./routes/caseRoutes");
@@ -153,6 +154,7 @@ const sweepRounds = ({ boot = false } = {}) => {
   recoverStuckRounds(io, coinFlip.winPayout, { boot }).catch((e) => console.log(e));
   completeStuckBattles(io, { boot }).catch((e) => console.log(e));
   sweepBlackjackHands(io).catch((e) => console.log(e));
+  sweepMinesGames(io).catch((e) => console.log(e));
 };
 sweepRounds({ boot: true });
 setInterval(() => sweepRounds({ boot: false }), 5 * 60 * 1000);

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -60,4 +60,17 @@ const diceRollLimiter = rateLimit({
   message: { message: "Too many rolls, slow down a little." },
 });
 
-module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter, diceRollLimiter };
+// mines fires one request per tile revealed, so a player clicking through a board needs
+// more headroom than a one-roll game; keyed per user (after auth)
+const minesActionLimiter = rateLimit({
+  windowMs: 10 * 1000,
+  max: 80,
+  keyGenerator: (req) => String(req.user._id),
+  skip: skipInTests,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  message: { message: "Too many actions, slow down a little." },
+});
+
+module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter, diceRollLimiter, minesActionLimiter };

--- a/backend/models/MinesGame.js
+++ b/backend/models/MinesGame.js
@@ -1,0 +1,46 @@
+const mongoose = require("mongoose");
+
+// one document per mines game: a multi-request HTTP game, so the in-progress state
+// (and the committed mine layout) must survive restarts. the serverSeed is never
+// stored here; it resolves through seedId and stays secret until the seed rotates.
+const minesGameSchema = new mongoose.Schema(
+  {
+    gameId: { type: String, required: true, unique: true },
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    status: { type: String, enum: ["active", "cashed", "busted", "voided"], default: "active" },
+    // compare-and-set token: every mutation filters on it and bumps it
+    actionSeq: { type: Number, default: 0 },
+
+    betAmount: { type: Number, required: true },
+    mineCount: { type: Number, required: true },
+    // the committed mine positions (0..24), fixed at deal time from the seed
+    mineSet: { type: [Number], required: true },
+    // tiles the player has revealed, in the order picked
+    revealed: { type: [Number], default: [] },
+
+    seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
+    clientSeed: { type: String, required: true },
+    serverSeedHash: { type: String, required: true },
+    nonce: { type: Number, required: true },
+
+    multiplier: { type: Number, default: 1 },
+    payout: { type: Number, default: 0 },
+    // the tile that ended it on a bust, for the reveal animation
+    bustTile: { type: Number, default: null },
+    settledAt: { type: Date, default: null },
+    settlementStartedAt: { type: Date, default: null },
+    settlementDone: { type: Boolean, default: false },
+    rollId: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+// at most one active game per user
+minesGameSchema.index(
+  { userId: 1 },
+  { unique: true, partialFilterExpression: { status: "active" } }
+);
+minesGameSchema.index({ status: 1, updatedAt: 1 });
+minesGameSchema.index({ userId: 1, createdAt: -1 });
+
+module.exports = mongoose.model("MinesGame", minesGameSchema);

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -8,7 +8,7 @@ const RollSchema = new mongoose.Schema(
   {
     rollId: { type: String, required: true, unique: true }, // public short id, e.g. R821872881
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice"], required: true },
+    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice", "mines"], required: true },
 
     seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
     clientSeed: { type: String, required: true },

--- a/backend/routes/fairRoutes.js
+++ b/backend/routes/fairRoutes.js
@@ -5,6 +5,7 @@ const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const Round = require("../models/Round");
 const BlackjackHand = require("../models/BlackjackHand");
+const MinesGame = require("../models/MinesGame");
 const { crashPointFromSeed } = require("../utils/crashMath");
 const { coinResultFromSeed } = require("../utils/coinMath");
 const { sha256 } = require("../utils/hashChain");
@@ -43,6 +44,10 @@ router.post("/rotate", isAuthenticated, async (req, res) => {
     // future draw of the live blackjack hand
     if (await BlackjackHand.exists({ userId: req.user._id, status: "active" })) {
       return res.status(409).json({ message: "Finish your blackjack hand before rotating" });
+    }
+    // and mid-mines would reveal the committed mine layout
+    if (await MinesGame.exists({ userId: req.user._id, status: "active" })) {
+      return res.status(409).json({ message: "Finish your mines game before rotating" });
     }
     const newClientSeed = req.body.clientSeed ? cleanClientSeed(req.body.clientSeed) : undefined;
     const { revealed, current } = await seeds.rotate(req.user._id, newClientSeed);

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
-const { plinkoDropLimiter, diceRollLimiter } = require("../middleware/rateLimit");
+const { plinkoDropLimiter, diceRollLimiter, minesActionLimiter } = require("../middleware/rateLimit");
 
 const User = require("../models/User");
 const Case = require("../models/Case");
@@ -11,6 +11,7 @@ const SlotGameController = require("../games/slot");
 const PlinkoGameController = require("../games/plinko");
 const BlackjackGameController = require("../games/blackjack");
 const DiceGameController = require("../games/dice");
+const MinesGameController = require("../games/mines");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const referrals = require("../utils/referrals");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
@@ -265,6 +266,21 @@ module.exports = (io) => {
   ));
   router.get("/blackjack/active", isAuthenticated, blackjackAction(
     async (req) => ({ hand: await BlackjackGameController.active(req.user._id) })
+  ));
+
+  // mines: a game spans several requests, so each action resolves the user's single
+  // active game; reuses the statused-error wrapper (409 = resync)
+  router.post("/mines/start", isAuthenticated, minesActionLimiter, blackjackAction(
+    (req) => MinesGameController.start(req.user._id, req.body.betAmount, req.body.mineCount, io)
+  ));
+  router.post("/mines/reveal", isAuthenticated, minesActionLimiter, blackjackAction(
+    (req) => MinesGameController.reveal(req.user._id, req.body.tile, io)
+  ));
+  router.post("/mines/cashout", isAuthenticated, minesActionLimiter, blackjackAction(
+    (req) => MinesGameController.cashout(req.user._id, io)
+  ));
+  router.get("/mines/active", isAuthenticated, blackjackAction(
+    async (req) => ({ game: await MinesGameController.active(req.user._id) })
   ));
 
   // recent coin flip results, so the page has a history the moment it loads. light and

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -41,6 +41,8 @@ const COUNTERPARTY_FOR_TYPE = {
   blackjack_refund: HOUSE,
   dice_bet: HOUSE,
   dice_win: HOUSE,
+  mines_bet: HOUSE,
+  mines_win: HOUSE,
   item_sell: HOUSE,
   market_order: ESCROW,
   market_order_refund: ESCROW,

--- a/backend/utils/adminStats.js
+++ b/backend/utils/adminStats.js
@@ -8,12 +8,12 @@ const { HOUSE, MINT, ESCROW, GENESIS } = require("./accounts");
 const PAGE_SIZE = 20;
 
 // KP-paying game wins and stake returns, for daily series and big-win surfacing
-const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.MINES_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 const REFUND_TYPES = [TX.CRASH_REFUND, TX.COINFLIP_REFUND, TX.BATTLE_REFUND, TX.BLACKJACK_PUSH, TX.BLACKJACK_REFUND];
 // KP printed to players outside the games
 const FAUCET_TYPES = [TX.SIGNUP, TX.BONUS, TX.MISSION_REWARD, TX.REFERRAL_BONUS, TX.REFERRAL_MILESTONE, TX.AD_REWARD];
 // designed edges per game, so the realized return can be judged against intent
-const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, blackjack: 0.9943, dice: 0.99, cases: 0.9, battles: 0.9 };
+const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, blackjack: 0.9943, dice: 0.99, mines: 0.99, cases: 0.9, battles: 0.9 };
 
 // window start, or null for all-time
 const sinceFor = (days) => {
@@ -49,6 +49,7 @@ const GAME_LINES = [
   { game: "plinko", bets: [TX.PLINKO_BET], outs: [TX.PLINKO_WIN] },
   { game: "blackjack", bets: [TX.BLACKJACK_BET], outs: [TX.BLACKJACK_WIN, TX.BLACKJACK_PUSH, TX.BLACKJACK_REFUND] },
   { game: "dice", bets: [TX.DICE_BET], outs: [TX.DICE_WIN] },
+  { game: "mines", bets: [TX.MINES_BET], outs: [TX.MINES_WIN] },
   { game: "cases", bets: [TX.CASE_OPEN], outs: [] },
   { game: "battles", bets: [TX.BATTLE_ENTRY], outs: [TX.BATTLE_REFUND] },
 ];

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -29,6 +29,8 @@ const TX = {
   BLACKJACK_REFUND: "blackjack_refund", // stake returned when a deal is voided
   DICE_BET: "dice_bet",
   DICE_WIN: "dice_win",
+  MINES_BET: "mines_bet",
+  MINES_WIN: "mines_win",
   MARKET_BUY: "market_buy",
   MARKET_SALE: "market_sale",
   MARKET_FEE: "market_fee", // the house cut on a settled trade, credited to HOUSE
@@ -46,7 +48,7 @@ const TX = {
 };
 
 // every KP put at risk on a game; missions and referral commission both count these
-const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BLACKJACK_BET, TX.DICE_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
+const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BLACKJACK_BET, TX.DICE_BET, TX.MINES_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 function calculateXPForLevel(level) {
   return Math.floor(BASE_XP * Math.pow(GROWTH_RATE, level - 1));

--- a/backend/utils/minesMath.js
+++ b/backend/utils/minesMath.js
@@ -1,0 +1,71 @@
+const { rollFloat } = require("./provablyFair");
+
+// bump when the mine derivation or the multiplier formula changes; the verifier refuses
+// other versions
+const MINES_ALGO_VERSION = 1;
+
+const TILES = 25; // 5x5 grid
+const MIN_MINES = 1;
+const MAX_MINES = 24; // at least one gem must remain
+const MIN_BET = 1;
+const MAX_BET = 10000;
+// some mid configs exceed a million-times multiplier; the payout is capped so the max
+// win stays bounded like the other games
+const MAX_PAYOUT = 1_000_000;
+const RTP = 0.99;
+
+function validMineCount(mineCount) {
+  return Number.isInteger(mineCount) && mineCount >= MIN_MINES && mineCount <= MAX_MINES;
+}
+
+function validBet(betAmount) {
+  return Number.isInteger(betAmount) && betAmount >= MIN_BET && betAmount <= MAX_BET;
+}
+
+// derive the mine positions deterministically from the seed: a partial Fisher-Yates over
+// [0..24] using one draw per placed mine, so the layout is fixed at deal time and any
+// third party reproduces it from the revealed seed. returns a sorted array of indices.
+function deriveMines(serverSeed, clientSeed, nonce, mineCount) {
+  const order = Array.from({ length: TILES }, (_, i) => i);
+  for (let i = 0; i < mineCount; i++) {
+    const j = i + Math.floor(rollFloat(serverSeed, clientSeed, nonce, i) * (TILES - i));
+    const tmp = order[i];
+    order[i] = order[j];
+    order[j] = tmp;
+  }
+  return order.slice(0, mineCount).sort((a, b) => a - b);
+}
+
+// fair multiplier for revealing `gems` safe tiles with `mineCount` mines, times the RTP.
+// at pick i there are (TILES - i) tiles, (TILES - mineCount - i) of them safe, so the
+// survival probability is the product of those ratios and the fair multiplier is its
+// inverse. returns 1 for zero gems (nothing revealed yet).
+function multiplierFor(mineCount, gems) {
+  let m = 1;
+  for (let i = 0; i < gems; i++) {
+    m *= (TILES - i) / (TILES - mineCount - i);
+  }
+  return gems === 0 ? 1 : RTP * m;
+}
+
+// payout in whole cents for a cashout, capped at MAX_PAYOUT
+function payoutCentsFor(betAmount, mineCount, gems) {
+  const raw = betAmount * multiplierFor(mineCount, gems);
+  return Math.min(Math.round(raw * 100), MAX_PAYOUT * 100);
+}
+
+module.exports = {
+  MINES_ALGO_VERSION,
+  TILES,
+  MIN_MINES,
+  MAX_MINES,
+  MIN_BET,
+  MAX_BET,
+  MAX_PAYOUT,
+  RTP,
+  validMineCount,
+  validBet,
+  deriveMines,
+  multiplierFor,
+  payoutCentsFor,
+};

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -8,7 +8,7 @@ const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
 const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 
 // a "big win" is any single game payout; pushes and refunds are returned stakes, not wins
-const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.MINES_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 
 // missions currently offered; a disabled one (active:false) stays defined but is
 // never shown, announced, or claimable

--- a/backend/utils/rolls.js
+++ b/backend/utils/rolls.js
@@ -6,6 +6,7 @@ const { roll: computeRoll, pickFromRanges, hashServerSeed } = require("./provabl
 const { PAYOUTS: PLINKO_PAYOUTS, PLINKO_ALGO_VERSION, derivePath, binFromPath } = require("./plinkoMath");
 const { BLACKJACK_ALGO_VERSION, replayHand } = require("./blackjackMath");
 const { DICE_ALGO_VERSION, resolveRoll: resolveDiceRoll } = require("./diceMath");
+const { MINES_ALGO_VERSION, deriveMines, multiplierFor: minesMultiplierFor, payoutCentsFor: minesPayoutCentsFor } = require("./minesMath");
 const { rollFloat } = require("./provablyFair");
 
 function generateRollId() {
@@ -232,6 +233,55 @@ async function verifyDiceRoll(rollId) {
   };
 }
 
+// recompute a mines game from its public inputs: re-derive the committed mine layout,
+// confirm no revealed tile was a mine (unless it busted on the last one), and re-price
+// the payout. folds through the same minesMath the game uses.
+async function verifyMinesRoll(rollId) {
+  const v = await getRollForVerify(rollId);
+  if (!v || v.game !== "mines") return { ok: false, reason: "not a mines roll" };
+  if (!v.serverSeed) return { ok: false, reason: "server seed not revealed yet" };
+
+  const outcome = v.outcome || {};
+  if (outcome.algoVersion !== MINES_ALGO_VERSION) {
+    return { ok: false, reason: "algorithm version superseded" };
+  }
+
+  const commitmentValid = hashServerSeed(v.serverSeed) === v.serverSeedHash;
+  const mineSet = deriveMines(v.serverSeed, v.clientSeed, v.nonce, outcome.mineCount);
+  const mineSetMatches = JSON.stringify(mineSet) === JSON.stringify((outcome.mineSet || []).slice().sort((a, b) => a - b));
+
+  const revealed = outcome.revealed || [];
+  const busted = !!outcome.busted;
+  // on a bust the last revealed tile is the mine and the rest are gems; on a cashout
+  // every revealed tile must be a gem
+  const safeReveals = busted ? revealed.slice(0, -1) : revealed;
+  const gemsAllSafe = safeReveals.every((t) => !mineSet.includes(t));
+  const bustTileIsMine = busted ? mineSet.includes(revealed[revealed.length - 1]) : true;
+
+  const gems = safeReveals.length;
+  const expectedPayout = busted ? 0 : minesPayoutCentsFor(outcome.betAmount, outcome.mineCount, gems) / 100;
+  const expectedMultiplier = busted ? 0 : minesMultiplierFor(outcome.mineCount, gems);
+
+  const ok =
+    commitmentValid &&
+    mineSetMatches &&
+    gemsAllSafe &&
+    bustTileIsMine &&
+    expectedPayout === outcome.payout;
+
+  return {
+    ok,
+    commitmentValid,
+    recomputedMineSet: mineSet,
+    recomputedGems: gems,
+    recomputedMultiplier: expectedMultiplier,
+    recomputedPayout: expectedPayout,
+    recomputedBusted: busted,
+    expectedMineSet: outcome.mineSet,
+    expectedPayout: outcome.payout,
+  };
+}
+
 // route a verify request to the game's reference verifier
 async function verifyRoll(rollId) {
   const r = await Roll.findOne({ rollId }).select("game").lean();
@@ -240,6 +290,7 @@ async function verifyRoll(rollId) {
   if (r.game === "plinko") return verifyPlinkoRoll(rollId);
   if (r.game === "blackjack") return verifyBlackjackRoll(rollId);
   if (r.game === "dice") return verifyDiceRoll(rollId);
+  if (r.game === "mines") return verifyMinesRoll(rollId);
   return { ok: false, reason: "no server-side verifier for this game" };
 }
 
@@ -252,5 +303,6 @@ module.exports = {
   verifyPlinkoRoll,
   verifyBlackjackRoll,
   verifyDiceRoll,
+  verifyMinesRoll,
   verifyRoll,
 };

--- a/public/images/mines.svg
+++ b/public/images/mines.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 348">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#221f3d"/>
+      <stop offset="1" stop-color="#151225"/>
+    </linearGradient>
+    <linearGradient id="star" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffe680"/>
+      <stop offset="1" stop-color="#f2b705"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="348" rx="14" fill="url(#bg)"/>
+  <g>
+    <rect x="40" y="70" width="48" height="48" rx="8" fill="#281d3f"/>
+    <rect x="96" y="70" width="48" height="48" rx="8" fill="#281d3f"/>
+    <rect x="152" y="70" width="48" height="48" rx="8" fill="#3a2c5c"/>
+    <rect x="40" y="126" width="48" height="48" rx="8" fill="#3a2c5c"/>
+    <rect x="96" y="126" width="48" height="48" rx="8" fill="#281d3f"/>
+    <rect x="152" y="126" width="48" height="48" rx="8" fill="#281d3f"/>
+    <rect x="40" y="182" width="48" height="48" rx="8" fill="#281d3f"/>
+    <rect x="96" y="182" width="48" height="48" rx="8" fill="#3a2c5c"/>
+    <rect x="152" y="182" width="48" height="48" rx="8" fill="#281d3f"/>
+  </g>
+  <path fill="url(#star)" stroke="#7a5c00" stroke-width="1.5" transform="translate(120 94) scale(1.5)" d="M0 -11l2.6 6.3 6.8.5-5.2 4.4 1.7 6.6L0 4.9 -5.7 8.3l1.7-6.6L-9.2 -2.7l6.8-.5z"/>
+  <g fill="#ef4444" transform="translate(64 150) scale(1.4)">
+    <circle cx="0" cy="0" r="6"/>
+    <path d="M0 0 L11 0 L6 3 Z"/><path d="M0 0 L0 11 L-3 6 Z"/><path d="M0 0 L-11 0 L-6 -3 Z"/><path d="M0 0 L0 -11 L3 -6 Z"/>
+    <path d="M0 0 L8 8 L3 6 Z"/><path d="M0 0 L-8 8 L-6 3 Z"/><path d="M0 0 L-8 -8 L-3 -6 Z"/><path d="M0 0 L8 -8 L6 -3 Z"/>
+  </g>
+  <text x="128" y="272" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="bold" fill="#e1dde9" letter-spacing="5">MINES</text>
+</svg>

--- a/public/images/mines.svg
+++ b/public/images/mines.svg
@@ -4,9 +4,9 @@
       <stop offset="0" stop-color="#221f3d"/>
       <stop offset="1" stop-color="#151225"/>
     </linearGradient>
-    <linearGradient id="star" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#ffe680"/>
-      <stop offset="1" stop-color="#f2b705"/>
+    <linearGradient id="gem" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7bffbe"/>
+      <stop offset="1" stop-color="#17c964"/>
     </linearGradient>
   </defs>
   <rect width="256" height="348" rx="14" fill="url(#bg)"/>
@@ -21,11 +21,16 @@
     <rect x="96" y="182" width="48" height="48" rx="8" fill="#3a2c5c"/>
     <rect x="152" y="182" width="48" height="48" rx="8" fill="#281d3f"/>
   </g>
-  <path fill="url(#star)" stroke="#7a5c00" stroke-width="1.5" transform="translate(120 94) scale(1.5)" d="M0 -11l2.6 6.3 6.8.5-5.2 4.4 1.7 6.6L0 4.9 -5.7 8.3l1.7-6.6L-9.2 -2.7l6.8-.5z"/>
-  <g fill="#ef4444" transform="translate(64 150) scale(1.4)">
-    <circle cx="0" cy="0" r="6"/>
-    <path d="M0 0 L11 0 L6 3 Z"/><path d="M0 0 L0 11 L-3 6 Z"/><path d="M0 0 L-11 0 L-6 -3 Z"/><path d="M0 0 L0 -11 L3 -6 Z"/>
-    <path d="M0 0 L8 8 L3 6 Z"/><path d="M0 0 L-8 8 L-6 3 Z"/><path d="M0 0 L-8 -8 L-3 -6 Z"/><path d="M0 0 L8 -8 L6 -3 Z"/>
+  <g stroke="#0c6b39" stroke-width="1" stroke-linejoin="round" transform="translate(144 78) scale(1.5)">
+    <polygon points="6,3 18,3 22,9 12,22 2,9" fill="url(#gem)"/>
+    <path d="M2 9h20M6 3l2 6-2 0M18 3l-2 6 2 0M8 9l4 13 4-13" fill="none" opacity="0.5"/>
+  </g>
+  <g transform="translate(52 140) scale(1.5)">
+    <circle cx="11" cy="14" r="7" fill="#161421"/>
+    <circle cx="8.5" cy="11.5" r="2" fill="#3a3550"/>
+    <rect x="12" y="4" width="3" height="4" rx="1" fill="#5a5470" transform="rotate(-20 13 6)"/>
+    <path d="M15 5c3-2 4 1 6-1" fill="none" stroke="#8a8398" stroke-width="1.2" stroke-linecap="round"/>
+    <circle cx="21" cy="4" r="1.6" fill="#eab308"/>
   </g>
   <text x="128" y="272" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="bold" fill="#e1dde9" letter-spacing="5">MINES</text>
 </svg>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -10,6 +10,7 @@ import Slot from "./pages/Slot/Slot";
 import Plinko from "./pages/Plinko";
 import Blackjack from "./pages/Blackjack";
 import Dice from "./pages/Dice";
+import Mines from "./pages/Mines";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
 import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
@@ -32,6 +33,7 @@ const defaultRoutes = (
     <Route path="/plinko" element={<Plinko />} />
     <Route path="/blackjack" element={<Blackjack />} />
     <Route path="/dice" element={<Dice />} />
+    <Route path="/mines" element={<Mines />} />
     <Route path="/battles" element={<Battles />} />
     <Route path="/battles/:id" element={<BattleRoom />} />
     <Route path="/provably-fair" element={<ProvablyFair />} />

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -43,6 +43,9 @@ const GAME_LABELS: Record<string, string> = {
   coinflip: "Coin Flip",
   slots: "Slots",
   plinko: "Plinko",
+  blackjack: "Blackjack",
+  dice: "Dice",
+  mines: "Mines",
   cases: "Case openings",
   battles: "Case battles",
 };
@@ -70,8 +73,10 @@ const label = (type: string) => LINE_LABELS[type] || type.replace(/_/g, " ");
 
 const netClass = (n: number) => (n > 0 ? "text-green-400" : n < 0 ? "text-red-400" : "text-ink-soft");
 
-// KP-paying games can be judged against their designed return; item games cannot
-const KP_GAMES = new Set(["crash", "coinflip", "slots", "plinko"]);
+// KP-paying games can be judged against their designed return; item games (cases,
+// battles) pay in items, so they have no KP RTP. listing the exceptions keeps new KP
+// games from silently falling through as item games.
+const ITEM_GAMES = new Set(["cases", "battles"]);
 const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
 const rtpClass = (actual: number, theo: number | null, wagered: number) => {
   if (theo === null || wagered < 10000) return "text-ink-soft";
@@ -374,7 +379,7 @@ const BackofficeView: React.FC<Props> = ({
                   </thead>
                   <tbody>
                     {games.games.map((g) => {
-                      const kpGame = KP_GAMES.has(g.game);
+                      const kpGame = !ITEM_GAMES.has(g.game);
                       const actual = kpGame && g.wagered > 0 ? g.paidOut / g.wagered : null;
                       return (
                         <tr key={g.game} className="border-t border-line">
@@ -384,7 +389,7 @@ const BackofficeView: React.FC<Props> = ({
                           <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.wagered} /></td>
                           <td className="py-3 pr-4 text-ink-soft"><Monetary value={g.paidOut} /></td>
                           <td className={`py-3 pr-4 font-semibold ${actual !== null ? rtpClass(actual, g.theoRtp, g.wagered) : "text-ink-muted"}`}>
-                            {actual !== null ? pct(actual) : "items"}
+                            {actual !== null ? pct(actual) : kpGame ? "-" : "items"}
                           </td>
                           <td className="py-3 pr-4 text-ink-muted">{kpGame && g.theoRtp ? pct(g.theoRtp) : "-"}</td>
                           <td className="py-3 pr-4 text-ink-soft">{g.biggestWin > 0 ? <Monetary value={g.biggestWin} /> : "-"}</td>

--- a/src/pages/Home/GamesListing.tsx
+++ b/src/pages/Home/GamesListing.tsx
@@ -55,6 +55,12 @@ const GameListing: React.FC<GameListingProps> = ({ name, description }) => {
       image: "/images/dice.svg",
       link: "/dice",
     },
+    {
+      id: "9",
+      title: "Mines",
+      image: "/images/mines.svg",
+      link: "/mines",
+    },
   ];
   return (
     <section className="w-full flex flex-col py-6 items-center">

--- a/src/pages/Mines/Mines.services.ts
+++ b/src/pages/Mines/Mines.services.ts
@@ -1,0 +1,218 @@
+import { useContext, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import UserContext from "../../UserContext";
+import {
+  cashoutMines,
+  getActiveMinesGame,
+  revealMines,
+  startMines,
+} from "../../services/games/GamesServices";
+import { MAX_BET, MIN_BET, MIN_MINES, TILES, gemsFor, payoutFor } from "./minesGrid";
+import { MinesGameState } from "./Mines.types";
+
+const DEFAULT_BET = 10;
+const DEFAULT_MINES = 3;
+const HISTORY_SIZE = 10;
+const AUTO_STEP_MS = 320; // paced so an auto run reads as a sequence of picks
+export const AUTO_COUNTS = [10, 25, 50, 100];
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export const useMinesServices = () => {
+  const { userData, toogleUserFlow } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
+  const [mineCount, setMineCount] = useState<number>(DEFAULT_MINES);
+  const [game, setGame] = useState<MinesGameState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [history, setHistory] = useState<{ key: string; won: boolean; multiplier: number; payout: number; rollId: string | null }[]>([]);
+  const [mode, setMode] = useState<"manual" | "auto">("manual");
+  const [autoCount, setAutoCount] = useState<number>(AUTO_COUNTS[0]);
+  const [autoPicks, setAutoPicks] = useState<number>(3);
+  const [autoRunning, setAutoRunning] = useState(false);
+  const [autoLeft, setAutoLeft] = useState(0);
+
+  const seq = useRef(0);
+  const gameRef = useRef<MinesGameState | null>(null);
+  gameRef.current = game;
+  const autoStop = useRef(false);
+
+  const betValue = Math.min(Math.max(Math.floor(Number(betInput)) || MIN_BET, MIN_BET), MAX_BET);
+  const active = game?.status === "active";
+  const gems = game?.gems ?? 0;
+  const currentPayout = active && gems > 0 ? payoutFor(betValue, mineCount, gems) : 0;
+
+  // resume an in-progress game so a reload does not strand a live bet
+  useEffect(() => {
+    if (userData == null) return;
+    getActiveMinesGame()
+      .then((res) => {
+        if (res?.game) {
+          setGame(res.game);
+          setMineCount(res.game.mineCount);
+          setBetInput(String(res.game.betAmount));
+        }
+      })
+      .catch(() => setGame(null));
+  }, [userData]);
+
+  const recordEnd = (g: MinesGameState) => {
+    seq.current += 1;
+    setHistory((h) =>
+      [{ key: `m${seq.current}`, won: g.status === "cashed", multiplier: g.multiplier, payout: g.payout, rollId: g.rollId }, ...h].slice(0, HISTORY_SIZE)
+    );
+  };
+
+  const start = async (): Promise<MinesGameState | null> => {
+    if (userData == null) {
+      toogleUserFlow(true);
+      return null;
+    }
+    if (userData.walletBalance < betValue) {
+      toast.error("Insufficient funds", { theme: "dark" });
+      return null;
+    }
+    setBusy(true);
+    try {
+      const g: MinesGameState = await startMines(betValue, mineCount);
+      setGame(g);
+      return g;
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Could not start the game", { theme: "dark" });
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reveal = async (tile: number): Promise<MinesGameState | null> => {
+    const g = gameRef.current;
+    if (!g || g.status !== "active" || g.revealed.includes(tile) || busy) return null;
+    setBusy(true);
+    try {
+      const next: MinesGameState = await revealMines(tile);
+      setGame(next);
+      if (next.status !== "active") recordEnd(next);
+      return next;
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Could not reveal the tile", { theme: "dark" });
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cashout = async (): Promise<MinesGameState | null> => {
+    const g = gameRef.current;
+    if (!g || g.status !== "active" || g.gems === 0 || busy) return null;
+    setBusy(true);
+    try {
+      const next: MinesGameState = await cashoutMines();
+      setGame(next);
+      recordEnd(next);
+      return next;
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Could not cash out", { theme: "dark" });
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const randomTile = () => {
+    const g = gameRef.current;
+    if (!g || g.status !== "active") return;
+    const covered = [];
+    for (let t = 0; t < TILES; t++) if (!g.revealed.includes(t)) covered.push(t);
+    if (!covered.length) return;
+    const pick = covered[Math.floor(Math.random() * covered.length)];
+    reveal(pick);
+  };
+
+  const stopAuto = () => {
+    autoStop.current = true;
+    setAutoRunning(false);
+    setAutoLeft(0);
+  };
+
+  // simple auto: each round reveals `autoPicks` random tiles, cashing out if it survives
+  // them and moving on if it busts. sequential so the board animates one pick at a time.
+  const startAuto = async () => {
+    if (autoRunning) return;
+    if (userData == null) {
+      toogleUserFlow(true);
+      return;
+    }
+    autoStop.current = false;
+    setAutoRunning(true);
+    let left = autoCount;
+    setAutoLeft(left);
+    while (left > 0 && !autoStop.current) {
+      const started = await start();
+      if (!started) break;
+      await wait(AUTO_STEP_MS);
+      let g: MinesGameState | null = started;
+      let picks = 0;
+      const target = Math.min(autoPicks, gemsFor(mineCount));
+      while (g && g.status === "active" && picks < target && !autoStop.current) {
+        const covered = [];
+        for (let t = 0; t < TILES; t++) if (!g.revealed.includes(t)) covered.push(t);
+        g = await reveal(covered[Math.floor(Math.random() * covered.length)]);
+        picks += 1;
+        await wait(AUTO_STEP_MS);
+      }
+      if (g && g.status === "active" && !autoStop.current) {
+        await cashout();
+        await wait(AUTO_STEP_MS);
+      }
+      left -= 1;
+      setAutoLeft(left);
+    }
+    setAutoRunning(false);
+    setAutoLeft(0);
+  };
+
+  useEffect(() => () => { autoStop.current = true; }, []);
+
+  const changeMineCount = (n: number) => {
+    if (active) return;
+    setMineCount(Math.min(Math.max(Math.floor(n) || MIN_MINES, MIN_MINES), TILES - 1));
+  };
+
+  return {
+    isLogged: userData != null,
+    walletBalance: userData?.walletBalance ?? 0,
+    betInput,
+    betValue,
+    setBetInput,
+    normalizeBet: () => setBetInput(String(betValue)),
+    halveBet: () => setBetInput(String(Math.max(MIN_BET, Math.floor(betValue / 2)))),
+    doubleBet: () => setBetInput(String(Math.min(MAX_BET, betValue * 2))),
+    mineCount,
+    changeMineCount,
+    gemsCount: gemsFor(mineCount),
+    game,
+    active,
+    busy,
+    gems,
+    currentPayout,
+    history,
+    mode,
+    setMode,
+    autoCount,
+    setAutoCount,
+    autoPicks,
+    setAutoPicks,
+    autoRunning,
+    autoLeft,
+    startAuto,
+    stopAuto,
+    start,
+    reveal,
+    cashout,
+    randomTile,
+    openRoll: (rollId: string) => navigate(`/provably-fair?roll=${rollId}`),
+  };
+};

--- a/src/pages/Mines/Mines.types.ts
+++ b/src/pages/Mines/Mines.types.ts
@@ -1,0 +1,20 @@
+import { useMinesServices } from "./Mines.services";
+
+export interface MinesGameState {
+  gameId: string;
+  status: "active" | "cashed" | "busted" | "voided";
+  actionSeq: number;
+  betAmount: number;
+  mineCount: number;
+  revealed: number[];
+  gems: number;
+  multiplier: number;
+  nextMultiplier: number | null;
+  canCashout: boolean;
+  mineSet: number[] | null;
+  bustTile: number | null;
+  payout: number;
+  rollId: string | null;
+}
+
+export type MinesViewProps = ReturnType<typeof useMinesServices>;

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -253,7 +253,7 @@ const MinesView: React.FC<MinesViewProps> = ({
       </div>
 
       <p className="text-ink-muted text-xs max-w-[640px] text-center">
-        Balance: <Monetary value={walletBalance} />. Collect diamonds, avoid the bombs. Every game is provably fair, 99% RTP.
+        Balance: <Monetary value={walletBalance} />. Collect diamonds, avoid the bombs.
       </p>
     </div>
   );

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -4,37 +4,28 @@ import { AUTO_COUNTS } from "./Mines.services";
 import { MAX_BET, TILES, mineOptions } from "./minesGrid";
 import { MinesViewProps } from "./Mines.types";
 
-const StarGem = () => (
+const Diamond = () => (
   <svg viewBox="0 0 24 24" className="w-3/5 h-3/5 drop-shadow">
     <defs>
-      <linearGradient id="mines-star" x1="0" y1="0" x2="1" y2="1">
-        <stop offset="0" stopColor="#ffe680" />
-        <stop offset="1" stopColor="#f2b705" />
+      <linearGradient id="mines-gem" x1="0" y1="0" x2="0" y2="1">
+        <stop offset="0" stopColor="#7bffbe" />
+        <stop offset="1" stopColor="#17c964" />
       </linearGradient>
     </defs>
-    <path
-      fill="url(#mines-star)"
-      stroke="#7a5c00"
-      strokeWidth="0.6"
-      d="M12 2l2.6 6.3 6.8.5-5.2 4.4 1.7 6.6L12 16.9 6.3 20.3l1.7-6.6L2.8 9.3l6.8-.5z"
-    />
+    <g stroke="#0c6b39" strokeWidth="0.5" strokeLinejoin="round">
+      <polygon points="6,3 18,3 22,9 12,22 2,9" fill="url(#mines-gem)" />
+      <path d="M2 9h20M6 3l2 6-2 0M18 3l-2 6 2 0M8 9l4 13 4-13" fill="none" opacity="0.5" />
+    </g>
   </svg>
 );
 
-const Seal = ({ hit }: { hit: boolean }) => (
-  <svg viewBox="0 0 24 24" className={`w-2/3 h-2/3 ${hit ? "" : "opacity-70"}`}>
-    <g fill={hit ? "#ef4444" : "#b0355f"}>
-      <circle cx="12" cy="12" r="5" />
-      {Array.from({ length: 8 }).map((_, i) => {
-        const a = (i * Math.PI) / 4;
-        return (
-          <path
-            key={i}
-            d={`M12 12 L${12 + Math.cos(a) * 10} ${12 + Math.sin(a) * 10} L${12 + Math.cos(a + 0.28) * 6} ${12 + Math.sin(a + 0.28) * 6} Z`}
-          />
-        );
-      })}
-    </g>
+const Bomb = ({ hit }: { hit: boolean }) => (
+  <svg viewBox="0 0 24 24" className={`w-3/5 h-3/5 ${hit ? "" : "opacity-80"}`}>
+    <circle cx="11" cy="14" r="7" fill="#161421" />
+    <circle cx="8.5" cy="11.5" r="2" fill="#3a3550" />
+    <rect x="12" y="4" width="3" height="4" rx="1" fill="#5a5470" transform="rotate(-20 13 6)" />
+    <path d="M15 5c3-2 4 1 6-1" fill="none" stroke="#8a8398" strokeWidth="1.2" strokeLinecap="round" />
+    <circle cx="21" cy="4" r="1.6" fill={hit ? "#f97316" : "#eab308"} />
   </svg>
 );
 
@@ -242,17 +233,17 @@ const MinesView: React.FC<MinesViewProps> = ({
                   key={tile}
                   onClick={() => clickable && reveal(tile)}
                   disabled={!clickable}
-                  className={`aspect-square rounded-lg flex items-center justify-center transition-all
+                  className={`aspect-square rounded-lg flex items-center justify-center transition-all duration-150
                     ${face.kind === "covered"
-                      ? `bg-surface-raised ${clickable ? "hover:bg-surface-hover hover:-translate-y-0.5 cursor-pointer" : "cursor-default"}`
+                      ? `bg-gradient-to-b from-[#3a3560] to-[#2c2846] shadow-[0_4px_0_#1a1830] ${clickable ? "cursor-pointer hover:-translate-y-1 hover:shadow-[0_6px_0_#1a1830] hover:brightness-110 active:translate-y-0 active:shadow-[0_2px_0_#1a1830]" : "cursor-default"}`
                       : face.kind === "gem"
-                        ? "bg-green-500/15 border border-green-500/40"
+                        ? "bg-green-500/15 shadow-[inset_0_2px_6px_rgba(0,0,0,0.4)] border border-green-500/40"
                         : face.kind === "mine"
-                          ? `${face.hit ? "bg-red-500/30 border border-red-500" : "bg-surface-nav border border-line"}`
-                          : "bg-surface-nav border border-line opacity-60"}`}
+                          ? `${face.hit ? "bg-red-500/30 border border-red-500 shadow-[0_0_16px_rgba(239,68,68,0.6)]" : "bg-surface-nav shadow-[inset_0_2px_6px_rgba(0,0,0,0.4)] border border-line"}`
+                          : "bg-surface-nav border border-line opacity-50"}`}
                 >
-                  {face.kind === "gem" && <StarGem />}
-                  {face.kind === "mine" && <Seal hit={face.hit} />}
+                  {face.kind === "gem" && <Diamond />}
+                  {face.kind === "mine" && <Bomb hit={face.hit} />}
                   {face.kind === "faint" && <div className="w-2 h-2 rounded-full bg-line" />}
                 </button>
               );
@@ -262,7 +253,7 @@ const MinesView: React.FC<MinesViewProps> = ({
       </div>
 
       <p className="text-ink-muted text-xs max-w-[640px] text-center">
-        Balance: <Monetary value={walletBalance} />. Collect stars, avoid the spell-card seals. Every game is provably fair, 99% RTP.
+        Balance: <Monetary value={walletBalance} />. Collect diamonds, avoid the bombs. Every game is provably fair, 99% RTP.
       </p>
     </div>
   );

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -1,0 +1,271 @@
+import Title from "../../components/Title";
+import Monetary from "../../components/Monetary";
+import { AUTO_COUNTS } from "./Mines.services";
+import { MAX_BET, TILES, mineOptions } from "./minesGrid";
+import { MinesViewProps } from "./Mines.types";
+
+const StarGem = () => (
+  <svg viewBox="0 0 24 24" className="w-3/5 h-3/5 drop-shadow">
+    <defs>
+      <linearGradient id="mines-star" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stopColor="#ffe680" />
+        <stop offset="1" stopColor="#f2b705" />
+      </linearGradient>
+    </defs>
+    <path
+      fill="url(#mines-star)"
+      stroke="#7a5c00"
+      strokeWidth="0.6"
+      d="M12 2l2.6 6.3 6.8.5-5.2 4.4 1.7 6.6L12 16.9 6.3 20.3l1.7-6.6L2.8 9.3l6.8-.5z"
+    />
+  </svg>
+);
+
+const Seal = ({ hit }: { hit: boolean }) => (
+  <svg viewBox="0 0 24 24" className={`w-2/3 h-2/3 ${hit ? "" : "opacity-70"}`}>
+    <g fill={hit ? "#ef4444" : "#b0355f"}>
+      <circle cx="12" cy="12" r="5" />
+      {Array.from({ length: 8 }).map((_, i) => {
+        const a = (i * Math.PI) / 4;
+        return (
+          <path
+            key={i}
+            d={`M12 12 L${12 + Math.cos(a) * 10} ${12 + Math.sin(a) * 10} L${12 + Math.cos(a + 0.28) * 6} ${12 + Math.sin(a + 0.28) * 6} Z`}
+          />
+        );
+      })}
+    </g>
+  </svg>
+);
+
+const MinesView: React.FC<MinesViewProps> = ({
+  isLogged,
+  walletBalance,
+  betInput,
+  betValue,
+  setBetInput,
+  normalizeBet,
+  halveBet,
+  doubleBet,
+  mineCount,
+  changeMineCount,
+  gemsCount,
+  game,
+  active,
+  busy,
+  gems,
+  currentPayout,
+  history,
+  mode,
+  setMode,
+  autoCount,
+  setAutoCount,
+  autoPicks,
+  setAutoPicks,
+  autoRunning,
+  autoLeft,
+  startAuto,
+  stopAuto,
+  start,
+  reveal,
+  cashout,
+  randomTile,
+  openRoll,
+}) => {
+  const ended = !!game && game.status !== "active";
+  const controlsLocked = active || autoRunning;
+
+  const tileFace = (tile: number) => {
+    const isRevealed = game?.revealed.includes(tile);
+    const isMine = ended && game?.mineSet?.includes(tile);
+    const isBust = game?.bustTile === tile;
+    if (isMine) return { kind: "mine" as const, hit: isBust };
+    if (isRevealed) return { kind: "gem" as const, hit: false };
+    return { kind: ended ? ("faint" as const) : ("covered" as const), hit: false };
+  };
+
+  return (
+    <div className="w-screen flex flex-col items-center py-6 gap-6 px-4">
+      <Title title="Mines" />
+
+      <div className="flex flex-col lg:flex-row w-full max-w-[1000px] bg-surface rounded-lg overflow-hidden border border-line">
+        <div className="lg:w-[300px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
+          <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
+            <button
+              onClick={() => setMode("manual")}
+              disabled={autoRunning}
+              className={`flex-1 py-1.5 rounded ${mode === "manual" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
+            >
+              Manual
+            </button>
+            <button
+              onClick={() => setMode("auto")}
+              disabled={active}
+              className={`flex-1 py-1.5 rounded ${mode === "auto" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
+            >
+              Auto
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
+            <span>Bet Amount</span>
+            <span><Monetary value={betValue} /></span>
+          </div>
+          <div className="flex">
+            <input
+              type="number"
+              value={betInput}
+              max={MAX_BET}
+              onChange={(e) => setBetInput(e.target.value.replace(/[^0-9]/g, ""))}
+              onBlur={normalizeBet}
+              disabled={controlsLocked}
+              className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm disabled:opacity-50"
+            />
+            <button onClick={halveBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold disabled:opacity-50">½</button>
+            <button onClick={doubleBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold disabled:opacity-50">2×</button>
+          </div>
+
+          <div className="flex gap-3">
+            <div className="flex-1 flex flex-col gap-1">
+              <span className="text-xs font-semibold text-ink-muted">Mines</span>
+              <select
+                value={mineCount}
+                onChange={(e) => changeMineCount(Number(e.target.value))}
+                disabled={controlsLocked}
+                className="p-2 bg-surface-nav border border-line rounded text-sm disabled:opacity-50"
+              >
+                {mineOptions.map((n) => (
+                  <option key={n} value={n}>{n}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1 flex flex-col gap-1">
+              <span className="text-xs font-semibold text-ink-muted">Gems</span>
+              <div className="p-2 bg-surface-nav border border-line rounded text-sm text-ink-soft">{gemsCount}</div>
+            </div>
+          </div>
+
+          {mode === "auto" && (
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold text-ink-muted">Tiles per round</span>
+              <input
+                type="number"
+                min={1}
+                max={gemsCount}
+                value={autoPicks}
+                onChange={(e) => setAutoPicks(Math.min(Math.max(1, Math.floor(Number(e.target.value)) || 1), gemsCount))}
+                disabled={autoRunning}
+                className="p-2 bg-surface-nav border border-line rounded text-sm disabled:opacity-50"
+              />
+              <span className="text-xs font-semibold text-ink-muted">Number of Bets</span>
+              <div className="grid grid-cols-4 gap-1">
+                {AUTO_COUNTS.map((n) => (
+                  <button
+                    key={n}
+                    onClick={() => setAutoCount(n)}
+                    disabled={autoRunning}
+                    className={`py-1.5 rounded text-sm font-semibold ${autoCount === n ? "bg-surface-raised text-white" : "bg-surface-nav text-ink-muted"} disabled:opacity-50`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {mode === "manual" ? (
+            active ? (
+              <>
+                <button
+                  onClick={cashout}
+                  disabled={busy || gems === 0}
+                  className="p-3 rounded bg-accent-gold hover:brightness-110 text-[#2a2100] font-bold w-full disabled:opacity-40 transition"
+                >
+                  {gems > 0 ? <>Cash Out <Monetary value={currentPayout} showFraction /></> : "Reveal a tile"}
+                </button>
+                <button
+                  onClick={randomTile}
+                  disabled={busy}
+                  className="p-2.5 rounded bg-surface-raised hover:bg-surface-hover text-ink-soft font-semibold w-full disabled:opacity-40 transition"
+                >
+                  Random Tile
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={start}
+                disabled={busy}
+                className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full disabled:opacity-40 transition"
+              >
+                {isLogged ? "Bet" : "Sign in to play"}
+              </button>
+            )
+          ) : (
+            <button
+              onClick={autoRunning ? stopAuto : startAuto}
+              className={`p-3 rounded font-bold w-full transition ${autoRunning ? "bg-red-500 hover:bg-red-400 text-white" : "bg-green-500 hover:bg-green-400 text-[#10241A]"}`}
+            >
+              {autoRunning ? `Stop (${autoLeft} left)` : isLogged ? `Start ${autoCount} Bets` : "Sign in to play"}
+            </button>
+          )}
+
+          {ended && game && (
+            <button
+              onClick={() => game.rollId && openRoll(game.rollId)}
+              disabled={!game.rollId}
+              className={`text-xs font-semibold text-center py-1 rounded ${game.status === "cashed" ? "text-green-400" : "text-red-400"} disabled:opacity-50`}
+            >
+              {game.status === "cashed" ? <>Won <Monetary value={game.payout} showFraction /> at {game.multiplier.toFixed(2)}×</> : "Boom! Verify roll"}
+            </button>
+          )}
+        </div>
+
+        <div className="flex-1 flex flex-col p-5 gap-4">
+          <div className="flex items-center justify-end gap-2 h-7 overflow-hidden">
+            {history.map((h) => (
+              <button
+                key={h.key}
+                onClick={() => h.rollId && openRoll(h.rollId)}
+                className={`px-2 py-0.5 rounded text-xs font-bold shrink-0 ${h.won ? "bg-green-500/20 text-green-400" : "bg-red-500/20 text-red-400"}`}
+              >
+                {h.won ? `${h.multiplier.toFixed(2)}×` : "✕"}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-5 gap-2 sm:gap-3 max-w-[560px] mx-auto w-full">
+            {Array.from({ length: TILES }).map((_, tile) => {
+              const face = tileFace(tile);
+              const clickable = active && !busy && face.kind === "covered" && mode === "manual";
+              return (
+                <button
+                  key={tile}
+                  onClick={() => clickable && reveal(tile)}
+                  disabled={!clickable}
+                  className={`aspect-square rounded-lg flex items-center justify-center transition-all
+                    ${face.kind === "covered"
+                      ? `bg-surface-raised ${clickable ? "hover:bg-surface-hover hover:-translate-y-0.5 cursor-pointer" : "cursor-default"}`
+                      : face.kind === "gem"
+                        ? "bg-green-500/15 border border-green-500/40"
+                        : face.kind === "mine"
+                          ? `${face.hit ? "bg-red-500/30 border border-red-500" : "bg-surface-nav border border-line"}`
+                          : "bg-surface-nav border border-line opacity-60"}`}
+                >
+                  {face.kind === "gem" && <StarGem />}
+                  {face.kind === "mine" && <Seal hit={face.hit} />}
+                  {face.kind === "faint" && <div className="w-2 h-2 rounded-full bg-line" />}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-ink-muted text-xs max-w-[640px] text-center">
+        Balance: <Monetary value={walletBalance} />. Collect stars, avoid the spell-card seals. Every game is provably fair, 99% RTP.
+      </p>
+    </div>
+  );
+};
+
+export default MinesView;

--- a/src/pages/Mines/index.tsx
+++ b/src/pages/Mines/index.tsx
@@ -1,0 +1,9 @@
+import MinesView from "./Mines.view";
+import { useMinesServices } from "./Mines.services";
+
+const Mines = () => {
+  const service = useMinesServices();
+  return <MinesView {...service} />;
+};
+
+export default Mines;

--- a/src/pages/Mines/minesGrid.test.ts
+++ b/src/pages/Mines/minesGrid.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { TILES, gemsFor, multiplierFor, payoutFor, MAX_PAYOUT } from "./minesGrid";
+
+describe("mines grid math", () => {
+    it("gems fill the grid minus the mines", () => {
+        expect(gemsFor(3)).toBe(22);
+        expect(gemsFor(1)).toBe(24);
+    });
+
+    it("multiplier matches the backend formula and starts at 1", () => {
+        expect(multiplierFor(3, 0)).toBe(1);
+        expect(multiplierFor(3, 1)).toBeCloseTo(0.99 * (25 / 22), 8);
+        expect(multiplierFor(1, 24)).toBeCloseTo(0.99 * 25, 6);
+    });
+
+    it("multiplier rises with each gem revealed", () => {
+        let prev = 0;
+        for (let g = 1; g <= 20; g++) {
+            const m = multiplierFor(5, g);
+            expect(m).toBeGreaterThan(prev);
+            prev = m;
+        }
+    });
+
+    it("payout caps at the max win", () => {
+        expect(payoutFor(10000, 12, 13)).toBe(MAX_PAYOUT);
+        expect(payoutFor(100, 3, 1)).toBeCloseTo(100 * multiplierFor(3, 1), 6);
+    });
+
+    it("the grid is 25 tiles", () => {
+        expect(TILES).toBe(25);
+    });
+});

--- a/src/pages/Mines/minesGrid.ts
+++ b/src/pages/Mines/minesGrid.ts
@@ -1,0 +1,24 @@
+// client mirror of backend/utils/minesMath.js for the multiplier readouts; the server
+// is authoritative for outcomes, this only drives what the panel shows.
+export const TILES = 25;
+export const COLS = 5;
+export const MIN_MINES = 1;
+export const MAX_MINES = 24;
+export const MIN_BET = 1;
+export const MAX_BET = 10000;
+export const MAX_PAYOUT = 1_000_000;
+const RTP = 0.99;
+
+export const mineOptions = Array.from({ length: MAX_MINES }, (_, i) => i + 1);
+
+export const gemsFor = (mineCount: number) => TILES - mineCount;
+
+export const multiplierFor = (mineCount: number, gems: number) => {
+    if (gems <= 0) return 1;
+    let m = 1;
+    for (let i = 0; i < gems; i++) m *= (TILES - i) / (TILES - mineCount - i);
+    return RTP * m;
+};
+
+export const payoutFor = (betAmount: number, mineCount: number, gems: number) =>
+    Math.min(Math.round(betAmount * multiplierFor(mineCount, gems) * 100) / 100, MAX_PAYOUT);

--- a/src/pages/ProvablyFair/ProvablyFair.view.tsx
+++ b/src/pages/ProvablyFair/ProvablyFair.view.tsx
@@ -32,7 +32,7 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
     <Title title="Provably Fair" />
 
     <p className="text-[#84819a] text-sm max-w-[640px] text-center">
-      Every case, upgrade, slot, plinko, blackjack and dice roll is HMAC-SHA256 of your
+      Every case, upgrade, slot, plinko, blackjack, dice and mines roll is HMAC-SHA256 of your
       client seed, a nonce, and a secret server seed we commit to up front.
     </p>
 
@@ -63,11 +63,11 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
           </span>
           <button
             onClick={doVerify}
-            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice")}
+            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice" && roll.game !== "mines")}
             className="px-4 py-1.5 rounded bg-green-700 hover:bg-green-600 text-sm font-semibold disabled:opacity-50"
             title={
-              roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice"
-                ? "Auto-verify supported for case, plinko, blackjack and dice rolls"
+              roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice" && roll.game !== "mines"
+                ? "Auto-verify supported for case, plinko, blackjack, dice and mines rolls"
                 : ""
             }
           >
@@ -120,7 +120,9 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
                   ? `Verified: ${verify.recomputedPlayerCards?.length} player and ${verify.recomputedDealerCards.length} dealer cards replay to dealer ${verify.recomputedDealerTotal}, ${verify.recomputedOutcome}, payout ${verify.recomputedPayout}.`
                   : verify.recomputedResult !== undefined
                     ? `Verified: the recomputed roll is ${verify.recomputedResult}, a ${verify.recomputedWon ? "win" : "loss"} at x${verify.recomputedMultiplier}, payout ${verify.recomputedPayout}.`
-                    : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
+                    : verify.recomputedMineSet
+                      ? `Verified: the mines were at ${verify.recomputedMineSet.join(", ")}; ${verify.recomputedGems} gems, ${verify.recomputedBusted ? "busted" : "cashed"}, payout ${verify.recomputedPayout}.`
+                      : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
               : `Not verified${verify.reason ? `: ${verify.reason}` : ""}.`}
           </div>
         )}

--- a/src/seo/routes.json
+++ b/src/seo/routes.json
@@ -48,6 +48,10 @@
       "title": "Dice | KaniCasino",
       "description": "Set your target, roll over or under, and chase up to 49.50x. Provably fair, no real money involved."
     },
+    "/mines": {
+      "title": "Mines | KaniCasino",
+      "description": "Collect stars and dodge the spell-card seals. Cash out any time. Provably fair, no real money involved."
+    },
     "/battles": {
       "title": "Case Battles | KaniCasino",
       "description": "Open cases head to head against other players. Best total value takes the pot."

--- a/src/seo/routes.json
+++ b/src/seo/routes.json
@@ -50,7 +50,7 @@
     },
     "/mines": {
       "title": "Mines | KaniCasino",
-      "description": "Collect stars and dodge the spell-card seals. Cash out any time. Provably fair, no real money involved."
+      "description": "Reveal diamonds and dodge the bombs. Cash out any time. Provably fair, no real money involved."
     },
     "/battles": {
       "title": "Case Battles | KaniCasino",

--- a/src/services/fair/FairServices.ts
+++ b/src/services/fair/FairServices.ts
@@ -22,7 +22,7 @@ export interface RollRange {
 
 export interface RollView {
   rollId: string;
-  game: "case" | "upgrade" | "slots" | "battle" | "plinko" | "blackjack" | "dice";
+  game: "case" | "upgrade" | "slots" | "battle" | "plinko" | "blackjack" | "dice" | "mines";
   clientSeed: string;
   serverSeedHash: string;
   serverSeed: string | null;
@@ -62,6 +62,9 @@ export interface VerifyResult {
   expectedResult?: number;
   expectedWon?: boolean;
   expectedPayout?: number;
+  recomputedMineSet?: number[];
+  recomputedGems?: number;
+  recomputedBusted?: boolean;
 }
 
 export const getSeed = () => api.get<SeedState>("/fair/seed").then((r) => r.data);

--- a/src/services/games/GamesServices.ts
+++ b/src/services/games/GamesServices.ts
@@ -34,6 +34,26 @@ export async function rollDice(betAmount: number, target: number, direction: "ov
     return response.data;
 }
 
+export async function startMines(betAmount: number, mineCount: number) {
+    const response = await api.post(`/games/mines/start`, { betAmount, mineCount });
+    return response.data;
+}
+
+export async function revealMines(tile: number) {
+    const response = await api.post(`/games/mines/reveal`, { tile });
+    return response.data;
+}
+
+export async function cashoutMines() {
+    const response = await api.post(`/games/mines/cashout`, {});
+    return response.data;
+}
+
+export async function getActiveMinesGame() {
+    const response = await api.get(`/games/mines/active`);
+    return response.data;
+}
+
 export async function dealBlackjack(betAmount: number) {
     const response = await api.post(`/games/blackjack/deal`, { betAmount });
     return response.data;


### PR DESCRIPTION
A new Mines game (Stake original): a 5x5 grid where you reveal tiles to collect gems and raise a progressive multiplier, cashing out any time before you hit a mine. Stateful HTTP game built on the blackjack skeleton.

## Theme
Touhou danmaku: safe tiles reveal golden star items, mines are magenta/red spell-card seals that end the run.

## Game
- `POST /games/mines/start {betAmount, mineCount}`, then `/reveal {tile}` and `/cashout`. One active game per user (partial-unique index), `actionSeq` compare-and-set, and a recovery sweep in `index.js` that pays cashed-but-unpaid games from the ledger and abandons long-idle ones.
- The mine layout is committed at deal time: a seeded partial Fisher-Yates over the 25 tiles (one draw per mine), so positions are fixed before the first reveal and never leave the server while the game is active. Multiplier is the exact Stake formula `0.99 x product (25-i)/(25-m-i)` over gems revealed (99% RTP), payout capped at 1,000,000. Mines 1..24, bet 1..10000.
- Frontend: MVVM page with the grid, star/seal reveal, bet panel (half/double, mines dropdown, gems readout), cash-out button showing the live payout, a random-tile button, and a simple auto (tiles-per-round x number-of-bets). Full autobet (on-win/on-loss, stop-on-profit/loss) is a planned follow-up.

## Every ledger surface
MINES_BET/MINES_WIN types, STAKE_TYPES, missions and adminStats WIN_TYPES, the accounts counterparty map, the backoffice per-game P&L (GAME_LINES + THEO_RTP 0.99), the Roll enum, seed-rotation block while a game is live, and a verifyMinesRoll that re-derives the layout and re-prices the payout, wired into the fair page.

## Tests
Backend minesMath unit (deterministic derivation, Stake multiplier, payout cap, validation) and a minesPF integration suite (charge/reveal/cashout/bust, one-active-per-user, bad inputs, rotated-seed verify). Full backend suite green: 63 suites, 450 tests. Frontend minesGrid unit, plus unit/e2e/lint/build all green.
