### PR TITLE
Shared layout and controls for every game

### DIFF
--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -1,10 +1,12 @@
 interface TitleProps {
   title: string;
+  // game pages only: the full py-10 pushed the board too far down the page
+  compact?: boolean;
 }
 
-const Title: React.FC<TitleProps> = ({ title }) => {
+const Title: React.FC<TitleProps> = ({ title, compact = false }) => {
   return (
-    <div className="w-fit py-10">
+    <div className={`w-fit ${compact ? "pb-4" : "py-10"}`}>
       <div className="text-white w-auto text-3xl font-semibold">
         {title.toUpperCase()}
       </div>

--- a/src/components/game/BetAmount.tsx
+++ b/src/components/game/BetAmount.tsx
@@ -1,0 +1,75 @@
+import Monetary from "../Monetary";
+
+interface BetAmountProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBlur?: () => void;
+  onHalve: () => void;
+  onDouble: () => void;
+  // pass onMax to show the Max button; games that do not cap the bet leave it out
+  onMax?: () => void;
+  betValue: number;
+  disabled?: boolean;
+  label?: string;
+  hint?: React.ReactNode;
+}
+
+// the bet field every game shares: one input plus the ½ / 2× steppers, and Max when offered
+const BetAmount: React.FC<BetAmountProps> = ({
+  value,
+  onChange,
+  onBlur,
+  onHalve,
+  onDouble,
+  onMax,
+  betValue,
+  disabled,
+  label = "Bet Amount",
+  hint,
+}) => {
+  const steps = [
+    { key: "half", text: "½", run: onHalve },
+    { key: "double", text: "2×", run: onDouble },
+    ...(onMax ? [{ key: "max", text: "Max", run: onMax }] : []),
+  ];
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
+        <span>{label}</span>
+        <span><Monetary value={betValue} /></span>
+      </div>
+      <div className="flex">
+        <input
+          type="text"
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => onChange(e.target.value.replace(/[^0-9]/g, ""))}
+          onBlur={onBlur}
+          disabled={disabled}
+          // size 1 drops the input's default 20-character intrinsic width, which flex cannot
+          // shrink past and which pushed the whole page wider than a phone
+          size={1}
+          className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full min-w-0 text-sm disabled:opacity-50"
+        />
+        {steps.map((step, i) => (
+          <button
+            key={step.key}
+            onClick={step.run}
+            disabled={disabled}
+            className={`px-3 bg-surface-raised hover:bg-surface-hover text-sm font-semibold disabled:opacity-50 ${
+              i === steps.length - 1
+                ? "border border-line rounded-r rounded-l-none"
+                : "border-y border-line rounded-none"
+            }`}
+          >
+            {step.text}
+          </button>
+        ))}
+      </div>
+      {hint && <span className="text-xs text-ink-muted">{hint}</span>}
+    </div>
+  );
+};
+
+export default BetAmount;

--- a/src/components/game/GameButton.tsx
+++ b/src/components/game/GameButton.tsx
@@ -1,0 +1,27 @@
+interface GameButtonProps {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  variant?: "primary" | "cashout" | "danger" | "secondary";
+}
+
+// the four actions a game can offer, so play is green everywhere and cashing out is always gold.
+// hover is gated on :enabled, otherwise a disabled button still lights up under the cursor.
+const variants = {
+  primary: "bg-green-500 enabled:hover:bg-green-400 text-[#10241A]",
+  cashout: "bg-accent-gold enabled:hover:brightness-110 text-[#2a2100]",
+  danger: "bg-red-500 enabled:hover:bg-red-400 text-white",
+  secondary: "bg-accent enabled:hover:bg-accent-light text-white",
+};
+
+const GameButton: React.FC<GameButtonProps> = ({ children, onClick, disabled, variant = "primary" }) => (
+  <button
+    onClick={onClick}
+    disabled={disabled}
+    className={`w-full min-h-[46px] px-3 rounded font-bold transition-colors disabled:opacity-40 ${variants[variant]}`}
+  >
+    {children}
+  </button>
+);
+
+export default GameButton;

