### PR TITLE
First-visit onboarding modal

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+// same no-backend mocks as smoke.spec.ts, but without seeding the seen flag:
+// a fresh context is exactly the first visit the onboarding is for
+test.beforeEach(async ({ page }) => {
+  await page.route("**/cases**", (route) => route.fulfill({ json: [] }));
+  await page.route("**/cases/most-opened**", (route) => route.fulfill({ json: [] }));
+  await page.route("**/topPlayers**", (route) => route.fulfill({ json: [] }));
+  await page.route("**/ranking**", (route) =>
+    route.fulfill({ json: { ranking: 0, users: [] } })
+  );
+  await page.route("**/marketplace**", (route) =>
+    route.fulfill({ json: { totalPages: 0, currentPage: 1, items: [] } })
+  );
+});
+
+test("the onboarding shows on a first visit and stays gone once dismissed", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Welcome to KaniCasino!")).toBeVisible();
+
+  await page.getByRole("button", { name: "Got it, let's play!" }).click();
+  await expect(page.getByText("Welcome to KaniCasino!")).toBeHidden();
+
+  // the page is usable again: a navbar link is clickable
+  await page.getByRole("link", { name: "Market" }).first().click();
+  await expect(page).toHaveURL(/\/marketplace/);
+
+  await page.goto("/");
+  await expect(page.getByText("Welcome to KaniCasino!")).toHaveCount(0);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -11,6 +11,9 @@ const cases = [
 
 // mock every API call the home page makes so the suite needs no backend
 test.beforeEach(async ({ page }) => {
+  // a fresh context counts as a first visit, so the onboarding modal would
+  // overlay the page and intercept every click below (it has its own spec)
+  await page.addInitScript(() => localStorage.setItem("kani.onboardingSeen", "1"));
   await page.route("**/cases**", (route) => route.fulfill({ json: cases }));
   // registered after the catch-all so it wins: playwright matches newest route first.
   // empty by default, so the same case title never renders in two sections at once

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { toastMissionComplete } from "./pages/Missions/components/missionComplet
 import NavigationBridge from "./components/NavigationBridge";
 import PageMeta from "./components/PageMeta";
 import BootLoader from "./components/BootLoader";
+import OnboardingModal from "./components/OnboardingModal";
 
 const Header = lazy(() => import("./components/header/index"));
 const AppRoutes = lazy(() => import("./Routes"));
@@ -228,6 +229,7 @@ function App() {
                   notification={notification}
                   setNotification={setNotification}
                 />
+                <OnboardingModal />
                 <div className="flex w-full">
                   <AppRoutes />
                 </div>

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -9,9 +9,11 @@ interface Avatar {
     loading?: boolean;
     level: number;
     showLevel?: boolean;
+    // skip the profile link when a parent already links to the profile (avoids nested <a>)
+    noLink?: boolean;
 }
 
-const Avatar: React.FC<Avatar> = ({ image, loading, id, size, level, showLevel = false }) => {
+const Avatar: React.FC<Avatar> = ({ image, loading, id, size, level, showLevel = false, noLink = false }) => {
     const [loaded, setLoaded] = useState<boolean>(false);
 
     let sizeClasses, skeletonSize;
@@ -74,6 +76,44 @@ const Avatar: React.FC<Avatar> = ({ image, loading, id, size, level, showLevel =
     }
 
 
+    const content = (
+        <>
+            {!loaded && (
+                <Skeleton
+                    circle={true}
+                    height={40}
+                    width={40}
+                    highlightColor="#161427"
+                    baseColor="#1c1a31"
+                />
+            )}
+
+            <div className="relative">
+                <img
+                    src={image ? image : "https://i.imgur.com/uUfJSwW.png"}
+                    alt="avatar"
+                    className={`${sizeClasses} rounded-full object-cover border-2 aspect-square ${loaded ? '' : 'hidden'}`}
+                    style={{
+                        borderColor: getLevelColor()
+                    }}
+                    onLoad={() => setLoaded(true)}
+                />
+                {
+                    showLevel && (
+                        <div className={`absolute rounded-full text-xs font-semibold min-w-[20px] h-5 flex justify-center items-center text-white
+                        ${LevelSize} ${DivPosition}`}
+                            style={{
+                                backgroundColor: getLevelColor()
+                            }}
+                        >
+                            {level}
+                        </div>
+                    )
+                }
+            </div>
+        </>
+    );
+
     return (
         <div className="min-w-[48px] ">
             {loading ? (
@@ -84,41 +124,11 @@ const Avatar: React.FC<Avatar> = ({ image, loading, id, size, level, showLevel =
                     highlightColor="#161427"
                     baseColor="#1c1a31"
                 />
+            ) : noLink ? (
+                content
             ) : (
                 <Link to={`/profile/${id}`}>
-                    {!loaded && (
-                        <Skeleton
-                            circle={true}
-                            height={40}
-                            width={40}
-                            highlightColor="#161427"
-                            baseColor="#1c1a31"
-                        />
-                    )}
-
-                    <div className="relative">
-                        <img
-                            src={image ? image : "https://i.imgur.com/uUfJSwW.png"}
-                            alt="avatar"
-                            className={`${sizeClasses} rounded-full object-cover border-2 aspect-square ${loaded ? '' : 'hidden'}`}
-                            style={{
-                                borderColor: getLevelColor()
-                            }}
-                            onLoad={() => setLoaded(true)}
-                        />
-                        {
-                            showLevel && (
-                                <div className={`absolute rounded-full text-xs font-semibold min-w-[20px] h-5 flex justify-center items-center text-white
-                                ${LevelSize} ${DivPosition}`}
-                                    style={{
-                                        backgroundColor: getLevelColor()
-                                    }}
-                                >
-                                    {level}
-                                </div>
-                            )
-                        }
-                    </div>
+                    {content}
                 </Link>
             )}
         </div>

--- a/src/components/OnboardingModal.test.tsx
+++ b/src/components/OnboardingModal.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import OnboardingModal from "./OnboardingModal";
+
+describe("OnboardingModal", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows on a first visit", () => {
+    render(<OnboardingModal />);
+    expect(screen.getByText("Welcome to KaniCasino!")).toBeInTheDocument();
+    expect(screen.getByText("Start with free coins")).toBeInTheDocument();
+  });
+
+  it("does not show again once seen", () => {
+    localStorage.setItem("kani.onboardingSeen", "1");
+    const { container } = render(<OnboardingModal />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("dismissing it marks it as seen", () => {
+    render(<OnboardingModal />);
+    fireEvent.click(screen.getByText("Got it, let's play!"));
+    expect(screen.queryByText("Welcome to KaniCasino!")).toBeNull();
+    expect(localStorage.getItem("kani.onboardingSeen")).toBe("1");
+  });
+
+  it("closing with the X also marks it as seen", () => {
+    render(<OnboardingModal />);
+    fireEvent.click(screen.getByLabelText("close modal"));
+    expect(screen.queryByText("Welcome to KaniCasino!")).toBeNull();
+    expect(localStorage.getItem("kani.onboardingSeen")).toBe("1");
+  });
+});

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import Modal from "./Modal";
+import MainButton from "./MainButton";
+
+const SEEN_KEY = "kani.onboardingSeen";
+
+const steps = [
+  {
+    image: "/images/coinHeads.webp",
+    title: "Start with free coins",
+    text: "Every new account gets a free K₽ balance, and the Claim Bonus button in the navbar adds more.",
+  },
+  {
+    image: "/images/boo.webp",
+    title: "Play and win",
+    text: "Bet on the games, open cases, and sell or upgrade the items you unbox.",
+  },
+  {
+    image: "/images/clock.webp",
+    title: "Empty on cash?",
+    text: "The free bonus comes back every 8 minutes. Wait out the cooldown, claim it, and keep playing.",
+  },
+];
+
+const OnboardingModal = () => {
+  // storage can be blocked; then the tour shows every visit, which is harmless
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem(SEEN_KEY);
+    } catch {
+      return true;
+    }
+  });
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(SEEN_KEY, "1");
+    } catch {
+      // nothing to do: the modal still closes for the session
+    }
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <Modal open={open} setOpen={dismiss} width="520px">
+      <div className="flex flex-col items-center gap-5">
+        <h2 className="text-2xl font-bold text-center">Welcome to KaniCasino!</h2>
+        <p className="text-ink-soft text-sm text-center">
+          Everything here runs on K₽, a fictional coin. It is never real money and
+          there is nothing to buy or cash out, so play as much as you want.
+        </p>
+        <div className="flex flex-col gap-3 w-full">
+          {steps.map((step) => (
+            <div key={step.title} className="flex items-center gap-4 bg-surface rounded-md p-4">
+              <img src={step.image} alt="" className="w-14 h-14 object-contain shrink-0" />
+              <div className="flex flex-col gap-1">
+                <span className="font-bold">{step.title}</span>
+                <span className="text-ink-soft text-sm">{step.text}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <MainButton text="Got it, let's play!" onClick={dismiss} />
+      </div>
+    </Modal>
+  );
+};
+
+export default OnboardingModal;

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { AiOutlineClockCircle } from "react-icons/ai";
 import Modal from "./Modal";
 import MainButton from "./MainButton";
 
@@ -8,7 +9,7 @@ const steps = [
   {
     image: "/images/coinHeads.webp",
     title: "Start with free coins",
-    text: "Every new account gets a free K₽ balance, and the Claim Bonus button in the navbar adds more.",
+    text: `Get K₽ by clicking on the bouncing "Claim Bonus" button on the navbar.`,
   },
   {
     image: "/images/boo.webp",
@@ -16,7 +17,7 @@ const steps = [
     text: "Bet on the games, open cases, and sell or upgrade the items you unbox.",
   },
   {
-    image: "/images/clock.webp",
+    icon: <AiOutlineClockCircle className="w-14 h-14 shrink-0 text-accent-gold" />,
     title: "Empty on cash?",
     text: "The free bonus comes back every 8 minutes. Wait out the cooldown, claim it, and keep playing.",
   },
@@ -46,15 +47,26 @@ const OnboardingModal = () => {
   return (
     <Modal open={open} setOpen={dismiss} width="520px">
       <div className="flex flex-col items-center gap-5">
-        <h2 className="text-2xl font-bold text-center">Welcome to KaniCasino!</h2>
+        <h2 className="text-2xl font-bold text-center">
+          Welcome to KaniCasino!
+        </h2>
         <p className="text-ink-soft text-sm text-center">
-          Everything here runs on K₽, a fictional coin. It is never real money and
-          there is nothing to buy or cash out, so play as much as you want.
+          Everything here runs on K₽, a fictional coin. It is not real money, so
+          play as much as you want.
         </p>
         <div className="flex flex-col gap-3 w-full">
           {steps.map((step) => (
-            <div key={step.title} className="flex items-center gap-4 bg-surface rounded-md p-4">
-              <img src={step.image} alt="" className="w-14 h-14 object-contain shrink-0" />
+            <div
+              key={step.title}
+              className="flex items-center gap-4 bg-surface rounded-md p-4"
+            >
+              {step.icon ?? (
+                <img
+                  src={step.image}
+                  alt=""
+                  className="w-14 h-14 object-contain shrink-0"
+                />
+              )}
               <div className="flex flex-col gap-1">
                 <span className="font-bold">{step.title}</span>
                 <span className="text-ink-soft text-sm">{step.text}</span>

--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -46,7 +46,7 @@ const Player: React.FC<Player> = ({ user, size, direction = "row", showLevel = "
             }
             <Link to={`/profile/${user._id}`}>
                 <div className={`flex items-center justify-center text-white ${direction == "row" ? "gap-4" : "flex-col"}`}>
-                    <Avatar id={user._id} image={user.profilePicture} size={size} showLevel={!!showLevel} level={user.level} />
+                    <Avatar id={user._id} image={user.profilePicture} size={size} showLevel={!!showLevel} level={user.level} noLink />
                     <span className="mt-2 font-semibold text-center">{user.username}</span>
                 </div>
             </Link>

--- a/src/pages/Home/Leaderboard.tsx
+++ b/src/pages/Home/Leaderboard.tsx
@@ -29,9 +29,9 @@ const Leaderboard = () => {
 
             {!loading && users[1] ? (
                 <div className="flex gap-14 my-16 ">
-                    <TopPlayer key={users[1].id} user={users[1]} rank={2} />
-                    <TopPlayer key={users[0].id} user={users[0]} rank={1} />
-                    <TopPlayer key={users[2].id} user={users[2]} rank={3} />
+                    <TopPlayer key={users[1]._id} user={users[1]} rank={2} />
+                    <TopPlayer key={users[0]._id} user={users[0]} rank={1} />
+                    <TopPlayer key={users[2]._id} user={users[2]} rank={3} />
                 </div>
             ) : (
                 <div className="h-[330px]">
@@ -60,7 +60,7 @@ const Leaderboard = () => {
                         </td></tr>}
 
                         {!loading && users.slice(3).map((user, index) => (
-                            <tr key={user.id}>
+                            <tr key={user._id}>
                                 <td className="px-6 py-4 whitespace-nowrap">
                                     #{index + 4}
                                 </td>


### PR DESCRIPTION
## Problem

New players had no way to tell the coins are fictional or how to get a starting balance, and no cue about the bonus cooldown when they run out.

## Change

A one-time welcome modal that shows on the first visit, explaining that K₽ is a fake currency and walking through three steps: claim the free bonus, play the games and open cases, and wait out the 8-minute cooldown when empty. Dismissal (button, X, or backdrop) is stored in localStorage, so it never nags a returning player; a reload without acknowledging shows it again.

Also fixes two pre-existing console warnings on the Home leaderboard that surfaced while testing: undefined React keys (the topPlayers response has `_id` but not the `id` virtual) and a nested `<a>` from Avatar re-linking inside Player's link.

## Tests

- Unit (`OnboardingModal.test.tsx`): first-visit show, suppressed once seen, both dismiss paths set the flag.
- E2E (`onboarding.spec.ts`): shows on first visit, dismisses, page stays usable, stays gone on reload. Smoke suite seeds the seen flag so the overlay doesn't swallow its clicks.
- `tsc`, eslint (touched files clean), full `npm run build`, and `npm run test:unit` (88 passing) all green.