### PR TITLE
Credit Cygames and NEXON Games in the artists modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ KaniCasino is a non-commercial fan project. All trademarks and art belong to the
 - Touhou items by [dairi](https://www.pixiv.net/en/users/4920496)
 - Counter-Strike items by [Valve](https://store.steampowered.com/app/730/CounterStrike_2/)
 - Cats items from the [Hello Street Cat Wiki](https://streetcat.wiki/index.php/Main_Page)
+- Uma Musume items by [Cygames](https://umamusume.jp/)
+- Blue Archive items by [NEXON Games](https://bluearchive.nexon.com/)
 
 **Games**
 

--- a/src/components/modalsChilden/Artists.tsx
+++ b/src/components/modalsChilden/Artists.tsx
@@ -20,6 +20,14 @@ const Assets = () => {
                 <p className="text-md">
                     All cats items are from the Hello Street Cat Wiki: <a href="https://streetcat.wiki/index.php/Main_Page" target="_blank" rel="noreferrer" className="text-blue-500">https://streetcat.wiki/index.php/Main_Page</a>.
                 </p>
+
+                <p className="text-md">
+                    All Uma Musume items are from Cygames: <a href="https://umamusume.jp/" target="_blank" rel="noreferrer" className="text-blue-500">https://umamusume.jp/</a>.
+                </p>
+
+                <p className="text-md">
+                    All Blue Archive items are from NEXON Games: <a href="https://bluearchive.nexon.com/" target="_blank" rel="noreferrer" className="text-blue-500">https://bluearchive.nexon.com/</a>.
+                </p>
             </div>
 
             <div className="mb-4 flex flex-col gap-2">


### PR DESCRIPTION
The Uma Musume and Blue Archive case sets have both been live for a while, but neither is listed in the artists modal, which only credits Touhou, Counter-Strike and the cats. Adds an entry for each to the modal and mirrors both into the README credits.