--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -1,0 +1,30 @@
+import Title from "../Title";
+
+interface GameLayoutProps {
+  title?: string;
+  panel: React.ReactNode;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+// the shared shell every game page sits in: one container holding the controls and the board.
+// the board comes first on phones, so the game is on screen without scrolling past a tall
+// stack of controls to reach it.
+const GameLayout: React.FC<GameLayoutProps> = ({ title, panel, children, footer }) => (
+  <div className="w-full flex flex-col items-center gap-6 px-3 sm:px-4 pt-4 pb-10">
+    {title && <Title title={title} compact />}
+
+    <div className="w-full max-w-[1200px] flex flex-col-reverse lg:flex-row bg-surface rounded-lg overflow-hidden border border-line">
+      <div className="w-full lg:w-[320px] shrink-0 flex flex-col gap-3 p-4 sm:p-5 border-t lg:border-t-0 lg:border-r border-line">
+        {panel}
+      </div>
+      <div className="flex-1 min-w-0 flex items-center justify-center p-3 sm:p-6">
+        {children}
+      </div>
+    </div>
+
+    {footer}
+  </div>
+);
+
+export default GameLayout;

--- a/src/components/game/ModeToggle.tsx
+++ b/src/components/game/ModeToggle.tsx
@@ -1,0 +1,27 @@
+const MODES = ["manual", "auto"] as const;
+
+interface ModeToggleProps {
+  mode: "manual" | "auto";
+  setMode: (mode: "manual" | "auto") => void;
+  manualDisabled?: boolean;
+  autoDisabled?: boolean;
+}
+
+const ModeToggle: React.FC<ModeToggleProps> = ({ mode, setMode, manualDisabled, autoDisabled }) => (
+  <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
+    {MODES.map((m) => (
+      <button
+        key={m}
+        onClick={() => setMode(m)}
+        disabled={m === "manual" ? manualDisabled : autoDisabled}
+        className={`flex-1 py-1.5 rounded capitalize transition-colors disabled:opacity-50 ${
+          mode === m ? "bg-surface-raised text-white" : "text-ink-muted hover:text-white"
+        }`}
+      >
+        {m}
+      </button>
+    ))}
+  </div>
+);
+
+export default ModeToggle;

--- a/src/components/game/OptionRow.tsx
+++ b/src/components/game/OptionRow.tsx
@@ -1,0 +1,39 @@
+interface OptionRowProps<T extends string | number> {
+  label?: string;
+  options: readonly T[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+}
+
+// the segmented picker behind every fixed choice in a game panel: risk level, bet count, and
+// anything else that is a short list of equal options
+function OptionRow<T extends string | number>({
+  label,
+  options,
+  value,
+  onChange,
+  disabled,
+}: OptionRowProps<T>) {
+  return (
+    <div className="flex flex-col gap-1">
+      {label && <span className="text-xs font-semibold text-ink-muted">{label}</span>}
+      <div className="flex gap-1">
+        {options.map((option) => (
+          <button
+            key={option}
+            onClick={() => onChange(option)}
+            disabled={disabled}
+            className={`flex-1 py-1.5 rounded text-sm font-semibold capitalize transition-colors disabled:opacity-50 ${
+              value === option ? "bg-surface-raised text-white" : "bg-surface-nav text-ink-muted hover:text-white"
+            }`}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default OptionRow;

--- a/src/pages/Blackjack/Blackjack.view.tsx
+++ b/src/pages/Blackjack/Blackjack.view.tsx
@@ -2,6 +2,7 @@ import { GiCardDraw, GiTwoCoins } from "react-icons/gi";
 import { FaClone, FaHandPaper } from "react-icons/fa";
 import GameLayout from "../../components/game/GameLayout";
 import GameButton from "../../components/game/GameButton";
+import BetAmount from "../../components/game/BetAmount";
 import Monetary from "../../components/Monetary";
 import PlayingCard from "./PlayingCard";
 import { outcomeLabel, totalLabel } from "./blackjackCards";
@@ -185,42 +186,17 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
       }
       panel={
         <>
-          <div className="flex items-center justify-between">
-            <label className="text-xs uppercase tracking-wider text-[#84819a]">Bet amount</label>
-            <span className="text-xs text-[#84819a]">
-              <Monetary value={walletBalance} />
-            </span>
-          </div>
-          <div className="flex items-stretch bg-[#19172D] border border-[#2A2840] focus-within:border-indigo-500 rounded-md overflow-hidden">
-            <span className="flex items-center pl-3 pr-1 text-[#FFCC00] font-extrabold text-sm">
-              K₽
-            </span>
-            <input
-              value={betInput}
-              onChange={(e) => setBetInput(e.target.value)}
-              onBlur={normalizeBet}
-              disabled={!betting || acting}
-              inputMode="numeric"
-              // size 1 kills the input's default 20-character intrinsic width, which flex-1
-              // cannot shrink past and which pushed the whole page wider than a phone
-              size={1}
-              className="flex-1 min-w-0 bg-transparent outline-none px-2 py-2.5 text-sm font-semibold disabled:opacity-60"
-            />
-            {[
-              { label: "½", fn: halveBet },
-              { label: "2×", fn: doubleBet },
-              { label: "Max", fn: maxOutBet },
-            ].map((b) => (
-              <button
-                key={b.label}
-                onClick={b.fn}
-                disabled={!betting || acting}
-                className="px-3 border-l border-[#2A2840] text-sm font-bold text-[#C9C6DE] hover:bg-[#281D3F] disabled:opacity-40"
-              >
-                {b.label}
-              </button>
-            ))}
-          </div>
+          <BetAmount
+            value={betInput}
+            onChange={setBetInput}
+            onBlur={normalizeBet}
+            onHalve={halveBet}
+            onDouble={doubleBet}
+            onMax={maxOutBet}
+            betValue={betValue}
+            disabled={!betting || acting}
+            hint={<>Balance <Monetary value={walletBalance} /></>}
+          />
 
           {awaitingInsurance && (
             <div className="rounded-md bg-[#19172D] border border-[#2A2840] p-3 flex flex-col gap-2">

--- a/src/pages/Blackjack/Blackjack.view.tsx
+++ b/src/pages/Blackjack/Blackjack.view.tsx
@@ -1,6 +1,7 @@
 import { GiCardDraw, GiTwoCoins } from "react-icons/gi";
 import { FaClone, FaHandPaper } from "react-icons/fa";
-import Title from "../../components/Title";
+import GameLayout from "../../components/game/GameLayout";
+import GameButton from "../../components/game/GameButton";
 import Monetary from "../../components/Monetary";
 import PlayingCard from "./PlayingCard";
 import { outcomeLabel, totalLabel } from "./blackjackCards";
@@ -171,11 +172,19 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
       : totalLabel(dealerShown.length > 1 ? dealerShown : dealerCards.slice(0, 2));
 
   return (
-    <div className="w-full flex flex-col items-center py-6 px-3">
-      <Title title="Blackjack" />
-      <div className="flex flex-col lg:flex-row gap-6 w-full max-w-[1100px] mt-4">
-        {/* control panel: one stable layout, actions always visible */}
-        <div className="w-full lg:w-72 shrink-0 order-2 lg:order-1 bg-[#212031] rounded-lg p-4 flex flex-col gap-3 h-fit">
+    <GameLayout
+      title="Blackjack"
+      footer={
+        <button
+          onClick={() => hand?.rollId && openRoll(hand.rollId)}
+          disabled={!hand?.rollId}
+          className="text-xs text-[#625F7E] hover:text-[#84819a] disabled:cursor-default"
+        >
+          Provably fair · one seed per hand, one cursor per card
+        </button>
+      }
+      panel={
+        <>
           <div className="flex items-center justify-between">
             <label className="text-xs uppercase tracking-wider text-[#84819a]">Bet amount</label>
             <span className="text-xs text-[#84819a]">
@@ -192,6 +201,9 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
               onBlur={normalizeBet}
               disabled={!betting || acting}
               inputMode="numeric"
+              // size 1 kills the input's default 20-character intrinsic width, which flex-1
+              // cannot shrink past and which pushed the whole page wider than a phone
+              size={1}
               className="flex-1 min-w-0 bg-transparent outline-none px-2 py-2.5 text-sm font-semibold disabled:opacity-60"
             />
             {[
@@ -244,13 +256,9 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
             <ActionButton label="Double" icon={<GiTwoCoins size={17} />} iconColor="text-[#5EEAD4]" onClick={double} disabled={!canDouble} />
           </div>
 
-          <button
-            onClick={() => deal()}
-            disabled={!betting || acting || betValue > walletBalance}
-            className="min-h-[50px] rounded-md bg-green-600 hover:bg-green-500 font-extrabold text-base tracking-wide disabled:opacity-40 disabled:hover:bg-green-600 transition-colors"
-          >
+          <GameButton onClick={() => deal()} disabled={!betting || acting || betValue > walletBalance}>
             {acting ? "Dealing..." : phase === "settled" ? "Rebet" : "Deal"}
-          </button>
+          </GameButton>
 
           {phase === "settled" && settledOutcome && (
             <div className="rounded-md bg-[#19172D] px-3 py-2 text-center">
@@ -301,10 +309,10 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
               </div>
             </div>
           )}
-        </div>
-
-        {/* table */}
-        <div className="flex-1 order-1 lg:order-2 rounded-lg p-4 sm:p-8 flex flex-col items-center justify-between min-h-[460px] sm:min-h-[540px] [background:radial-gradient(ellipse_at_50%_-20%,#2a2650_0%,#1a1830_55%,#151225_100%)]">
+        </>
+      }
+    >
+      <div className="w-full rounded-lg p-4 sm:p-8 flex flex-col items-center justify-between min-h-[460px] sm:min-h-[540px] [background:radial-gradient(ellipse_at_50%_-20%,#2a2650_0%,#1a1830_55%,#151225_100%)]">
           {/* dealer */}
           <div className="flex flex-col items-center min-h-[170px] justify-start">
             {hand ? (
@@ -365,18 +373,9 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
                 insurance <Monetary value={hand.insuranceBet} />
               </span>
             )}
-          </div>
         </div>
       </div>
-
-      <button
-        onClick={() => hand?.rollId && openRoll(hand.rollId)}
-        disabled={!hand?.rollId}
-        className="mt-4 text-xs text-[#625F7E] hover:text-[#84819a] disabled:cursor-default"
-      >
-        Provably fair · one seed per hand, one cursor per card
-      </button>
-    </div>
+    </GameLayout>
   );
 };
 

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import UserContext from "../../UserContext";
 import LiveBets from "./LiveBets";
 import GameButton from "../../components/game/GameButton";
+import BetAmount from "../../components/game/BetAmount";
 import { getCoinFlipHistory } from "../../services/games/GamesServices";
 
 const socket = SocketConnection.getInstance();
@@ -146,20 +147,15 @@ const CoinFlip = () => {
     <div className="w-screen flex flex-col items-center justify-center gap-12">
       <div className="flex bg-[#212031] rounded flex-col lg:flex-row">
         <div className="lg:w-[340px] flex flex-col items-center gap-4 border-r border-gray-700 py-4 px-6">
-          <input
-            type="number"
-            value={bet}
-            onKeyDown={(event) => {
-              if (!/[0-9]/.test(event.key) && event.key !== "Backspace") {
-                event.preventDefault();
-              }
-            }}
-            onChange={(e) => {
-              const value = Number(e.target.value);
-              setBet(value < 0 ? 0 : value);
-            }}
-            className="p-2 border rounded w-1/2 lg:w-full"
-          />
+          <div className="w-full">
+            <BetAmount
+              value={bet === 0 ? "" : String(bet)}
+              onChange={(value) => setBet(value === "" ? 0 : Math.min(MAX_BET, Number(value)))}
+              onHalve={() => setBet(Math.max(MIN_BET, Math.floor(bet / 2)))}
+              onDouble={() => setBet(Math.min(MAX_BET, (bet || MIN_BET) * 2))}
+              betValue={bet}
+            />
+          </div>
           <div className="flex flex-col gap-2 w-full">
             <label className="text-lg font-semibold">Choose a side</label>
             <div className="flex items-center justify-between gap-2 w-full flex-col lg:flex-row">
@@ -184,7 +180,7 @@ const CoinFlip = () => {
                 ))
               }
             </div></div>
-          <div className="mt-4">
+          <div className="w-full mt-4">
             <GameButton
               onClick={handleBet}
               disabled={

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -5,6 +5,7 @@ import Coin from "./Coin"
 import { motion } from "framer-motion";
 import UserContext from "../../UserContext";
 import LiveBets from "./LiveBets";
+import GameButton from "../../components/game/GameButton";
 import { getCoinFlipHistory } from "../../services/games/GamesServices";
 
 const socket = SocketConnection.getInstance();
@@ -183,21 +184,25 @@ const CoinFlip = () => {
                 ))
               }
             </div></div>
-          <button onClick={handleBet} className=" p-2 border rounded bg-indigo-600 hover:bg-indigo-700 w-full mt-4" disabled={
-            choice === null || bet < MIN_BET || userGambled || (userData !== null && userData.walletBalance < bet) || spinning || bet > MAX_BET
-          }>
-            {
-
-              spinning ? "Spinning..."
-                : choice === null ? "Choose a side"
-                  : bet === 0 ? "Place the bet value"
-                    : bet < MIN_BET ? `Min bet is ${MIN_BET}`
-                      : bet > MAX_BET ? "Max bet is 1M"
-                        : userGambled ? "You're in!"
-                          : userData !== null && userData.walletBalance < bet ? "Not enough money"
-                            : "Enter the Game"
-            }
-          </button>
+          <div className="mt-4">
+            <GameButton
+              onClick={handleBet}
+              disabled={
+                choice === null || bet < MIN_BET || userGambled || (userData !== null && userData.walletBalance < bet) || spinning || bet > MAX_BET
+              }
+            >
+              {
+                spinning ? "Spinning..."
+                  : choice === null ? "Choose a side"
+                    : bet === 0 ? "Place the bet value"
+                      : bet < MIN_BET ? `Min bet is ${MIN_BET}`
+                        : bet > MAX_BET ? "Max bet is 1M"
+                          : userGambled ? "You're in!"
+                            : userData !== null && userData.walletBalance < bet ? "Not enough money"
+                              : "Enter the Game"
+              }
+            </GameButton>
+          </div>
           {/* the payout is not 2x, so it says so rather than leaving it to be inferred */}
           <div className="flex justify-between text-xs text-[#84819a] pt-2">
             <span>Win pays {WIN_MULTIPLIER}x</span>

--- a/src/pages/Crash/SideMenu.tsx
+++ b/src/pages/Crash/SideMenu.tsx
@@ -1,6 +1,7 @@
 import { AiFillCaretDown, AiFillCaretUp } from 'react-icons/ai';
 import Monetary from '../../components/Monetary';
 import GameButton from '../../components/game/GameButton';
+import BetAmount from '../../components/game/BetAmount';
 import { User } from '../../components/Types';
 
 interface SideMenuProps {
@@ -77,39 +78,13 @@ const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutA
 
     return (
       <div className="lg:w-[340px] flex flex-col gap-2 border-r border-gray-700 py-4 px-6">
-        <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
-          <span>Bet Amount</span>
-          <span><Monetary value={bet || 0} /></span>
-        </div>
-        <div className="flex">
-          <input
-            type="number"
-            value={bet || ""}
-            onKeyDown={(event) => {
-              if (!/[0-9]/.test(event.key) && event.key !== "Backspace") {
-                event.preventDefault();
-              }
-            }}
-            max={MAX_BET}
-            onChange={(e) => {
-              const value = Number(e.target.value);
-              setBet(value < 0 ? 0 : value);
-            }}
-            className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm"
-          />
-          <button
-            onClick={() => setBet(Math.max(1, Math.floor((bet || 0) / 2)))}
-            className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold"
-          >
-            ½
-          </button>
-          <button
-            onClick={() => setBet(Math.min(MAX_BET, (bet || 1) * 2))}
-            className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold"
-          >
-            2×
-          </button>
-        </div>
+        <BetAmount
+          value={bet === null ? "" : String(bet)}
+          onChange={(value) => setBet(value === "" ? null : Math.min(MAX_BET, Number(value)))}
+          onHalve={() => setBet(Math.max(1, Math.floor((bet || 0) / 2)))}
+          onDouble={() => setBet(Math.min(MAX_BET, (bet || 1) * 2))}
+          betValue={bet || 0}
+        />
 
         <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-2">
           <span>Cashout At</span>

--- a/src/pages/Crash/SideMenu.tsx
+++ b/src/pages/Crash/SideMenu.tsx
@@ -1,5 +1,6 @@
 import { AiFillCaretDown, AiFillCaretUp } from 'react-icons/ai';
 import Monetary from '../../components/Monetary';
+import GameButton from '../../components/game/GameButton';
 import { User } from '../../components/Types';
 
 interface SideMenuProps {
@@ -144,13 +145,14 @@ const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutA
           </span>
         </div>
 
-        <button
-          onClick={userGambled && gameStarted ? handleCashout : handleBet}
-          className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full mt-2 disabled:opacity-40 disabled:hover:bg-green-500 transition-colors"
-          disabled={disabled}
-        >
-          {renderMessage()}
-        </button>
+        <div className="mt-2">
+          <GameButton
+            onClick={userGambled && gameStarted ? handleCashout : handleBet}
+            disabled={disabled}
+          >
+            {renderMessage()}
+          </GameButton>
+        </div>
       </div>
     );
   }

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -1,8 +1,10 @@
 import GameLayout from "../../components/game/GameLayout";
 import GameButton from "../../components/game/GameButton";
+import BetAmount from "../../components/game/BetAmount";
+import ModeToggle from "../../components/game/ModeToggle";
+import OptionRow from "../../components/game/OptionRow";
 import Monetary from "../../components/Monetary";
 import { AUTO_COUNTS } from "./Dice.services";
-import { MAX_BET } from "./diceControls";
 import { DiceViewProps } from "./Dice.types";
 
 const TICKS = [0, 25, 50, 75, 100];
@@ -59,50 +61,17 @@ const DiceView: React.FC<DiceViewProps> = ({
       }
       panel={
         <>
-          <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
-            <button
-              onClick={() => setMode("manual")}
-              className={`flex-1 py-1.5 rounded ${mode === "manual" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
-            >
-              Manual
-            </button>
-            <button
-              onClick={() => setMode("auto")}
-              className={`flex-1 py-1.5 rounded ${mode === "auto" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
-            >
-              Auto
-            </button>
-          </div>
+          <ModeToggle mode={mode} setMode={setMode} />
 
-          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
-            <span>Bet Amount</span>
-            <span><Monetary value={betValue} /></span>
-          </div>
-          <div className="flex">
-            <input
-              type="number"
-              value={betInput}
-              max={MAX_BET}
-              onChange={(e) => setBetInput(e.target.value.replace(/[^0-9]/g, ""))}
-              onBlur={normalizeBet}
-              disabled={autoRunning}
-              className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm disabled:opacity-50"
-            />
-            <button
-              onClick={halveBet}
-              disabled={autoRunning}
-              className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold disabled:opacity-50"
-            >
-              ½
-            </button>
-            <button
-              onClick={doubleBet}
-              disabled={autoRunning}
-              className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold disabled:opacity-50"
-            >
-              2×
-            </button>
-          </div>
+          <BetAmount
+            value={betInput}
+            onChange={setBetInput}
+            onBlur={normalizeBet}
+            onHalve={halveBet}
+            onDouble={doubleBet}
+            betValue={betValue}
+            disabled={autoRunning}
+          />
 
           <div className="flex items-center justify-between text-xs font-semibold text-ink-muted mt-1">
             <span>Profit on Win</span>
@@ -110,21 +79,7 @@ const DiceView: React.FC<DiceViewProps> = ({
           </div>
 
           {mode === "auto" && (
-            <div className="flex flex-col gap-2 mt-1">
-              <span className="text-xs font-semibold text-ink-muted">Number of Bets</span>
-              <div className="grid grid-cols-4 gap-1">
-                {AUTO_COUNTS.map((n) => (
-                  <button
-                    key={n}
-                    onClick={() => setAutoCount(n)}
-                    disabled={autoRunning}
-                    className={`py-1.5 rounded text-sm font-semibold ${autoCount === n ? "bg-surface-raised text-white" : "bg-surface-nav text-ink-muted"} disabled:opacity-50`}
-                  >
-                    {n}
-                  </button>
-                ))}
-              </div>
-            </div>
+            <OptionRow label="Number of Bets" options={AUTO_COUNTS} value={autoCount} onChange={setAutoCount} disabled={autoRunning} />
           )}
 
           {mode === "manual" ? (

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -1,4 +1,5 @@
-import Title from "../../components/Title";
+import GameLayout from "../../components/game/GameLayout";
+import GameButton from "../../components/game/GameButton";
 import Monetary from "../../components/Monetary";
 import { AUTO_COUNTS } from "./Dice.services";
 import { MAX_BET } from "./diceControls";
@@ -49,11 +50,15 @@ const DiceView: React.FC<DiceViewProps> = ({
       : `linear-gradient(to right, ${GREEN} 0%, ${GREEN} ${targetPct}%, ${RED} ${targetPct}%, ${RED} 100%)`;
 
   return (
-    <div className="w-screen flex flex-col items-center py-6 gap-6 px-4">
-      <Title title="Dice" />
-
-      <div className="flex flex-col lg:flex-row w-full max-w-[1100px] bg-surface rounded-lg overflow-hidden border border-line">
-        <div className="lg:w-[320px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
+    <GameLayout
+      title="Dice"
+      footer={
+        <p className="text-ink-muted text-xs max-w-[640px] text-center">
+          Balance: <Monetary value={walletBalance} />. Every roll is provably fair. 99% RTP, 1% house edge.
+        </p>
+      }
+      panel={
+        <>
           <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
             <button
               onClick={() => setMode("manual")}
@@ -123,24 +128,18 @@ const DiceView: React.FC<DiceViewProps> = ({
           )}
 
           {mode === "manual" ? (
-            <button
-              onClick={roll}
-              disabled={rolling}
-              className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full mt-2 disabled:opacity-40 transition-colors"
-            >
+            <GameButton onClick={roll} disabled={rolling}>
               {isLogged ? "Roll Dice" : "Sign in to play"}
-            </button>
+            </GameButton>
           ) : (
-            <button
-              onClick={autoRunning ? stopAuto : startAuto}
-              className={`p-3 rounded font-bold w-full mt-2 transition-colors ${autoRunning ? "bg-red-500 hover:bg-red-400 text-white" : "bg-green-500 hover:bg-green-400 text-[#10241A]"}`}
-            >
+            <GameButton onClick={autoRunning ? stopAuto : startAuto} variant={autoRunning ? "danger" : "primary"}>
               {autoRunning ? `Stop (${autoLeft} left)` : isLogged ? `Start ${autoCount} Bets` : "Sign in to play"}
-            </button>
+            </GameButton>
           )}
-        </div>
-
-        <div className="flex-1 flex flex-col p-6 gap-6">
+        </>
+      }
+    >
+      <div className="w-full flex flex-col gap-6">
           <div className="flex items-center justify-end gap-2 h-8 overflow-hidden">
             {history.map((h) => (
               <button
@@ -228,13 +227,8 @@ const DiceView: React.FC<DiceViewProps> = ({
             </div>
           </div>
 
-        </div>
       </div>
-
-      <p className="text-ink-muted text-xs max-w-[640px] text-center">
-        Balance: <Monetary value={walletBalance} />. Every roll is provably fair. 99% RTP, 1% house edge.
-      </p>
-    </div>
+    </GameLayout>
   );
 };
 

--- a/src/pages/Hilo/Hilo.view.tsx
+++ b/src/pages/Hilo/Hilo.view.tsx
@@ -1,5 +1,6 @@
 import { AiFillCaretDown, AiFillCaretUp } from "react-icons/ai";
-import Title from "../../components/Title";
+import GameLayout from "../../components/game/GameLayout";
+import GameButton from "../../components/game/GameButton";
 import Monetary from "../../components/Monetary";
 import PlayingCard, { SuitIcon } from "../Blackjack/PlayingCard";
 import { isRedSuit, rankLabel, suitOf } from "../Blackjack/blackjackCards";
@@ -39,11 +40,15 @@ const HiloView: React.FC<HiloViewProps> = ({
   const currentPayout = game ? betValue * game.multiplier : betValue;
 
   return (
-    <div className="w-screen flex flex-col items-center py-6 gap-6 px-4">
-      <Title title="HiLo" />
-
-      <div className="flex flex-col lg:flex-row w-full max-w-[1100px] bg-surface rounded-lg overflow-hidden border border-line">
-        <div className="lg:w-[320px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
+    <GameLayout
+      title="HiLo"
+      footer={
+        <p className="text-ink-muted text-xs max-w-[640px] text-center">
+          Balance: <Monetary value={walletBalance} />. Predict if the next card is higher or lower, then cash out before you miss.
+        </p>
+      }
+      panel={
+        <>
           <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
             <span>Bet Amount</span>
             <span><Monetary value={betValue} /></span>
@@ -63,21 +68,13 @@ const HiloView: React.FC<HiloViewProps> = ({
           </div>
 
           {active ? (
-            <button
-              onClick={cashout}
-              disabled={busy || !game?.canCashout}
-              className="p-3 rounded bg-accent-gold hover:brightness-110 text-[#2a2100] font-bold w-full disabled:opacity-40 transition"
-            >
+            <GameButton onClick={cashout} disabled={busy || !game?.canCashout} variant="cashout">
               {game?.canCashout ? <>Cash Out <Monetary value={currentPayout} showFraction /></> : "Make a prediction"}
-            </button>
+            </GameButton>
           ) : (
-            <button
-              onClick={start}
-              disabled={busy}
-              className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full disabled:opacity-40 transition"
-            >
+            <GameButton onClick={start} disabled={busy}>
               {isLogged ? "Bet" : "Sign in to play"}
-            </button>
+            </GameButton>
           )}
 
           <button
@@ -119,9 +116,10 @@ const HiloView: React.FC<HiloViewProps> = ({
               {game.status === "cashed" ? <>Won <Monetary value={game.payout} showFraction /> at {game.multiplier.toFixed(2)}×</> : "Busted! Verify roll"}
             </button>
           )}
-        </div>
-
-        <div className="flex-1 flex flex-col items-center p-6 gap-6">
+        </>
+      }
+    >
+      <div className="w-full flex flex-col items-center gap-6">
           <div className="flex items-center justify-center gap-6 sm:gap-14 w-full">
             <div className="hidden sm:flex flex-col items-center gap-2 opacity-40">
               <div className="w-16 h-24 rounded-lg border-2 border-line flex flex-col items-center justify-center text-ink-soft">
@@ -166,13 +164,8 @@ const HiloView: React.FC<HiloViewProps> = ({
               ))}
             </div>
           )}
-        </div>
       </div>
-
-      <p className="text-ink-muted text-xs max-w-[640px] text-center">
-        Balance: <Monetary value={walletBalance} />. Predict if the next card is higher or lower, then cash out before you miss.
-      </p>
-    </div>
+    </GameLayout>
   );
 };
 

--- a/src/pages/Hilo/Hilo.view.tsx
+++ b/src/pages/Hilo/Hilo.view.tsx
@@ -1,10 +1,11 @@
 import { AiFillCaretDown, AiFillCaretUp } from "react-icons/ai";
 import GameLayout from "../../components/game/GameLayout";
 import GameButton from "../../components/game/GameButton";
+import BetAmount from "../../components/game/BetAmount";
 import Monetary from "../../components/Monetary";
 import PlayingCard, { SuitIcon } from "../Blackjack/PlayingCard";
 import { isRedSuit, rankLabel, suitOf } from "../Blackjack/blackjackCards";
-import { MAX_BET, pct } from "./hiloCards";
+import { pct } from "./hiloCards";
 import { HiloViewProps } from "./Hilo.types";
 
 const CardChip = ({ card, label }: { card: number; label?: string }) => (
@@ -49,23 +50,15 @@ const HiloView: React.FC<HiloViewProps> = ({
       }
       panel={
         <>
-          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
-            <span>Bet Amount</span>
-            <span><Monetary value={betValue} /></span>
-          </div>
-          <div className="flex">
-            <input
-              type="number"
-              value={betInput}
-              max={MAX_BET}
-              onChange={(e) => setBetInput(e.target.value.replace(/[^0-9]/g, ""))}
-              onBlur={normalizeBet}
-              disabled={controlsLocked}
-              className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm disabled:opacity-50"
-            />
-            <button onClick={halveBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold disabled:opacity-50">½</button>
-            <button onClick={doubleBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold disabled:opacity-50">2×</button>
-          </div>
+          <BetAmount
+            value={betInput}
+            onChange={setBetInput}
+            onBlur={normalizeBet}
+            onHalve={halveBet}
+            onDouble={doubleBet}
+            betValue={betValue}
+            disabled={controlsLocked}
+          />
 
           {active ? (
             <GameButton onClick={cashout} disabled={busy || !game?.canCashout} variant="cashout">

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -1,8 +1,11 @@
 import GameLayout from "../../components/game/GameLayout";
 import GameButton from "../../components/game/GameButton";
+import BetAmount from "../../components/game/BetAmount";
+import ModeToggle from "../../components/game/ModeToggle";
+import OptionRow from "../../components/game/OptionRow";
 import Monetary from "../../components/Monetary";
 import { AUTO_COUNTS } from "./Mines.services";
-import { MAX_BET, TILES, mineOptions } from "./minesGrid";
+import { TILES, mineOptions } from "./minesGrid";
 import { MinesViewProps } from "./Mines.types";
 
 const Diamond = () => (
@@ -86,40 +89,17 @@ const MinesView: React.FC<MinesViewProps> = ({
       }
       panel={
         <>
-          <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
-            <button
-              onClick={() => setMode("manual")}
-              disabled={autoRunning}
-              className={`flex-1 py-1.5 rounded ${mode === "manual" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
-            >
-              Manual
-            </button>
-            <button
-              onClick={() => setMode("auto")}
-              disabled={active}
-              className={`flex-1 py-1.5 rounded ${mode === "auto" ? "bg-surface-raised text-white" : "text-ink-muted"}`}
-            >
-              Auto
-            </button>
-          </div>
+          <ModeToggle mode={mode} setMode={setMode} manualDisabled={autoRunning} autoDisabled={active} />
 
-          <div className="flex items-center justify-between text-xs font-semibold text-ink-muted">
-            <span>Bet Amount</span>
-            <span><Monetary value={betValue} /></span>
-          </div>
-          <div className="flex">
-            <input
-              type="number"
-              value={betInput}
-              max={MAX_BET}
-              onChange={(e) => setBetInput(e.target.value.replace(/[^0-9]/g, ""))}
-              onBlur={normalizeBet}
-              disabled={controlsLocked}
-              className="p-2 bg-surface-nav border border-line rounded-l rounded-r-none w-full text-sm disabled:opacity-50"
-            />
-            <button onClick={halveBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border-y border-line rounded-none text-sm font-semibold disabled:opacity-50">½</button>
-            <button onClick={doubleBet} disabled={controlsLocked} className="px-3 bg-surface-raised hover:bg-surface-hover border border-line rounded-r rounded-l-none text-sm font-semibold disabled:opacity-50">2×</button>
-          </div>
+          <BetAmount
+            value={betInput}
+            onChange={setBetInput}
+            onBlur={normalizeBet}
+            onHalve={halveBet}
+            onDouble={doubleBet}
+            betValue={betValue}
+            disabled={controlsLocked}
+          />
 
           <div className="flex gap-3">
             <div className="flex-1 flex flex-col gap-1">
@@ -153,19 +133,7 @@ const MinesView: React.FC<MinesViewProps> = ({
                 disabled={autoRunning}
                 className="p-2 bg-surface-nav border border-line rounded text-sm disabled:opacity-50"
               />
-              <span className="text-xs font-semibold text-ink-muted">Number of Bets</span>
-              <div className="grid grid-cols-4 gap-1">
-                {AUTO_COUNTS.map((n) => (
-                  <button
-                    key={n}
-                    onClick={() => setAutoCount(n)}
-                    disabled={autoRunning}
-                    className={`py-1.5 rounded text-sm font-semibold ${autoCount === n ? "bg-surface-raised text-white" : "bg-surface-nav text-ink-muted"} disabled:opacity-50`}
-                  >
-                    {n}
-                  </button>
-                ))}
-              </div>
+              <OptionRow label="Number of Bets" options={AUTO_COUNTS} value={autoCount} onChange={setAutoCount} disabled={autoRunning} />
             </div>
           )}
 

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -1,4 +1,5 @@
-import Title from "../../components/Title";
+import GameLayout from "../../components/game/GameLayout";
+import GameButton from "../../components/game/GameButton";
 import Monetary from "../../components/Monetary";
 import { AUTO_COUNTS } from "./Mines.services";
 import { MAX_BET, TILES, mineOptions } from "./minesGrid";
@@ -76,11 +77,15 @@ const MinesView: React.FC<MinesViewProps> = ({
   };
 
   return (
-    <div className="w-screen flex flex-col items-center py-6 gap-6 px-4">
-      <Title title="Mines" />
-
-      <div className="flex flex-col lg:flex-row w-full max-w-[1000px] bg-surface rounded-lg overflow-hidden border border-line">
-        <div className="lg:w-[300px] flex flex-col gap-3 border-b lg:border-b-0 lg:border-r border-line p-5">
+    <GameLayout
+      title="Mines"
+      footer={
+        <p className="text-ink-muted text-xs max-w-[640px] text-center">
+          Balance: <Monetary value={walletBalance} />. Collect diamonds, avoid the bombs.
+        </p>
+      }
+      panel={
+        <>
           <div className="flex bg-surface-nav rounded p-1 text-sm font-semibold">
             <button
               onClick={() => setMode("manual")}
@@ -167,13 +172,9 @@ const MinesView: React.FC<MinesViewProps> = ({
           {mode === "manual" ? (
             active ? (
               <>
-                <button
-                  onClick={cashout}
-                  disabled={busy || gems === 0}
-                  className="p-3 rounded bg-accent-gold hover:brightness-110 text-[#2a2100] font-bold w-full disabled:opacity-40 transition"
-                >
+                <GameButton onClick={cashout} disabled={busy || gems === 0} variant="cashout">
                   {gems > 0 ? <>Cash Out <Monetary value={currentPayout} showFraction /></> : "Reveal a tile"}
-                </button>
+                </GameButton>
                 <button
                   onClick={randomTile}
                   disabled={busy}
@@ -183,21 +184,14 @@ const MinesView: React.FC<MinesViewProps> = ({
                 </button>
               </>
             ) : (
-              <button
-                onClick={start}
-                disabled={busy}
-                className="p-3 rounded bg-green-500 hover:bg-green-400 text-[#10241A] font-bold w-full disabled:opacity-40 transition"
-              >
+              <GameButton onClick={start} disabled={busy}>
                 {isLogged ? "Bet" : "Sign in to play"}
-              </button>
+              </GameButton>
             )
           ) : (
-            <button
-              onClick={autoRunning ? stopAuto : startAuto}
-              className={`p-3 rounded font-bold w-full transition ${autoRunning ? "bg-red-500 hover:bg-red-400 text-white" : "bg-green-500 hover:bg-green-400 text-[#10241A]"}`}
-            >
+            <GameButton onClick={autoRunning ? stopAuto : startAuto} variant={autoRunning ? "danger" : "primary"}>
               {autoRunning ? `Stop (${autoLeft} left)` : isLogged ? `Start ${autoCount} Bets` : "Sign in to play"}
-            </button>
+            </GameButton>
           )}
 
           {ended && game && (
@@ -209,9 +203,10 @@ const MinesView: React.FC<MinesViewProps> = ({
               {game.status === "cashed" ? <>Won <Monetary value={game.payout} showFraction /> at {game.multiplier.toFixed(2)}×</> : "Boom! Verify roll"}
             </button>
           )}
-        </div>
-
-        <div className="flex-1 flex flex-col p-5 gap-4">
+        </>
+      }
+    >
+      <div className="w-full flex flex-col gap-4">
           <div className="flex items-center justify-end gap-2 h-7 overflow-hidden">
             {history.map((h) => (
               <button
@@ -249,13 +244,8 @@ const MinesView: React.FC<MinesViewProps> = ({
               );
             })}
           </div>
-        </div>
       </div>
-
-      <p className="text-ink-muted text-xs max-w-[640px] text-center">
-        Balance: <Monetary value={walletBalance} />. Collect diamonds, avoid the bombs.
-      </p>
-    </div>
+    </GameLayout>
   );
 };
 

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -2,6 +2,9 @@ import { memo, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import GameLayout from "../../components/game/GameLayout";
 import GameButton from "../../components/game/GameButton";
+import BetAmount from "../../components/game/BetAmount";
+import ModeToggle from "../../components/game/ModeToggle";
+import OptionRow from "../../components/game/OptionRow";
 import Monetary from "../../components/Monetary";
 import {
   BALL_RADIUS,
@@ -110,84 +113,23 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
     title="Plinko"
     panel={
       <>
-        <div className="flex bg-[#19172D] rounded p-1">
-          {(["manual", "auto"] as const).map((m) => (
-            <button
-              key={m}
-              onClick={() => setMode(m)}
-              disabled={autoRunning}
-              className={`flex-1 py-2 rounded text-sm font-semibold capitalize transition-colors ${
-                mode === m ? "bg-[#281D3F]" : "text-[#84819a] hover:text-white"
-              } disabled:opacity-50`}
-            >
-              {m}
-            </button>
-          ))}
-        </div>
+        <ModeToggle mode={mode} setMode={setMode} manualDisabled={autoRunning} autoDisabled={autoRunning} />
 
-        <div className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wider text-[#84819a]">Amount</span>
-          <div className="flex gap-2">
-            <input
-              type="number"
-              min={1}
-              max={maxBet}
-              value={betInput}
-              onChange={(e) => setBetInput(e.target.value)}
-              onBlur={normalizeBet}
-              className="w-full min-w-0 bg-[#19172D] border border-gray-700 focus:border-indigo-500 outline-none rounded px-3 py-2 text-sm"
-            />
-            <button onClick={halveBet} className="px-2 rounded bg-[#281D3F] hover:bg-[#3a2c5c] text-xs font-semibold">
-              1/2
-            </button>
-            <button onClick={doubleBet} className="px-2 rounded bg-[#281D3F] hover:bg-[#3a2c5c] text-xs font-semibold">
-              x2
-            </button>
-            <button onClick={maxOutBet} className="px-2 rounded bg-[#281D3F] hover:bg-[#3a2c5c] text-xs font-semibold">
-              Max
-            </button>
-          </div>
-          <span className="text-xs text-[#84819a]">
-            Bet 1 to {maxBet.toLocaleString("en-US")} on {risk} risk
-          </span>
-        </div>
+        <BetAmount
+          value={betInput}
+          onChange={setBetInput}
+          onBlur={normalizeBet}
+          onHalve={halveBet}
+          onDouble={doubleBet}
+          onMax={maxOutBet}
+          betValue={betValue}
+          hint={`Bet 1 to ${maxBet.toLocaleString("en-US")} on ${risk} risk`}
+        />
 
-        <div className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wider text-[#84819a]">Risk</span>
-          <div className="flex gap-2">
-            {RISKS.map((r) => (
-              <button
-                key={r}
-                onClick={() => changeRisk(r)}
-                disabled={!canChangeRisk}
-                className={`flex-1 py-2 rounded text-sm font-semibold capitalize transition-colors ${
-                  risk === r ? "bg-indigo-600" : "bg-[#19172D] text-[#84819a] hover:text-white"
-                } disabled:opacity-50`}
-              >
-                {r}
-              </button>
-            ))}
-          </div>
-        </div>
+        <OptionRow label="Risk" options={RISKS} value={risk} onChange={changeRisk} disabled={!canChangeRisk} />
 
         {mode === "auto" && (
-          <div className="flex flex-col gap-1">
-            <span className="text-xs uppercase tracking-wider text-[#84819a]">Balls</span>
-            <div className="flex gap-2">
-              {AUTO_COUNTS.map((n) => (
-                <button
-                  key={n}
-                  onClick={() => setAutoCount(n)}
-                  disabled={autoRunning}
-                  className={`flex-1 py-2 rounded text-sm font-semibold ${
-                    autoCount === n ? "bg-indigo-600" : "bg-[#19172D] text-[#84819a] hover:text-white"
-                  } disabled:opacity-50`}
-                >
-                  {n}
-                </button>
-              ))}
-            </div>
-          </div>
+          <OptionRow label="Balls" options={AUTO_COUNTS} value={autoCount} onChange={setAutoCount} disabled={autoRunning} />
         )}
 
         {mode === "manual" ? (

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
-import Title from "../../components/Title";
-import MainButton from "../../components/MainButton";
+import GameLayout from "../../components/game/GameLayout";
+import GameButton from "../../components/game/GameButton";
 import Monetary from "../../components/Monetary";
 import {
   BALL_RADIUS,
@@ -106,12 +106,10 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
   settleBall,
   openRoll,
 }) => (
-  <div className="w-screen flex flex-col items-center py-6 px-4">
-    <Title title="Plinko" />
-
-    <div className="flex flex-col lg:flex-row gap-6 w-full max-w-[1300px] pt-6">
-      {/* control panel */}
-      <div className="w-full lg:w-72 shrink-0 bg-[#212031] rounded-lg p-4 flex flex-col gap-4 self-start">
+  <GameLayout
+    title="Plinko"
+    panel={
+      <>
         <div className="flex bg-[#19172D] rounded p-1">
           {(["manual", "auto"] as const).map((m) => (
             <button
@@ -193,36 +191,29 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
         )}
 
         {mode === "manual" ? (
-          <MainButton
-            text={
-              isLogged ? (
-                <div className="flex items-center justify-center text-base">
-                  <span className="mr-1">Drop ball - </span>
-                  <Monetary value={betValue} />
-                </div>
-              ) : (
-                "Sign in to play"
-              )
-            }
-            onClick={drop}
-            disabled={!canDrop}
-          />
+          <GameButton onClick={drop} disabled={!canDrop}>
+            {isLogged ? (
+              <span className="flex items-center justify-center gap-1">
+                Drop ball <Monetary value={betValue} />
+              </span>
+            ) : (
+              "Sign in to play"
+            )}
+          </GameButton>
         ) : autoRunning ? (
-          <MainButton text={`Stop (${autoLeft} left)`} onClick={stopAuto} type="danger" />
+          <GameButton onClick={stopAuto} variant="danger">
+            {`Stop (${autoLeft} left)`}
+          </GameButton>
         ) : (
-          <MainButton
-            text={
-              isLogged ? (
-                <div className="flex items-center justify-center text-base">
-                  <span className="mr-1">Drop {autoCount} balls - </span>
-                  <Monetary value={betValue * autoCount} />
-                </div>
-              ) : (
-                "Sign in to play"
-              )
-            }
-            onClick={startAuto}
-          />
+          <GameButton onClick={startAuto}>
+            {isLogged ? (
+              <span className="flex items-center justify-center gap-1">
+                Drop {autoCount} balls <Monetary value={betValue * autoCount} />
+              </span>
+            ) : (
+              "Sign in to play"
+            )}
+          </GameButton>
         )}
 
         <div className="text-xs text-[#84819a] border-t border-[#2a2840] pt-3 flex flex-col gap-1">
@@ -231,87 +222,86 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
           </span>
           <span>Every drop is provably fair; click a result to verify it.</span>
         </div>
+      </>
+    }
+  >
+    <div className="relative w-full flex justify-center">
+      <div className="absolute right-0 top-0 flex flex-col gap-1 items-end z-10">
+        {history.map((h) => (
+          <motion.button
+            key={h.key}
+            initial={{ opacity: 0, x: 12 }}
+            animate={{ opacity: 1, x: 0 }}
+            onClick={() => h.rollId && openRoll(h.rollId)}
+            title={h.rollId ? `Roll ${h.rollId}` : undefined}
+            className="px-2 py-1 rounded text-xs font-bold"
+            style={{ backgroundColor: binColor(h.bin), color: binTextColor(h.bin) }}
+          >
+            {formatMultiplier(h.multiplier)}
+          </motion.button>
+        ))}
       </div>
 
-      {/* board */}
-      <div className="relative flex-1 flex justify-start">
-        <div className="absolute right-0 top-0 flex flex-col gap-1 items-end z-10">
-          {history.map((h) => (
-            <motion.button
-              key={h.key}
-              initial={{ opacity: 0, x: 12 }}
-              animate={{ opacity: 1, x: 0 }}
-              onClick={() => h.rollId && openRoll(h.rollId)}
-              title={h.rollId ? `Roll ${h.rollId}` : undefined}
-              className="px-2 py-1 rounded text-xs font-bold"
-              style={{ backgroundColor: binColor(h.bin), color: binTextColor(h.bin) }}
-            >
-              {formatMultiplier(h.multiplier)}
-            </motion.button>
-          ))}
-        </div>
+      <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[680px]">
+        <PegField />
 
-        <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[680px]">
-          <PegField />
-
-          {Array.from({ length: BINS }, (_, k) => {
-            const label = formatMultiplier(PAYOUT_MULTIPLIERS[risk][k]);
-            const chip = (
-              <>
-                <rect
-                  x={binCenterX(k) - BIN_W / 2}
-                  y={BIN_Y}
-                  width={BIN_W}
-                  height={BIN_H}
-                  rx={6}
-                  fill={binColor(k)}
-                />
-                <text
-                  x={binCenterX(k)}
-                  y={BIN_Y + BIN_H / 2 + 4}
-                  textAnchor="middle"
-                  fontSize={label.length > 4 ? 11 : 13}
-                  fontWeight={700}
-                  fill={binTextColor(k)}
-                >
-                  {label}
-                </text>
-              </>
-            );
-            return lastHit && lastHit.bin === k ? (
-              <motion.g
-                key={`${k}-${lastHit.seq}`}
-                initial={{ y: 0 }}
-                animate={{ y: [0, 12, 0] }}
-                transition={{ duration: 0.3 }}
+        {Array.from({ length: BINS }, (_, k) => {
+          const label = formatMultiplier(PAYOUT_MULTIPLIERS[risk][k]);
+          const chip = (
+            <>
+              <rect
+                x={binCenterX(k) - BIN_W / 2}
+                y={BIN_Y}
+                width={BIN_W}
+                height={BIN_H}
+                rx={6}
+                fill={binColor(k)}
+              />
+              <text
+                x={binCenterX(k)}
+                y={BIN_Y + BIN_H / 2 + 4}
+                textAnchor="middle"
+                fontSize={label.length > 4 ? 11 : 13}
+                fontWeight={700}
+                fill={binTextColor(k)}
               >
-                {chip}
-              </motion.g>
-            ) : (
-              <g key={`${k}-static`}>{chip}</g>
-            );
-          })}
+                {label}
+              </text>
+            </>
+          );
+          return lastHit && lastHit.bin === k ? (
+            <motion.g
+              key={`${k}-${lastHit.seq}`}
+              initial={{ y: 0 }}
+              animate={{ y: [0, 12, 0] }}
+              transition={{ duration: 0.3 }}
+            >
+              {chip}
+            </motion.g>
+          ) : (
+            <g key={`${k}-static`}>{chip}</g>
+          );
+        })}
 
-          {/* one ghost per drop still waiting on the server, so a click is visibly queued */}
-          {Array.from({ length: pendingDrops }, (_, i) => (
-            <circle
-              key={`q-${i}`}
-              className="ball-queued"
-              cx={DROP_X + (i - (pendingDrops - 1) / 2) * BALL_RADIUS * 2.5}
-              cy={DROP_Y}
-              r={BALL_RADIUS * 0.8}
-              fill="#FFCC00"
-              style={{ animationDelay: `${i * 0.15}s` }}
-            />
-          ))}
+        {/* one ghost per drop still waiting on the server, so a click is visibly queued */}
+        {Array.from({ length: pendingDrops }, (_, i) => (
+          <circle
+            key={`q-${i}`}
+            className="ball-queued"
+            cx={DROP_X + (i - (pendingDrops - 1) / 2) * BALL_RADIUS * 2.5}
+            cy={DROP_Y}
+            r={BALL_RADIUS * 0.8}
+            fill="#FFCC00"
+            style={{ animationDelay: `${i * 0.15}s` }}
+          />
+        ))}
 
-          {balls.map((ball) => (
-            <FallingBall key={ball.key} ball={ball} onSettle={settleBall} />
-          ))}
-        </svg>
-      </div>
+        {balls.map((ball) => (
+          <FallingBall key={ball.key} ball={ball} onSettle={settleBall} />
+        ))}
+      </svg>
     </div>
-  </div>
+  </GameLayout>
 );
 
 export default PlinkoView;


### PR DESCRIPTION
## Problem

Each game page had drifted into its own design. Plinko had no container at all, its board floating loose beside the panel, and blackjack used two separate cards instead of one. The game title added 80px of vertical padding that pushed every board down the page. The bet field had five different designs, the play button three different colours, and the Manual/Auto switch and the auto-count picker two each. Most of the drift came from hard-coded hex values instead of the semantic tokens.

## Change

A shared set in `src/components/game/` that every game page is now built from:

- `GameLayout`: the shell, controls and board in one container, board first on phones.
- `BetAmount`: the bet field with the half and double steppers. Pass `onMax` to show the Max button, omit it to hide.
- `GameButton`: green to play, gold to cash out, red to stop.
- `ModeToggle` and `OptionRow` for the Manual/Auto switch and rows of fixed choices.

`Title` gains a compact variant used only by games, so home, battles and the other pages keep their old spacing. Coin flip gains the half and double steppers it never had.

Also fixes a phone overflow on blackjack that predates this branch: the bet input kept its default 20 character intrinsic width, which flex cannot shrink past, and it pushed the page wider than the viewport.