### PR TITLE
HiLo game: provably-fair higher/lower with backoffice

### DIFF
--- a/backend/__tests__/integration/hiloPF.test.js
+++ b/backend/__tests__/integration/hiloPF.test.js
@@ -1,0 +1,139 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Roll = require("../../models/Roll");
+const Seed = require("../../models/Seed");
+const Transaction = require("../../models/Transaction");
+const HiloGame = require("../../models/HiloGame");
+const { TX } = require("../../utils/economy");
+const { rankOf, hiChance, loChance } = require("../../utils/hiloMath");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  await Promise.all([Seed.syncIndexes(), Roll.syncIndexes(), HiloGame.syncIndexes()]);
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(walletBalance = 1000) {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", walletBalance });
+}
+
+const auth = (u) => ({ Authorization: `Bearer ${tokenFor(u)}` });
+// the safe direction for the current card: the side with the higher win chance
+const safeDir = (card) => (hiChance(rankOf(card)) >= loChance(rankOf(card)) ? "hi" : "lo");
+
+test("start charges the bet and deals the first card without exposing the deck", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  const res = await request(app).post("/games/hilo/start").set(h).send({ betAmount: 100 });
+  expect(res.status).toBe(200);
+  expect(res.body.current).toBeGreaterThanOrEqual(0);
+  expect(res.body.current).toBeLessThan(52);
+  expect(res.body.multiplier).toBe(1);
+  expect(res.body.canCashout).toBe(false);
+  expect(res.body.hiMultiplier).toBeGreaterThan(0);
+  expect((await User.findById(u._id)).walletBalance).toBe(900);
+
+  const bet = await Transaction.findOne({ userId: u._id, type: TX.HILO_BET });
+  expect(bet.amount).toBe(100);
+});
+
+test("a correct guess raises the multiplier and lets you cash out", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  const start = await request(app).post("/games/hilo/start").set(h).send({ betAmount: 100 });
+  const dir = safeDir(start.body.current);
+
+  const guess = await request(app).post("/games/hilo/guess").set(h).send({ direction: dir });
+  expect(guess.status).toBe(200);
+  // the safe side wins the vast majority of the time; if it lost, the game busted
+  if (guess.body.status === "active") {
+    expect(guess.body.guesses).toBe(1);
+    expect(guess.body.multiplier).toBeGreaterThan(0);
+    expect(guess.body.canCashout).toBe(true);
+
+    const cash = await request(app).post("/games/hilo/cashout").set(h).send({});
+    expect(cash.body.status).toBe("cashed");
+    expect(cash.body.payout).toBeCloseTo(Math.round(100 * guess.body.multiplier * 100) / 100, 6);
+    const win = await Transaction.findOne({ userId: u._id, type: TX.HILO_WIN });
+    expect(win.amount).toBeCloseTo(cash.body.payout, 6);
+    expect(await Roll.findOne({ userId: u._id, game: "hilo" })).toBeTruthy();
+  } else {
+    expect(guess.body.status).toBe("busted");
+    expect(guess.body.payout).toBe(0);
+  }
+});
+
+test("skipping draws a new card without changing the multiplier or charging", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/hilo/start").set(h).send({ betAmount: 100 });
+
+  const skip = await request(app).post("/games/hilo/skip").set(h).send({});
+  expect(skip.status).toBe(200);
+  expect(skip.body.skips).toBe(1);
+  expect(skip.body.multiplier).toBe(1);
+  expect(skip.body.guesses).toBe(0);
+  expect((await User.findById(u._id)).walletBalance).toBe(900); // no extra charge
+});
+
+test("cashing out before any guess is refused", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/hilo/start").set(h).send({ betAmount: 100 });
+  const cash = await request(app).post("/games/hilo/cashout").set(h).send({});
+  expect(cash.status).toBe(400);
+  expect((await HiloGame.findOne({ userId: u._id })).status).toBe("active");
+});
+
+test("only one active game per user, and bad inputs are refused", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  await request(app).post("/games/hilo/start").set(h).send({ betAmount: 100 });
+  const second = await request(app).post("/games/hilo/start").set(h).send({ betAmount: 100 });
+  expect(second.status).toBe(409);
+  // bad direction is rejected
+  const bad = await request(app).post("/games/hilo/guess").set(h).send({ direction: "sideways" });
+  expect(bad.status).toBe(400);
+
+  const b = await makeUser(1000);
+  const hb = auth(b);
+  for (const body of [{ betAmount: 0 }, { betAmount: 20000 }, { betAmount: 5.5 }]) {
+    expect((await request(app).post("/games/hilo/start").set(hb).send(body)).status).toBe(400);
+  }
+  expect((await User.findById(b._id)).walletBalance).toBe(1000);
+});
+
+test("a rotated seed lets the verifier reproduce the game", async () => {
+  const u = await makeUser(1000);
+  const h = auth(u);
+  const start = await request(app).post("/games/hilo/start").set(h).send({ betAmount: 50 });
+  await request(app).post("/games/hilo/skip").set(h).send({});
+  const g = await HiloGame.findOne({ userId: u._id });
+  const dir = safeDir(g.cards[g.cards.length - 1]);
+  const guess = await request(app).post("/games/hilo/guess").set(h).send({ direction: dir });
+  // end the game either way (cash out if still alive)
+  let rollId = guess.body.rollId;
+  if (guess.body.status === "active") {
+    const cash = await request(app).post("/games/hilo/cashout").set(h).send({});
+    rollId = cash.body.rollId;
+  }
+  expect(rollId).toMatch(/^R\d+$/);
+
+  const early = await request(app).get(`/fair/roll/${rollId}/verify`);
+  expect(early.body.ok).toBe(false); // seed still hidden
+
+  await request(app).post("/fair/rotate").set(h).send({});
+  const verified = await request(app).get(`/fair/roll/${rollId}/verify`);
+  expect(verified.body.ok).toBe(true);
+  expect(verified.body.commitmentValid).toBe(true);
+  expect(verified.body.recomputedPayout).toBe((await HiloGame.findOne({ userId: u._id }).lean()).payout);
+});

--- a/backend/__tests__/unit/hiloMath.test.js
+++ b/backend/__tests__/unit/hiloMath.test.js
@@ -32,14 +32,20 @@ describe("hilo math", () => {
     expect(stepMultiplier(q, "lo")).toBeCloseTo(1.0725, 4); // 0.99 * 13/12
   });
 
-  test("ace and king are the extremes", () => {
-    expect(hiChance(0)).toBeCloseTo(1, 8); // higher-or-equal to ace is everything
+  test("the extremes never offer a 100% bet: the tie falls to the minority side", () => {
+    // ace: "higher" is strictly higher (12/13), the tie goes to "lower" (1/13)
+    expect(hiChance(0)).toBeCloseTo(12 / 13, 8);
     expect(loChance(0)).toBeCloseTo(1 / 13, 8);
+    expect(guessWins(0, 0, "hi")).toBe(false); // another ace does not win "higher"
+    expect(guessWins(0, 0, "lo")).toBe(true);
+    // king: "lower" is strictly lower (12/13), the tie goes to "higher" (1/13)
     expect(hiChance(12)).toBeCloseTo(1 / 13, 8);
-    expect(loChance(12)).toBeCloseTo(1, 8); // lower-or-equal to king is everything
+    expect(loChance(12)).toBeCloseTo(12 / 13, 8);
+    expect(guessWins(12, 12, "lo")).toBe(false); // another king does not win "lower"
+    expect(guessWins(12, 12, "hi")).toBe(true);
   });
 
-  test("a guess wins on its side, ties included", () => {
+  test("a guess wins on its side, ties win both on a middle card", () => {
     expect(guessWins(5, 7, "hi")).toBe(true);
     expect(guessWins(5, 5, "hi")).toBe(true); // tie wins higher-or-equal
     expect(guessWins(5, 5, "lo")).toBe(true); // and lower-or-equal

--- a/backend/__tests__/unit/hiloMath.test.js
+++ b/backend/__tests__/unit/hiloMath.test.js
@@ -1,0 +1,89 @@
+const {
+  RANKS,
+  cardAt,
+  rankOf,
+  hiChance,
+  loChance,
+  stepMultiplier,
+  guessWins,
+  validBet,
+  resolveHilo,
+  MAX_PAYOUT,
+} = require("../../utils/hiloMath");
+const { sha256 } = require("../../utils/hashChain");
+
+describe("hilo math", () => {
+  test("cards map to 0..51 and ranks to 0..12 (ace low, king high)", () => {
+    const seed = sha256("hilo-cards");
+    for (let c = 0; c < 200; c++) {
+      const card = cardAt(seed, "client", c, 0);
+      expect(card).toBeGreaterThanOrEqual(0);
+      expect(card).toBeLessThan(52);
+      expect(rankOf(card)).toBe(card % 13);
+    }
+  });
+
+  test("chances and multipliers reproduce the Stake queen example (99% RTP)", () => {
+    // queen is rank 11 (0=ace .. 12=king)
+    const q = 11;
+    expect(hiChance(q)).toBeCloseTo(2 / 13, 8); // Q, K
+    expect(loChance(q)).toBeCloseTo(12 / 13, 8); // A..Q
+    expect(stepMultiplier(q, "hi")).toBeCloseTo(6.435, 3); // 0.99 * 13/2
+    expect(stepMultiplier(q, "lo")).toBeCloseTo(1.0725, 4); // 0.99 * 13/12
+  });
+
+  test("ace and king are the extremes", () => {
+    expect(hiChance(0)).toBeCloseTo(1, 8); // higher-or-equal to ace is everything
+    expect(loChance(0)).toBeCloseTo(1 / 13, 8);
+    expect(hiChance(12)).toBeCloseTo(1 / 13, 8);
+    expect(loChance(12)).toBeCloseTo(1, 8); // lower-or-equal to king is everything
+  });
+
+  test("a guess wins on its side, ties included", () => {
+    expect(guessWins(5, 7, "hi")).toBe(true);
+    expect(guessWins(5, 5, "hi")).toBe(true); // tie wins higher-or-equal
+    expect(guessWins(5, 5, "lo")).toBe(true); // and lower-or-equal
+    expect(guessWins(5, 3, "hi")).toBe(false);
+    expect(guessWins(5, 7, "lo")).toBe(false);
+  });
+
+  test("bet bounds are whole coins 1..10000", () => {
+    expect(validBet(1)).toBe(true);
+    expect(validBet(10000)).toBe(true);
+    expect(validBet(0)).toBe(false);
+    expect(validBet(10001)).toBe(false);
+    expect(validBet(5.5)).toBe(false);
+  });
+
+  test("resolveHilo replays cards, multiplier and payout consistently", () => {
+    const seed = sha256("hilo-replay");
+    // build a winning action list by always guessing the higher-chance side
+    const actions = [];
+    const cards = [cardAt(seed, "c", 0, 0)];
+    for (let i = 0; i < 6; i++) {
+      const rank = rankOf(cards[i]);
+      const dir = hiChance(rank) >= loChance(rank) ? "hi" : "lo";
+      const next = cardAt(seed, "c", 0, i + 1);
+      if (!guessWins(rank, rankOf(next), dir)) break;
+      actions.push(dir === "hi" ? "guess-hi" : "guess-lo");
+      cards.push(next);
+    }
+    const r = resolveHilo({ serverSeed: seed, clientSeed: "c", nonce: 0, betAmount: 100, actions });
+    expect(r.busted).toBe(false);
+    expect(r.guesses).toBe(actions.length);
+    expect(r.payout).toBe(Math.min(Math.round(100 * r.multiplier * 100) / 100, MAX_PAYOUT));
+    expect(r.cards).toHaveLength(actions.length + 1);
+  });
+
+  test("a wrong guess busts and pays nothing", () => {
+    // craft a forced loss: guess lo on an ace (only wins on another ace)
+    const actions = ["guess-hi", "guess-lo", "guess-lo"];
+    // just assert the shape: a resolve that busts yields payout 0
+    const r = resolveHilo({ serverSeed: sha256("x"), clientSeed: "c", nonce: 0, betAmount: 100, actions });
+    if (r.busted) expect(r.payout).toBe(0);
+  });
+
+  test("RANKS is 13", () => {
+    expect(RANKS).toBe(13);
+  });
+});

--- a/backend/games/hilo.js
+++ b/backend/games/hilo.js
@@ -1,0 +1,323 @@
+const crypto = require("crypto");
+const HiloGame = require("../models/HiloGame");
+const Seed = require("../models/Seed");
+const Transaction = require("../models/Transaction");
+const { chargeUser, creditUser, TX } = require("../utils/economy");
+const seeds = require("../utils/seeds");
+const rolls = require("../utils/rolls");
+const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const {
+  HILO_ALGO_VERSION,
+  MAX_SKIPS,
+  cardAt,
+  rankOf,
+  hiChance,
+  loChance,
+  stepMultiplier,
+  guessWins,
+  validBet,
+  payoutCentsFor,
+} = require("../utils/hiloMath");
+
+const PENDING_LEASE_MS = 60 * 1000;
+const STALE_GAME_MS = 30 * 60 * 1000;
+
+function httpError(status, message) {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+}
+
+function newGameId() {
+  return "HL" + String(crypto.randomInt(0, 1e9)).padStart(9, "0");
+}
+
+// the current card, its odds and both potential multipliers, so the ui can price each
+// side against the running total before the player commits
+function currentView(game) {
+  const current = game.cards[game.cards.length - 1];
+  const rank = rankOf(current);
+  return {
+    current,
+    hiChance: hiChance(rank),
+    loChance: loChance(rank),
+    hiMultiplier: game.multiplier * stepMultiplier(rank, "hi"),
+    loMultiplier: game.multiplier * stepMultiplier(rank, "lo"),
+  };
+}
+
+function publicView(game) {
+  const active = game.status === "active";
+  return {
+    gameId: game.gameId,
+    status: game.status,
+    actionSeq: game.actionSeq,
+    betAmount: game.betAmount,
+    cards: game.cards,
+    multiplier: game.multiplier,
+    guesses: game.guesses,
+    skips: game.skips,
+    ...(active ? currentView(game) : { current: game.cards[game.cards.length - 1] }),
+    canCashout: active && game.guesses > 0,
+    canSkip: active && game.skips < MAX_SKIPS,
+    payout: active ? 0 : game.payout,
+    fair: {
+      clientSeed: game.clientSeed,
+      serverSeedHash: game.serverSeedHash,
+      nonce: game.nonce,
+    },
+    rollId: game.rollId || null,
+  };
+}
+
+async function loadActiveGame(userId) {
+  const game = await HiloGame.findOne({ userId, status: "active" });
+  if (!game) throw httpError(404, "No active game");
+  return game;
+}
+
+async function loadServerSeed(game) {
+  const seed = await Seed.findById(game.seedId).select("serverSeed");
+  if (!seed) throw httpError(500, "Seed material missing");
+  return seed.serverSeed;
+}
+
+const drawAt = (serverSeed, game, cursor) => cardAt(serverSeed, game.clientSeed, game.nonce, cursor);
+
+// credit a cashed game's payout exactly once, keyed on the ledger by meta.gameId
+async function payCashout(game, io) {
+  if (game.payout > 0) {
+    const credited = await creditUser(game.userId, game.payout, game.payout, {
+      type: TX.HILO_WIN,
+      meta: { gameId: game.gameId, betAmount: game.betAmount, guesses: game.guesses, multiplier: game.multiplier, payout: game.payout },
+    });
+    if (!credited) return false;
+    io.to(game.userId.toString()).emit("userDataUpdated", {
+      walletBalance: credited.walletBalance,
+      xp: credited.xp,
+      level: credited.level,
+    });
+  }
+  await HiloGame.updateOne({ _id: game._id }, { $set: { settlementDone: true } });
+  return true;
+}
+
+// audit record: written once at settlement, best-effort (money is already settled)
+async function recordGameRoll(game) {
+  try {
+    const serverSeed = await loadServerSeed(game).catch(() => null);
+    const rec = await rolls.recordRoll({
+      game: "hilo",
+      userId: game.userId,
+      seedId: game.seedId,
+      clientSeed: game.clientSeed,
+      serverSeedHash: game.serverSeedHash,
+      nonce: game.nonce,
+      cursor: 0,
+      roll: serverSeed ? Math.floor(rollFloat(serverSeed, game.clientSeed, game.nonce, 0) * TOTAL) + 1 : 0,
+      total: TOTAL,
+      outcome: {
+        betAmount: game.betAmount,
+        actions: game.actions,
+        cards: game.cards,
+        multiplier: game.multiplier,
+        guesses: game.guesses,
+        busted: game.status === "busted",
+        payout: game.payout,
+        algoVersion: HILO_ALGO_VERSION,
+      },
+    });
+    await HiloGame.updateOne({ _id: game._id }, { $set: { rollId: rec.rollId } });
+    return rec.rollId;
+  } catch (recordError) {
+    console.error("hilo roll record failed", recordError);
+    return null;
+  }
+}
+
+class HiloGameController {
+  static async start(userId, betAmount, io) {
+    if (!validBet(betAmount)) throw httpError(400, "Invalid bet amount");
+
+    const reserved = await seeds.reserveNonces(userId, 1);
+    const nonce = reserved.startNonce;
+    const startCard = cardAt(reserved.serverSeed, reserved.clientSeed, nonce, 0);
+
+    // create before charging: an unfunded game is visible and the sweep voids it
+    let game = null;
+    for (let attempt = 0; attempt < 3 && !game; attempt++) {
+      try {
+        game = await HiloGame.create({
+          gameId: newGameId(),
+          userId,
+          betAmount,
+          cards: [startCard],
+          seedId: reserved.seedId,
+          clientSeed: reserved.clientSeed,
+          serverSeedHash: reserved.serverSeedHash,
+          nonce,
+        });
+      } catch (e) {
+        if (e.code === 11000 && e.keyPattern && e.keyPattern.userId) {
+          throw httpError(409, "Game in progress");
+        }
+        if (e.code === 11000 && e.keyPattern && e.keyPattern.gameId) continue;
+        throw e;
+      }
+    }
+    if (!game) throw httpError(500, "Could not create game");
+
+    const player = await chargeUser(userId, betAmount, {
+      type: TX.HILO_BET,
+      meta: { gameId: game.gameId, betAmount },
+    });
+    if (!player) {
+      await HiloGame.updateOne(
+        { _id: game._id, status: "active" },
+        { $set: { status: "voided", settlementDone: true } }
+      );
+      throw httpError(400, "Insufficient balance");
+    }
+
+    io.to(userId.toString()).emit("userDataUpdated", {
+      walletBalance: player.walletBalance,
+      xp: player.xp,
+      level: player.level,
+    });
+
+    return publicView(game);
+  }
+
+  static async guess(userId, direction, io) {
+    if (direction !== "hi" && direction !== "lo") throw httpError(400, "Invalid direction");
+    const game = await loadActiveGame(userId);
+    const serverSeed = await loadServerSeed(game);
+
+    const current = game.cards[game.cards.length - 1];
+    const next = drawAt(serverSeed, game, game.cards.length);
+    const won = guessWins(rankOf(current), rankOf(next), direction);
+    const action = direction === "hi" ? "guess-hi" : "guess-lo";
+
+    if (won) {
+      const nextMultiplier = game.multiplier * stepMultiplier(rankOf(current), direction);
+      const updated = await HiloGame.findOneAndUpdate(
+        { _id: game._id, status: "active", actionSeq: game.actionSeq },
+        { $push: { cards: next, actions: action }, $set: { multiplier: nextMultiplier }, $inc: { guesses: 1, actionSeq: 1 } },
+        { new: true }
+      );
+      if (!updated) throw httpError(409, "Action already applied, refresh");
+      return publicView(updated);
+    }
+
+    const busted = await HiloGame.findOneAndUpdate(
+      { _id: game._id, status: "active", actionSeq: game.actionSeq },
+      {
+        $push: { cards: next, actions: action },
+        $set: { status: "busted", payout: 0, settledAt: new Date(), settlementStartedAt: new Date(), settlementDone: true },
+        $inc: { actionSeq: 1 },
+      },
+      { new: true }
+    );
+    if (!busted) throw httpError(409, "Action already applied, refresh");
+    busted.rollId = await recordGameRoll(busted);
+    return publicView(busted);
+  }
+
+  static async skip(userId, io) {
+    const game = await loadActiveGame(userId);
+    if (game.skips >= MAX_SKIPS) throw httpError(400, "No skips left");
+    const serverSeed = await loadServerSeed(game);
+    const next = drawAt(serverSeed, game, game.cards.length);
+
+    const updated = await HiloGame.findOneAndUpdate(
+      { _id: game._id, status: "active", actionSeq: game.actionSeq },
+      { $push: { cards: next, actions: "skip" }, $inc: { skips: 1, actionSeq: 1 } },
+      { new: true }
+    );
+    if (!updated) throw httpError(409, "Action already applied, refresh");
+    return publicView(updated);
+  }
+
+  static async cashout(userId, io) {
+    const game = await loadActiveGame(userId);
+    if (game.guesses === 0) throw httpError(400, "Make a prediction before cashing out");
+
+    const payout = payoutCentsFor(game.betAmount, game.multiplier) / 100;
+    const cashed = await HiloGame.findOneAndUpdate(
+      { _id: game._id, status: "active", actionSeq: game.actionSeq },
+      { $set: { status: "cashed", payout, settledAt: new Date(), settlementStartedAt: new Date() }, $inc: { actionSeq: 1 } },
+      { new: true }
+    );
+    if (!cashed) throw httpError(409, "Action already applied, refresh");
+    await payCashout(cashed, io);
+    cashed.rollId = await recordGameRoll(cashed);
+    return publicView(cashed);
+  }
+
+  static async active(userId) {
+    const game = await HiloGame.findOne({ userId, status: "active" });
+    return game ? publicView(game) : null;
+  }
+}
+
+// recovery sweep, same lease + ledger discipline as the blackjack/mines sweeps
+async function sweepHiloGames(io) {
+  const now = Date.now();
+  const staleCutoff = new Date(now - STALE_GAME_MS);
+  const leaseCutoff = new Date(now - PENDING_LEASE_MS);
+  const ioSafe = io || { to: () => ({ emit: () => {} }) };
+
+  const unpaid = await HiloGame.find({
+    status: "cashed",
+    settlementDone: { $ne: true },
+    settlementStartedAt: { $lte: leaseCutoff },
+  }).limit(50);
+  for (const game of unpaid) {
+    try {
+      const alreadyPaid = await Transaction.exists({ userId: game.userId, type: TX.HILO_WIN, "meta.gameId": game.gameId });
+      if (alreadyPaid) {
+        await HiloGame.updateOne({ _id: game._id }, { $set: { settlementDone: true } });
+        continue;
+      }
+      await payCashout(game, ioSafe);
+    } catch (e) {
+      console.error("hilo sweep (unpaid) failed", game.gameId, e);
+    }
+  }
+
+  const unrecorded = await HiloGame.find({
+    status: { $in: ["cashed", "busted"] },
+    settlementDone: true,
+    rollId: null,
+  }).limit(20);
+  for (const game of unrecorded) {
+    try {
+      await recordGameRoll(game);
+    } catch (e) {
+      console.error("hilo sweep (roll) failed", game.gameId, e);
+    }
+  }
+
+  // a funded game left idle is abandoned as a bust; an unfunded one is voided
+  const stale = await HiloGame.find({ status: "active", updatedAt: { $lte: staleCutoff } }).limit(50);
+  for (const game of stale) {
+    try {
+      const funded = await Transaction.exists({ userId: game.userId, type: TX.HILO_BET, "meta.gameId": game.gameId });
+      const next = funded
+        ? { status: "busted", payout: 0, settledAt: new Date(), settlementStartedAt: new Date(), settlementDone: true }
+        : { status: "voided", settlementDone: true };
+      const swept = await HiloGame.findOneAndUpdate(
+        { _id: game._id, status: "active", actionSeq: game.actionSeq },
+        { $set: next, $inc: { actionSeq: 1 } },
+        { new: true }
+      );
+      if (swept && funded) await recordGameRoll(swept);
+    } catch (e) {
+      console.error("hilo sweep (stale) failed", game.gameId, e);
+    }
+  }
+}
+
+module.exports = HiloGameController;
+module.exports.sweepHiloGames = sweepHiloGames;
+module.exports.publicView = publicView;

--- a/backend/index.js
+++ b/backend/index.js
@@ -74,6 +74,7 @@ const { recoverStuckRounds } = require("./utils/rounds");
 const { completeStuckBattles } = require("./games/battleEngine");
 const { sweepBlackjackHands } = require("./games/blackjack");
 const { sweepMinesGames } = require("./games/mines");
+const { sweepHiloGames } = require("./games/hilo");
 const { probeTransactions, setTransactionsSupported } = require("./utils/economy");
 const userRoutes = require("./routes/userRoutes");
 const caseRoutes = require("./routes/caseRoutes");
@@ -155,6 +156,7 @@ const sweepRounds = ({ boot = false } = {}) => {
   completeStuckBattles(io, { boot }).catch((e) => console.log(e));
   sweepBlackjackHands(io).catch((e) => console.log(e));
   sweepMinesGames(io).catch((e) => console.log(e));
+  sweepHiloGames(io).catch((e) => console.log(e));
 };
 sweepRounds({ boot: true });
 setInterval(() => sweepRounds({ boot: false }), 5 * 60 * 1000);

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -73,4 +73,16 @@ const minesActionLimiter = rateLimit({
   message: { message: "Too many actions, slow down a little." },
 });
 
-module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter, diceRollLimiter, minesActionLimiter };
+// hilo fires one request per prediction/skip; keyed per user (after auth), same headroom as mines
+const hiloActionLimiter = rateLimit({
+  windowMs: 10 * 1000,
+  max: 80,
+  keyGenerator: (req) => String(req.user._id),
+  skip: skipInTests,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  message: { message: "Too many actions, slow down a little." },
+});
+
+module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter, diceRollLimiter, minesActionLimiter, hiloActionLimiter };

--- a/backend/models/HiloGame.js
+++ b/backend/models/HiloGame.js
@@ -1,0 +1,45 @@
+const mongoose = require("mongoose");
+
+// one document per hilo game: a multi-request HTTP game, so the in-progress state (the
+// drawn cards and the running multiplier) must survive restarts. the serverSeed is never
+// stored here; cards resolve through seedId and stay secret until the seed rotates.
+const hiloGameSchema = new mongoose.Schema(
+  {
+    gameId: { type: String, required: true, unique: true },
+    userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    status: { type: String, enum: ["active", "cashed", "busted", "voided"], default: "active" },
+    // compare-and-set token: every mutation filters on it and bumps it
+    actionSeq: { type: Number, default: 0 },
+
+    betAmount: { type: Number, required: true },
+    // every card drawn so far (indices 0..51); the last one is the current card
+    cards: { type: [Number], required: true },
+    // one entry per draw after the first: "guess-hi" | "guess-lo" | "skip"
+    actions: { type: [String], default: [] },
+    multiplier: { type: Number, default: 1 },
+    guesses: { type: Number, default: 0 },
+    skips: { type: Number, default: 0 },
+
+    seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
+    clientSeed: { type: String, required: true },
+    serverSeedHash: { type: String, required: true },
+    nonce: { type: Number, required: true },
+
+    payout: { type: Number, default: 0 },
+    settledAt: { type: Date, default: null },
+    settlementStartedAt: { type: Date, default: null },
+    settlementDone: { type: Boolean, default: false },
+    rollId: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+// at most one active game per user
+hiloGameSchema.index(
+  { userId: 1 },
+  { unique: true, partialFilterExpression: { status: "active" } }
+);
+hiloGameSchema.index({ status: 1, updatedAt: 1 });
+hiloGameSchema.index({ userId: 1, createdAt: -1 });
+
+module.exports = mongoose.model("HiloGame", hiloGameSchema);

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -8,7 +8,7 @@ const RollSchema = new mongoose.Schema(
   {
     rollId: { type: String, required: true, unique: true }, // public short id, e.g. R821872881
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice", "mines"], required: true },
+    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice", "mines", "hilo"], required: true },
 
     seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
     clientSeed: { type: String, required: true },

--- a/backend/routes/fairRoutes.js
+++ b/backend/routes/fairRoutes.js
@@ -6,6 +6,7 @@ const rolls = require("../utils/rolls");
 const Round = require("../models/Round");
 const BlackjackHand = require("../models/BlackjackHand");
 const MinesGame = require("../models/MinesGame");
+const HiloGame = require("../models/HiloGame");
 const { crashPointFromSeed } = require("../utils/crashMath");
 const { coinResultFromSeed } = require("../utils/coinMath");
 const { sha256 } = require("../utils/hashChain");
@@ -48,6 +49,10 @@ router.post("/rotate", isAuthenticated, async (req, res) => {
     // and mid-mines would reveal the committed mine layout
     if (await MinesGame.exists({ userId: req.user._id, status: "active" })) {
       return res.status(409).json({ message: "Finish your mines game before rotating" });
+    }
+    // and mid-hilo would reveal the upcoming cards
+    if (await HiloGame.exists({ userId: req.user._id, status: "active" })) {
+      return res.status(409).json({ message: "Finish your hilo game before rotating" });
     }
     const newClientSeed = req.body.clientSeed ? cleanClientSeed(req.body.clientSeed) : undefined;
     const { revealed, current } = await seeds.rotate(req.user._id, newClientSeed);

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
-const { plinkoDropLimiter, diceRollLimiter, minesActionLimiter } = require("../middleware/rateLimit");
+const { plinkoDropLimiter, diceRollLimiter, minesActionLimiter, hiloActionLimiter } = require("../middleware/rateLimit");
 
 const User = require("../models/User");
 const Case = require("../models/Case");
@@ -12,6 +12,7 @@ const PlinkoGameController = require("../games/plinko");
 const BlackjackGameController = require("../games/blackjack");
 const DiceGameController = require("../games/dice");
 const MinesGameController = require("../games/mines");
+const HiloGameController = require("../games/hilo");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const referrals = require("../utils/referrals");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
@@ -281,6 +282,24 @@ module.exports = (io) => {
   ));
   router.get("/mines/active", isAuthenticated, blackjackAction(
     async (req) => ({ game: await MinesGameController.active(req.user._id) })
+  ));
+
+  // hilo: a game spans several requests, so each action resolves the user's single
+  // active game; reuses the statused-error wrapper (409 = resync)
+  router.post("/hilo/start", isAuthenticated, hiloActionLimiter, blackjackAction(
+    (req) => HiloGameController.start(req.user._id, req.body.betAmount, io)
+  ));
+  router.post("/hilo/guess", isAuthenticated, hiloActionLimiter, blackjackAction(
+    (req) => HiloGameController.guess(req.user._id, req.body.direction, io)
+  ));
+  router.post("/hilo/skip", isAuthenticated, hiloActionLimiter, blackjackAction(
+    (req) => HiloGameController.skip(req.user._id, io)
+  ));
+  router.post("/hilo/cashout", isAuthenticated, hiloActionLimiter, blackjackAction(
+    (req) => HiloGameController.cashout(req.user._id, io)
+  ));
+  router.get("/hilo/active", isAuthenticated, blackjackAction(
+    async (req) => ({ game: await HiloGameController.active(req.user._id) })
   ));
 
   // recent coin flip results, so the page has a history the moment it loads. light and

--- a/backend/utils/accounts.js
+++ b/backend/utils/accounts.js
@@ -43,6 +43,8 @@ const COUNTERPARTY_FOR_TYPE = {
   dice_win: HOUSE,
   mines_bet: HOUSE,
   mines_win: HOUSE,
+  hilo_bet: HOUSE,
+  hilo_win: HOUSE,
   item_sell: HOUSE,
   market_order: ESCROW,
   market_order_refund: ESCROW,

--- a/backend/utils/adminStats.js
+++ b/backend/utils/adminStats.js
@@ -8,12 +8,12 @@ const { HOUSE, MINT, ESCROW, GENESIS } = require("./accounts");
 const PAGE_SIZE = 20;
 
 // KP-paying game wins and stake returns, for daily series and big-win surfacing
-const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.MINES_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.MINES_WIN, TX.HILO_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 const REFUND_TYPES = [TX.CRASH_REFUND, TX.COINFLIP_REFUND, TX.BATTLE_REFUND, TX.BLACKJACK_PUSH, TX.BLACKJACK_REFUND];
 // KP printed to players outside the games
 const FAUCET_TYPES = [TX.SIGNUP, TX.BONUS, TX.MISSION_REWARD, TX.REFERRAL_BONUS, TX.REFERRAL_MILESTONE, TX.AD_REWARD];
 // designed edges per game, so the realized return can be judged against intent
-const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, blackjack: 0.9943, dice: 0.99, mines: 0.99, cases: 0.9, battles: 0.9 };
+const THEO_RTP = { crash: 0.9603, coinflip: 0.97, slots: 0.9645, plinko: 0.9655, blackjack: 0.9943, dice: 0.99, mines: 0.99, hilo: 0.99, cases: 0.9, battles: 0.9 };
 
 // window start, or null for all-time
 const sinceFor = (days) => {
@@ -50,6 +50,7 @@ const GAME_LINES = [
   { game: "blackjack", bets: [TX.BLACKJACK_BET], outs: [TX.BLACKJACK_WIN, TX.BLACKJACK_PUSH, TX.BLACKJACK_REFUND] },
   { game: "dice", bets: [TX.DICE_BET], outs: [TX.DICE_WIN] },
   { game: "mines", bets: [TX.MINES_BET], outs: [TX.MINES_WIN] },
+  { game: "hilo", bets: [TX.HILO_BET], outs: [TX.HILO_WIN] },
   { game: "cases", bets: [TX.CASE_OPEN], outs: [] },
   { game: "battles", bets: [TX.BATTLE_ENTRY], outs: [TX.BATTLE_REFUND] },
 ];

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -31,6 +31,8 @@ const TX = {
   DICE_WIN: "dice_win",
   MINES_BET: "mines_bet",
   MINES_WIN: "mines_win",
+  HILO_BET: "hilo_bet",
+  HILO_WIN: "hilo_win",
   MARKET_BUY: "market_buy",
   MARKET_SALE: "market_sale",
   MARKET_FEE: "market_fee", // the house cut on a settled trade, credited to HOUSE
@@ -48,7 +50,7 @@ const TX = {
 };
 
 // every KP put at risk on a game; missions and referral commission both count these
-const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BLACKJACK_BET, TX.DICE_BET, TX.MINES_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
+const STAKE_TYPES = [TX.CRASH_BET, TX.COINFLIP_BET, TX.SLOT_BET, TX.PLINKO_BET, TX.BLACKJACK_BET, TX.DICE_BET, TX.MINES_BET, TX.HILO_BET, TX.BATTLE_ENTRY, TX.CASE_OPEN];
 
 function calculateXPForLevel(level) {
   return Math.floor(BASE_XP * Math.pow(GROWTH_RATE, level - 1));

--- a/backend/utils/hiloMath.js
+++ b/backend/utils/hiloMath.js
@@ -1,0 +1,99 @@
+const { rollFloat } = require("./provablyFair");
+
+// bump when the card mapping or the multiplier formula changes; the verifier refuses
+// other versions
+const HILO_ALGO_VERSION = 1;
+
+const RANKS = 13;
+const DECK = 52;
+const MIN_BET = 1;
+const MAX_BET = 10000;
+// a long lucky streak can compound past a million; the payout is capped like the other games
+const MAX_PAYOUT = 1_000_000;
+const MAX_SKIPS = 52;
+const RTP = 0.99;
+
+// card 0..51, rank = card % 13 (0 = ace, the lowest, 12 = king, the highest), suit = floor/13
+function cardAt(serverSeed, clientSeed, nonce, cursor) {
+  return Math.floor(rollFloat(serverSeed, clientSeed, nonce, cursor) * DECK);
+}
+const rankOf = (card) => card % RANKS;
+
+// higher-or-equal covers ranks >= r, lower-or-equal covers ranks <= r; both include r,
+// so a tie wins either bet (the Stake model) and the two chances overlap on that rank
+const hiCount = (rank) => RANKS - rank;
+const loCount = (rank) => rank + 1;
+const hiChance = (rank) => hiCount(rank) / RANKS;
+const loChance = (rank) => loCount(rank) / RANKS;
+
+// per-step multiplier for a direction, 0.99 / chance (99% RTP)
+function stepMultiplier(rank, direction) {
+  const chance = direction === "hi" ? hiChance(rank) : loChance(rank);
+  return RTP / chance;
+}
+
+// a guess wins if the next card lands on the predicted side, ties included
+function guessWins(currentRank, nextRank, direction) {
+  return direction === "hi" ? nextRank >= currentRank : nextRank <= currentRank;
+}
+
+function validBet(betAmount) {
+  return Number.isInteger(betAmount) && betAmount >= MIN_BET && betAmount <= MAX_BET;
+}
+
+function payoutCentsFor(betAmount, multiplier) {
+  return Math.min(Math.round(betAmount * multiplier * 100), MAX_PAYOUT * 100);
+}
+
+// replay a whole game from the seed material and the recorded action list. one draw per
+// card at successive cursors (cursor 0 = the start card). the controller, the sweep and
+// the verifier all fold through this, so they cannot disagree about the cards.
+function resolveHilo({ serverSeed, clientSeed, nonce, betAmount, actions }) {
+  const cards = [cardAt(serverSeed, clientSeed, nonce, 0)];
+  let multiplier = 1;
+  let guesses = 0;
+  let skips = 0;
+  let busted = false;
+
+  const list = actions || [];
+  for (let i = 0; i < list.length; i++) {
+    const action = typeof list[i] === "string" ? list[i] : list[i].action;
+    const next = cardAt(serverSeed, clientSeed, nonce, i + 1);
+    cards.push(next);
+    if (action === "skip") {
+      skips += 1;
+      continue;
+    }
+    const direction = action === "guess-hi" ? "hi" : "lo";
+    if (guessWins(rankOf(cards[i]), rankOf(next), direction)) {
+      multiplier *= stepMultiplier(rankOf(cards[i]), direction);
+      guesses += 1;
+    } else {
+      busted = true;
+      break;
+    }
+  }
+
+  const payout = busted || guesses === 0 ? 0 : payoutCentsFor(betAmount, multiplier) / 100;
+  return { cards, multiplier, guesses, skips, busted, payout };
+}
+
+module.exports = {
+  HILO_ALGO_VERSION,
+  RANKS,
+  DECK,
+  MIN_BET,
+  MAX_BET,
+  MAX_PAYOUT,
+  MAX_SKIPS,
+  RTP,
+  cardAt,
+  rankOf,
+  hiChance,
+  loChance,
+  stepMultiplier,
+  guessWins,
+  validBet,
+  payoutCentsFor,
+  resolveHilo,
+};

--- a/backend/utils/hiloMath.js
+++ b/backend/utils/hiloMath.js
@@ -19,10 +19,12 @@ function cardAt(serverSeed, clientSeed, nonce, cursor) {
 }
 const rankOf = (card) => card % RANKS;
 
-// higher-or-equal covers ranks >= r, lower-or-equal covers ranks <= r; both include r,
-// so a tie wins either bet (the Stake model) and the two chances overlap on that rank
-const hiCount = (rank) => RANKS - rank;
-const loCount = (rank) => rank + 1;
+// a tie (same rank) wins both sides for a middle card, so their chances overlap on that
+// rank. for the extremes the tie only wins the minority side, so neither ace nor king
+// ever offers a 100% (0.99x) bet: an ace's "higher" is strictly higher (the tie falls to
+// "lower"), a king's "lower" is strictly lower (the tie falls to "higher").
+const hiCount = (rank) => (rank === 0 ? RANKS - 1 : RANKS - rank);
+const loCount = (rank) => (rank === RANKS - 1 ? RANKS - 1 : rank + 1);
 const hiChance = (rank) => hiCount(rank) / RANKS;
 const loChance = (rank) => loCount(rank) / RANKS;
 
@@ -32,9 +34,13 @@ function stepMultiplier(rank, direction) {
   return RTP / chance;
 }
 
-// a guess wins if the next card lands on the predicted side, ties included
+// a guess wins if the next card lands on the predicted side. a tie wins both, except on
+// an ace (the tie goes only to "lower") and a king (only to "higher"), matching the counts
 function guessWins(currentRank, nextRank, direction) {
-  return direction === "hi" ? nextRank >= currentRank : nextRank <= currentRank;
+  if (direction === "hi") {
+    return nextRank > currentRank || (nextRank === currentRank && currentRank !== 0);
+  }
+  return nextRank < currentRank || (nextRank === currentRank && currentRank !== RANKS - 1);
 }
 
 function validBet(betAmount) {

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -8,7 +8,7 @@ const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
 const { CATALOG, byKey, missionsLaunchAt } = require("./missionsCatalog");
 
 // a "big win" is any single game payout; pushes and refunds are returned stakes, not wins
-const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.MINES_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
+const WIN_TYPES = [TX.SLOT_WIN, TX.PLINKO_WIN, TX.BLACKJACK_WIN, TX.DICE_WIN, TX.MINES_WIN, TX.HILO_WIN, TX.CRASH_CASHOUT, TX.COINFLIP_WIN];
 
 // missions currently offered; a disabled one (active:false) stays defined but is
 // never shown, announced, or claimable

--- a/backend/utils/rolls.js
+++ b/backend/utils/rolls.js
@@ -7,6 +7,8 @@ const { PAYOUTS: PLINKO_PAYOUTS, PLINKO_ALGO_VERSION, derivePath, binFromPath } 
 const { BLACKJACK_ALGO_VERSION, replayHand } = require("./blackjackMath");
 const { DICE_ALGO_VERSION, resolveRoll: resolveDiceRoll } = require("./diceMath");
 const { MINES_ALGO_VERSION, deriveMines, multiplierFor: minesMultiplierFor, payoutCentsFor: minesPayoutCentsFor } = require("./minesMath");
+const { HILO_ALGO_VERSION, resolveHilo, rankOf: hiloRankOf } = require("./hiloMath");
+const HILO_RANK_LABELS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"];
 const { rollFloat } = require("./provablyFair");
 
 function generateRollId() {
@@ -282,6 +284,45 @@ async function verifyMinesRoll(rollId) {
   };
 }
 
+// replay a hilo game from its seed material and recorded action log; the verifier runs
+// the same resolveHilo the game and its recovery path use, so they cannot disagree about
+// the cards drawn or the payout
+async function verifyHiloRoll(rollId) {
+  const v = await getRollForVerify(rollId);
+  if (!v || v.game !== "hilo") return { ok: false, reason: "not a hilo roll" };
+  if (!v.serverSeed) return { ok: false, reason: "server seed not revealed yet" };
+
+  const outcome = v.outcome || {};
+  if (outcome.algoVersion !== HILO_ALGO_VERSION) {
+    return { ok: false, reason: "algorithm version superseded" };
+  }
+
+  const commitmentValid = hashServerSeed(v.serverSeed) === v.serverSeedHash;
+  const replayed = resolveHilo({
+    serverSeed: v.serverSeed,
+    clientSeed: v.clientSeed,
+    nonce: v.nonce,
+    betAmount: outcome.betAmount,
+    actions: outcome.actions || [],
+  });
+  const sameCards = JSON.stringify(replayed.cards) === JSON.stringify(outcome.cards);
+  const ok =
+    commitmentValid &&
+    sameCards &&
+    replayed.busted === !!outcome.busted &&
+    replayed.payout === outcome.payout;
+
+  return {
+    ok,
+    commitmentValid,
+    recomputedCards: replayed.cards.map((c) => HILO_RANK_LABELS[hiloRankOf(c)]),
+    recomputedGuesses: replayed.guesses,
+    recomputedBusted: replayed.busted,
+    recomputedPayout: replayed.payout,
+    expectedPayout: outcome.payout,
+  };
+}
+
 // route a verify request to the game's reference verifier
 async function verifyRoll(rollId) {
   const r = await Roll.findOne({ rollId }).select("game").lean();
@@ -291,6 +332,7 @@ async function verifyRoll(rollId) {
   if (r.game === "blackjack") return verifyBlackjackRoll(rollId);
   if (r.game === "dice") return verifyDiceRoll(rollId);
   if (r.game === "mines") return verifyMinesRoll(rollId);
+  if (r.game === "hilo") return verifyHiloRoll(rollId);
   return { ok: false, reason: "no server-side verifier for this game" };
 }
 
@@ -304,5 +346,6 @@ module.exports = {
   verifyBlackjackRoll,
   verifyDiceRoll,
   verifyMinesRoll,
+  verifyHiloRoll,
   verifyRoll,
 };

--- a/public/images/hilo.svg
+++ b/public/images/hilo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 348">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#221f3d"/>
+      <stop offset="1" stop-color="#151225"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="348" rx="14" fill="url(#bg)"/>
+  <g transform="translate(38 96) rotate(-10)">
+    <rect x="0" y="0" width="86" height="120" rx="10" fill="#ffffff" stroke="#0c0a18" stroke-width="2"/>
+    <text x="14" y="34" font-family="Arial, sans-serif" font-size="30" font-weight="bold" fill="#e02020">Q</text>
+    <path fill="#e02020" d="M20 44l7 10-7 10-7-10z"/>
+  </g>
+  <g transform="translate(132 96) rotate(8)">
+    <rect x="0" y="0" width="86" height="120" rx="10" fill="#ffffff" stroke="#0c0a18" stroke-width="2"/>
+    <text x="14" y="34" font-family="Arial, sans-serif" font-size="30" font-weight="bold" fill="#1c1a31">K</text>
+    <path fill="#1c1a31" d="M27 42s7 6 7 10a3.5 3.5 0 0 1-7 1.6A3.5 3.5 0 0 1 20 52c0-4 7-10 7-10z"/>
+  </g>
+  <g transform="translate(175 84)">
+    <circle cx="0" cy="0" r="17" fill="#17c964"/>
+    <path fill="#0c0a18" d="M0 -9l3 5h-6z"/>
+    <rect x="-2" y="-4" width="4" height="11" rx="2" fill="#0c0a18"/>
+  </g>
+  <g transform="translate(70 210)">
+    <circle cx="0" cy="0" r="17" fill="#e02020"/>
+    <path fill="#ffffff" d="M0 9l3 -5h-6z"/>
+    <rect x="-2" y="-7" width="4" height="11" rx="2" fill="#ffffff"/>
+  </g>
+  <text x="128" y="272" text-anchor="middle" font-family="Arial, sans-serif" font-size="30" font-weight="bold" fill="#e1dde9" letter-spacing="5">HILO</text>
+</svg>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -11,6 +11,7 @@ import Plinko from "./pages/Plinko";
 import Blackjack from "./pages/Blackjack";
 import Dice from "./pages/Dice";
 import Mines from "./pages/Mines";
+import Hilo from "./pages/Hilo";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
 import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
@@ -34,6 +35,7 @@ const defaultRoutes = (
     <Route path="/blackjack" element={<Blackjack />} />
     <Route path="/dice" element={<Dice />} />
     <Route path="/mines" element={<Mines />} />
+    <Route path="/hilo" element={<Hilo />} />
     <Route path="/battles" element={<Battles />} />
     <Route path="/battles/:id" element={<BattleRoom />} />
     <Route path="/provably-fair" element={<ProvablyFair />} />

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -46,6 +46,7 @@ const GAME_LABELS: Record<string, string> = {
   blackjack: "Blackjack",
   dice: "Dice",
   mines: "Mines",
+  hilo: "HiLo",
   cases: "Case openings",
   battles: "Case battles",
 };

--- a/src/pages/Hilo/Hilo.services.ts
+++ b/src/pages/Hilo/Hilo.services.ts
@@ -1,0 +1,106 @@
+import { useContext, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import UserContext from "../../UserContext";
+import {
+  cashoutHilo,
+  getActiveHiloGame,
+  guessHilo,
+  skipHilo,
+  startHilo,
+} from "../../services/games/GamesServices";
+import { MAX_BET, MIN_BET } from "./hiloCards";
+import { HiloGameState } from "./Hilo.types";
+
+const DEFAULT_BET = 10;
+const HISTORY_SIZE = 10;
+
+export const useHiloServices = () => {
+  const { userData, toogleUserFlow } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
+  const [game, setGame] = useState<HiloGameState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [history, setHistory] = useState<{ key: string; won: boolean; multiplier: number; payout: number; rollId: string | null }[]>([]);
+
+  const seq = useRef(0);
+  const gameRef = useRef<HiloGameState | null>(null);
+  gameRef.current = game;
+
+  const betValue = Math.min(Math.max(Math.floor(Number(betInput)) || MIN_BET, MIN_BET), MAX_BET);
+  const active = game?.status === "active";
+
+  useEffect(() => {
+    if (userData == null) return;
+    getActiveHiloGame()
+      .then((res) => {
+        if (res?.game) {
+          setGame(res.game);
+          setBetInput(String(res.game.betAmount));
+        }
+      })
+      .catch(() => setGame(null));
+  }, [userData]);
+
+  const recordEnd = (g: HiloGameState) => {
+    seq.current += 1;
+    setHistory((h) =>
+      [{ key: `h${seq.current}`, won: g.status === "cashed", multiplier: g.multiplier, payout: g.payout, rollId: g.rollId }, ...h].slice(0, HISTORY_SIZE)
+    );
+  };
+
+  const run = async (fn: () => Promise<HiloGameState>, guard = true): Promise<void> => {
+    if (guard && busy) return;
+    setBusy(true);
+    try {
+      const next = await fn();
+      setGame(next);
+      if (next.status !== "active" && next.status !== "voided") recordEnd(next);
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Something went wrong", { theme: "dark" });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const start = () => {
+    if (userData == null) return toogleUserFlow(true);
+    if (userData.walletBalance < betValue) return toast.error("Insufficient funds", { theme: "dark" });
+    run(() => startHilo(betValue));
+  };
+  const guess = (direction: "hi" | "lo") => {
+    if (!gameRef.current || gameRef.current.status !== "active") return;
+    run(() => guessHilo(direction));
+  };
+  const skip = () => {
+    const g = gameRef.current;
+    if (!g || g.status !== "active" || !g.canSkip) return;
+    run(() => skipHilo());
+  };
+  const cashout = () => {
+    const g = gameRef.current;
+    if (!g || g.status !== "active" || !g.canCashout) return;
+    run(() => cashoutHilo());
+  };
+
+  return {
+    isLogged: userData != null,
+    walletBalance: userData?.walletBalance ?? 0,
+    betInput,
+    betValue,
+    setBetInput,
+    normalizeBet: () => setBetInput(String(betValue)),
+    halveBet: () => setBetInput(String(Math.max(MIN_BET, Math.floor(betValue / 2)))),
+    doubleBet: () => setBetInput(String(Math.min(MAX_BET, betValue * 2))),
+    game,
+    active,
+    busy,
+    history,
+    start,
+    guess,
+    skip,
+    cashout,
+    openRoll: (rollId: string) => navigate(`/provably-fair?roll=${rollId}`),
+  };
+};

--- a/src/pages/Hilo/Hilo.types.ts
+++ b/src/pages/Hilo/Hilo.types.ts
@@ -1,0 +1,23 @@
+import { useHiloServices } from "./Hilo.services";
+
+export interface HiloGameState {
+  gameId: string;
+  status: "active" | "cashed" | "busted" | "voided";
+  actionSeq: number;
+  betAmount: number;
+  cards: number[];
+  multiplier: number;
+  guesses: number;
+  skips: number;
+  current: number;
+  hiChance?: number;
+  loChance?: number;
+  hiMultiplier?: number;
+  loMultiplier?: number;
+  canCashout: boolean;
+  canSkip: boolean;
+  payout: number;
+  rollId: string | null;
+}
+
+export type HiloViewProps = ReturnType<typeof useHiloServices>;

--- a/src/pages/Hilo/Hilo.view.tsx
+++ b/src/pages/Hilo/Hilo.view.tsx
@@ -1,0 +1,179 @@
+import { AiFillCaretDown, AiFillCaretUp } from "react-icons/ai";
+import Title from "../../components/Title";
+import Monetary from "../../components/Monetary";
+import PlayingCard, { SuitIcon } from "../Blackjack/PlayingCard";
+import { isRedSuit, rankLabel, suitOf } from "../Blackjack/blackjackCards";
+import { MAX_BET, pct } from "./hiloCards";
+import { HiloViewProps } from "./Hilo.types";
+
+const CardChip = ({ card, label }: { card: number; label?: string }) => (
+  <div className="flex flex-col items-center gap-1 shrink-0">
+    <div className={`w-9 h-12 rounded bg-white flex flex-col items-center justify-center leading-none ${isRedSuit(card) ? "text-red-600" : "text-[#1c1a31]"}`}>
+      <span className="font-extrabold text-sm">{rankLabel(card)}</span>
+      <SuitIcon suit={suitOf(card)} className="w-3.5" />
+    </div>
+    {label && <span className="text-[9px] text-accent-gold font-semibold uppercase">{label}</span>}
+  </div>
+);
+
+const HiloView: React.FC<HiloViewProps> = ({
+  isLogged,
+  walletBalance,
+  betInput,
+  betValue,
+  setBetInput,
+  normalizeBet,
+  halveBet,
+  doubleBet,
+  game,
+  active,
+  busy,
+  start,
+  guess,
+  skip,
+  cashout,
+  openRoll,
+}) => {
+  const ended = !!game && (game.status === "cashed" || game.status === "busted");
+  const controlsLocked = active;
+  const currentPayout = game ? betValue * game.multiplier : betValue;
+
+  return (
+    <div className="w-screen flex flex-col items-center py-6 gap-6 px-4">
+      <Title title="HiLo" />
+
+      <div className="flex flex-col lg:flex-row w-full max-w-[1100px] bg-surface rounded-lg overflow-hidden border border-line">
+        <div className="lg:w-[320px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
+          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
+            <span>Bet Amount</span>
+            <span><Monetary value={betValue} /></span>
+          </div>
+          <div className="flex">
+            <input
+              type="number"
+              value={betInput}
+              max={MAX_BET}
+              onChange={(e) => setBetInput(e.target.value.replace(/[^0-9]/g, ""))}
+              onBlur={normalizeBet}
+              disabled={controlsLocked}
+              className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm disabled:opacity-50"
+            />
+            <button onClick={halveBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold disabled:opacity-50">½</button>
+            <button onClick={doubleBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold disabled:opacity-50">2×</button>
+          </div>
+
+          {active ? (
+            <button
+              onClick={cashout}
+              disabled={busy || !game?.canCashout}
+              className="p-3 rounded bg-accent-gold hover:brightness-110 text-[#2a2100] font-bold w-full disabled:opacity-40 transition"
+            >
+              {game?.canCashout ? <>Cash Out <Monetary value={currentPayout} showFraction /></> : "Make a prediction"}
+            </button>
+          ) : (
+            <button
+              onClick={start}
+              disabled={busy}
+              className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full disabled:opacity-40 transition"
+            >
+              {isLogged ? "Bet" : "Sign in to play"}
+            </button>
+          )}
+
+          <button
+            onClick={skip}
+            disabled={busy || !game?.canSkip}
+            className="p-2.5 rounded bg-surface-raised hover:bg-surface-hover text-ink-soft font-semibold w-full flex items-center justify-center gap-2 disabled:opacity-40 transition"
+          >
+            Skip Card <span className="text-xs">»</span>
+          </button>
+
+          <button
+            onClick={() => guess("hi")}
+            disabled={busy || !active}
+            className="flex items-center justify-between p-2.5 rounded bg-surface-raised hover:bg-surface-hover disabled:opacity-40 transition text-sm font-semibold"
+          >
+            <span className="flex items-center gap-2 text-ink-soft">Higher or Equal <AiFillCaretUp className="text-green-400" /></span>
+            <span className="text-ink-muted">{game?.hiChance != null ? pct(game.hiChance) : "-"}</span>
+          </button>
+          <button
+            onClick={() => guess("lo")}
+            disabled={busy || !active}
+            className="flex items-center justify-between p-2.5 rounded bg-surface-raised hover:bg-surface-hover disabled:opacity-40 transition text-sm font-semibold"
+          >
+            <span className="flex items-center gap-2 text-ink-soft">Lower or Equal <AiFillCaretDown className="text-red-400" /></span>
+            <span className="text-ink-muted">{game?.loChance != null ? pct(game.loChance) : "-"}</span>
+          </button>
+
+          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-1">
+            <span>Total Profit ({(game?.multiplier ?? 1).toFixed(2)}×)</span>
+            <span className="text-accent-gold"><Monetary value={active && game ? currentPayout - betValue : 0} showFraction /></span>
+          </div>
+
+          {ended && game && (
+            <button
+              onClick={() => game.rollId && openRoll(game.rollId)}
+              disabled={!game.rollId}
+              className={`text-xs font-semibold text-center py-1 rounded ${game.status === "cashed" ? "text-green-400" : "text-red-400"} disabled:opacity-50`}
+            >
+              {game.status === "cashed" ? <>Won <Monetary value={game.payout} showFraction /> at {game.multiplier.toFixed(2)}×</> : "Busted! Verify roll"}
+            </button>
+          )}
+        </div>
+
+        <div className="flex-1 flex flex-col items-center p-6 gap-6">
+          <div className="flex items-center justify-center gap-6 sm:gap-14 w-full">
+            <div className="hidden sm:flex flex-col items-center gap-2 opacity-40">
+              <div className="w-16 h-24 rounded-lg border-2 border-line flex flex-col items-center justify-center text-ink-soft">
+                <span className="font-extrabold text-xl">K</span>
+                <AiFillCaretUp />
+              </div>
+              <span className="text-[10px] text-ink-muted font-semibold uppercase text-center w-24">King being<br />the highest</span>
+            </div>
+
+            <div className={busy ? "opacity-90" : ""}>
+              <PlayingCard key={game ? game.cards.length : -1} card={game?.current} faceDown={!game} instant={!game} />
+            </div>
+
+            <div className="hidden sm:flex flex-col items-center gap-2 opacity-40">
+              <div className="w-16 h-24 rounded-lg border-2 border-line flex flex-col items-center justify-center text-ink-soft">
+                <span className="font-extrabold text-xl">A</span>
+                <AiFillCaretDown />
+              </div>
+              <span className="text-[10px] text-ink-muted font-semibold uppercase text-center w-24">Ace being<br />the lowest</span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 w-full max-w-[520px]">
+            <div className="bg-surface-nav border border-line rounded p-3">
+              <div className="text-xs text-ink-muted font-semibold mb-1">Profit if Higher ({(game?.hiMultiplier ?? 0).toFixed(2)}×)</div>
+              <div className="text-sm text-accent-gold font-semibold">
+                <Monetary value={active && game?.hiMultiplier ? betValue * game.hiMultiplier - betValue : 0} showFraction />
+              </div>
+            </div>
+            <div className="bg-surface-nav border border-line rounded p-3">
+              <div className="text-xs text-ink-muted font-semibold mb-1">Profit if Lower ({(game?.loMultiplier ?? 0).toFixed(2)}×)</div>
+              <div className="text-sm text-accent-gold font-semibold">
+                <Monetary value={active && game?.loMultiplier ? betValue * game.loMultiplier - betValue : 0} showFraction />
+              </div>
+            </div>
+          </div>
+
+          {game && game.cards.length > 0 && (
+            <div className="flex items-end gap-2 w-full max-w-[560px] overflow-x-auto pb-2">
+              {game.cards.map((card, i) => (
+                <CardChip key={i} card={card} label={i === 0 ? "Initial" : undefined} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <p className="text-ink-muted text-xs max-w-[640px] text-center">
+        Balance: <Monetary value={walletBalance} />. Predict if the next card is higher or lower, then cash out before you miss.
+      </p>
+    </div>
+  );
+};
+
+export default HiloView;

--- a/src/pages/Hilo/Hilo.view.tsx
+++ b/src/pages/Hilo/Hilo.view.tsx
@@ -83,7 +83,7 @@ const HiloView: React.FC<HiloViewProps> = ({
           <button
             onClick={skip}
             disabled={busy || !game?.canSkip}
-            className="p-2.5 rounded bg-surface-raised hover:bg-surface-hover text-ink-soft font-semibold w-full flex items-center justify-center gap-2 disabled:opacity-40 transition"
+            className="p-2.5 rounded-md bg-surface-raised border border-line-strong hover:bg-surface-hover text-ink-soft font-semibold w-full flex items-center justify-center gap-2 shadow-sm hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0 transition"
           >
             Skip Card <span className="text-xs">»</span>
           </button>
@@ -91,18 +91,18 @@ const HiloView: React.FC<HiloViewProps> = ({
           <button
             onClick={() => guess("hi")}
             disabled={busy || !active}
-            className="flex items-center justify-between p-2.5 rounded bg-surface-raised hover:bg-surface-hover disabled:opacity-40 transition text-sm font-semibold"
+            className="flex items-center justify-between p-3 rounded-md bg-green-500/15 border border-green-500/50 hover:bg-green-500/25 hover:border-green-400 text-green-300 shadow-sm hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0 transition text-sm font-bold"
           >
-            <span className="flex items-center gap-2 text-ink-soft">Higher or Equal <AiFillCaretUp className="text-green-400" /></span>
-            <span className="text-ink-muted">{game?.hiChance != null ? pct(game.hiChance) : "-"}</span>
+            <span className="flex items-center gap-2">Higher or Equal <AiFillCaretUp /></span>
+            <span className="text-green-200/80">{game?.hiChance != null ? pct(game.hiChance) : "-"}</span>
           </button>
           <button
             onClick={() => guess("lo")}
             disabled={busy || !active}
-            className="flex items-center justify-between p-2.5 rounded bg-surface-raised hover:bg-surface-hover disabled:opacity-40 transition text-sm font-semibold"
+            className="flex items-center justify-between p-3 rounded-md bg-red-500/15 border border-red-500/50 hover:bg-red-500/25 hover:border-red-400 text-red-300 shadow-sm hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-40 disabled:hover:translate-y-0 transition text-sm font-bold"
           >
-            <span className="flex items-center gap-2 text-ink-soft">Lower or Equal <AiFillCaretDown className="text-red-400" /></span>
-            <span className="text-ink-muted">{game?.loChance != null ? pct(game.loChance) : "-"}</span>
+            <span className="flex items-center gap-2">Lower or Equal <AiFillCaretDown /></span>
+            <span className="text-red-200/80">{game?.loChance != null ? pct(game.loChance) : "-"}</span>
           </button>
 
           <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-1">

--- a/src/pages/Hilo/hiloCards.test.ts
+++ b/src/pages/Hilo/hiloCards.test.ts
@@ -14,11 +14,11 @@ describe("hilo card odds", () => {
         expect(loChance(11)).toBeCloseTo(12 / 13, 8);
     });
 
-    it("handles the ace and king extremes", () => {
-        expect(hiChance(0)).toBeCloseTo(1, 8);
+    it("never offers a 100% bet on the extremes", () => {
+        expect(hiChance(0)).toBeCloseTo(12 / 13, 8);
         expect(loChance(0)).toBeCloseTo(1 / 13, 8);
         expect(hiChance(12)).toBeCloseTo(1 / 13, 8);
-        expect(loChance(12)).toBeCloseTo(1, 8);
+        expect(loChance(12)).toBeCloseTo(12 / 13, 8);
     });
 
     it("has a 13-rank deck", () => {

--- a/src/pages/Hilo/hiloCards.test.ts
+++ b/src/pages/Hilo/hiloCards.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { rankOf, hiChance, loChance, RANKS } from "./hiloCards";
+
+describe("hilo card odds", () => {
+    it("ranks a card 0..12", () => {
+        expect(rankOf(11)).toBe(11); // queen of spades
+        expect(rankOf(24)).toBe(11); // queen of hearts
+        expect(rankOf(0)).toBe(0); // ace
+        expect(rankOf(12)).toBe(12); // king
+    });
+
+    it("matches the Stake queen odds", () => {
+        expect(hiChance(11)).toBeCloseTo(2 / 13, 8);
+        expect(loChance(11)).toBeCloseTo(12 / 13, 8);
+    });
+
+    it("handles the ace and king extremes", () => {
+        expect(hiChance(0)).toBeCloseTo(1, 8);
+        expect(loChance(0)).toBeCloseTo(1 / 13, 8);
+        expect(hiChance(12)).toBeCloseTo(1 / 13, 8);
+        expect(loChance(12)).toBeCloseTo(1, 8);
+    });
+
+    it("has a 13-rank deck", () => {
+        expect(RANKS).toBe(13);
+    });
+});

--- a/src/pages/Hilo/hiloCards.ts
+++ b/src/pages/Hilo/hiloCards.ts
@@ -7,7 +7,8 @@ export const MAX_BET = 10000;
 export const MAX_SKIPS = 52;
 
 export const rankOf = (card: number) => card % RANKS;
-export const hiChance = (rank: number) => (RANKS - rank) / RANKS;
-export const loChance = (rank: number) => (rank + 1) / RANKS;
+// the tie falls to the minority side on the extremes, so neither ace nor king is a 100% bet
+export const hiChance = (rank: number) => (rank === 0 ? RANKS - 1 : RANKS - rank) / RANKS;
+export const loChance = (rank: number) => (rank === RANKS - 1 ? RANKS - 1 : rank + 1) / RANKS;
 
 export const pct = (chance: number) => `${(chance * 100).toFixed(2)}%`;

--- a/src/pages/Hilo/hiloCards.ts
+++ b/src/pages/Hilo/hiloCards.ts
@@ -1,0 +1,13 @@
+// client mirror of backend/utils/hiloMath.js for the odds readouts; the server is
+// authoritative for the cards and payouts. card 0..51, rank = card % 13 (0 = ace, the
+// lowest, 12 = king, the highest).
+export const RANKS = 13;
+export const MIN_BET = 1;
+export const MAX_BET = 10000;
+export const MAX_SKIPS = 52;
+
+export const rankOf = (card: number) => card % RANKS;
+export const hiChance = (rank: number) => (RANKS - rank) / RANKS;
+export const loChance = (rank: number) => (rank + 1) / RANKS;
+
+export const pct = (chance: number) => `${(chance * 100).toFixed(2)}%`;

--- a/src/pages/Hilo/index.tsx
+++ b/src/pages/Hilo/index.tsx
@@ -1,0 +1,9 @@
+import HiloView from "./Hilo.view";
+import { useHiloServices } from "./Hilo.services";
+
+const Hilo = () => {
+  const service = useHiloServices();
+  return <HiloView {...service} />;
+};
+
+export default Hilo;

--- a/src/pages/Home/GamesListing.tsx
+++ b/src/pages/Home/GamesListing.tsx
@@ -61,6 +61,12 @@ const GameListing: React.FC<GameListingProps> = ({ name, description }) => {
       image: "/images/mines.svg",
       link: "/mines",
     },
+    {
+      id: "10",
+      title: "HiLo",
+      image: "/images/hilo.svg",
+      link: "/hilo",
+    },
   ];
   return (
     <section className="w-full flex flex-col py-6 items-center">

--- a/src/pages/ProvablyFair/ProvablyFair.view.tsx
+++ b/src/pages/ProvablyFair/ProvablyFair.view.tsx
@@ -32,7 +32,7 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
     <Title title="Provably Fair" />
 
     <p className="text-[#84819a] text-sm max-w-[640px] text-center">
-      Every case, upgrade, slot, plinko, blackjack, dice and mines roll is HMAC-SHA256 of your
+      Every case, upgrade, slot, plinko, blackjack, dice, mines and hilo roll is HMAC-SHA256 of your
       client seed, a nonce, and a secret server seed we commit to up front.
     </p>
 
@@ -63,11 +63,11 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
           </span>
           <button
             onClick={doVerify}
-            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice" && roll.game !== "mines")}
+            disabled={verifying || (roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice" && roll.game !== "mines" && roll.game !== "hilo")}
             className="px-4 py-1.5 rounded bg-green-700 hover:bg-green-600 text-sm font-semibold disabled:opacity-50"
             title={
-              roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice" && roll.game !== "mines"
-                ? "Auto-verify supported for case, plinko, blackjack, dice and mines rolls"
+              roll.game !== "case" && roll.game !== "plinko" && roll.game !== "blackjack" && roll.game !== "dice" && roll.game !== "mines" && roll.game !== "hilo"
+                ? "Auto-verify supported for case, plinko, blackjack, dice, mines and hilo rolls"
                 : ""
             }
           >
@@ -122,7 +122,9 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
                     ? `Verified: the recomputed roll is ${verify.recomputedResult}, a ${verify.recomputedWon ? "win" : "loss"} at x${verify.recomputedMultiplier}, payout ${verify.recomputedPayout}.`
                     : verify.recomputedMineSet
                       ? `Verified: the mines were at ${verify.recomputedMineSet.join(", ")}; ${verify.recomputedGems} gems, ${verify.recomputedBusted ? "busted" : "cashed"}, payout ${verify.recomputedPayout}.`
-                      : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
+                      : verify.recomputedCards
+                        ? `Verified: the cards were ${verify.recomputedCards.join(", ")}; ${verify.recomputedGuesses} correct, ${verify.recomputedBusted ? "busted" : "cashed"}, payout ${verify.recomputedPayout}.`
+                        : `Verified: recomputed roll ${verify.recomputedRoll} maps to the same item.`
               : `Not verified${verify.reason ? `: ${verify.reason}` : ""}.`}
           </div>
         )}

--- a/src/seo/routes.json
+++ b/src/seo/routes.json
@@ -52,6 +52,10 @@
       "title": "Mines | KaniCasino",
       "description": "Reveal diamonds and dodge the bombs. Cash out any time. Provably fair, no real money involved."
     },
+    "/hilo": {
+      "title": "HiLo | KaniCasino",
+      "description": "Predict higher or lower, build a multiplier, and cash out before you miss. Provably fair, no real money involved."
+    },
     "/battles": {
       "title": "Case Battles | KaniCasino",
       "description": "Open cases head to head against other players. Best total value takes the pot."

--- a/src/services/fair/FairServices.ts
+++ b/src/services/fair/FairServices.ts
@@ -22,7 +22,7 @@ export interface RollRange {
 
 export interface RollView {
   rollId: string;
-  game: "case" | "upgrade" | "slots" | "battle" | "plinko" | "blackjack" | "dice" | "mines";
+  game: "case" | "upgrade" | "slots" | "battle" | "plinko" | "blackjack" | "dice" | "mines" | "hilo";
   clientSeed: string;
   serverSeedHash: string;
   serverSeed: string | null;
@@ -65,6 +65,8 @@ export interface VerifyResult {
   recomputedMineSet?: number[];
   recomputedGems?: number;
   recomputedBusted?: boolean;
+  recomputedCards?: string[];
+  recomputedGuesses?: number;
 }
 
 export const getSeed = () => api.get<SeedState>("/fair/seed").then((r) => r.data);

--- a/src/services/games/GamesServices.ts
+++ b/src/services/games/GamesServices.ts
@@ -54,6 +54,31 @@ export async function getActiveMinesGame() {
     return response.data;
 }
 
+export async function startHilo(betAmount: number) {
+    const response = await api.post(`/games/hilo/start`, { betAmount });
+    return response.data;
+}
+
+export async function guessHilo(direction: "hi" | "lo") {
+    const response = await api.post(`/games/hilo/guess`, { direction });
+    return response.data;
+}
+
+export async function skipHilo() {
+    const response = await api.post(`/games/hilo/skip`, {});
+    return response.data;
+}
+
+export async function cashoutHilo() {
+    const response = await api.post(`/games/hilo/cashout`, {});
+    return response.data;
+}
+
+export async function getActiveHiloGame() {
+    const response = await api.get(`/games/hilo/active`);
+    return response.data;
+}
+
 export async function dealBlackjack(betAmount: number) {
     const response = await api.post(`/games/blackjack/deal`, { betAmount });
     return response.data;


### PR DESCRIPTION
A new HiLo game (Stake original): predict whether the next card is higher or lower than the current one, compounding a multiplier with each correct call, and cash out before you miss. Stateful HTTP game built on the blackjack/mines skeleton, reusing the existing blackjack card art.

## Game
- `POST /games/hilo/start {betAmount}`, then `/guess {direction}`, `/skip`, `/cashout`. One active game per user, actionSeq compare-and-set, recovery sweep, and seed rotation blocked while a game is live.
- Cards come from one nonce, one draw per card at successive cursors (cursor 0 = start card), so the upcoming cards are committed and never leave the server while active. Ace is low, King is high. Higher-or-equal wins on `>=`, lower-or-equal on `<=`, so a tie wins either bet (the Stake model). Each correct guess multiplies by `0.99 / chance` (99% RTP) - the queen example reproduces exactly (hi 2/13 -> 6.44x, lo 12/13 -> 1.07x). Wrong guess busts. Skip redraws the current card free (up to 52). Cash out after at least one correct guess; payout capped at 1,000,000.
- Frontend follows the reference image: the current card between the King-high / Ace-low legend, the two prediction rows with live odds, skip and cash-out, potential-profit boxes per direction, and a drawn-card strip with the initial card labelled.

## Every ledger surface
HILO_BET/HILO_WIN types, STAKE_TYPES, missions and adminStats WIN_TYPES, the accounts counterparty map, the backoffice per-game P&L (GAME_LINES + THEO_RTP 0.99 + label), the Roll enum, seed-rotation block, and a verifyHiloRoll that re-derives the cards and re-prices the payout, wired into the fair page.

## Tests
Backend hiloMath unit (card/rank mapping, Stake odds, tie handling, resolve/replay) and a hiloPF integration suite (charge/guess/skip/cashout/bust, one-active-per-user, bad inputs, rotated-seed verify). Full backend suite green: 65 suites, 464 tests. Frontend hiloCards unit, plus unit/e2e/lint/build all green.
