### PR TITLE
Stack duplicate items behind one card with a quantity counter

### DIFF
--- a/backend/__tests__/integration/inventoryStacking.test.js
+++ b/backend/__tests__/integration/inventoryStacking.test.js
@@ -1,0 +1,197 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const auth = (user) => ["Authorization", `Bearer ${tokenFor(user)}`];
+
+async function makeItem(overrides = {}) {
+  return Item.create({
+    name: `item-${uniqueSuffix()}`,
+    image: "i.png",
+    rarity: "1",
+    baseValue: 100,
+    ...overrides,
+  });
+}
+
+// n copies of the same catalog item, each its own inventory entry
+function copies(item, n, startMs = 0) {
+  return Array.from({ length: n }, (_, i) => ({
+    uniqueId: `u-${item._id}-${i}-${uniqueSuffix()}`,
+    _id: item._id,
+    name: item.name,
+    image: item.image,
+    rarity: item.rarity,
+    case: item.case,
+    createdAt: new Date(1700000000000 + startMs + i * 1000),
+  }));
+}
+
+async function makeUserWith(inventory, overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 0,
+    inventory,
+    ...overrides,
+  });
+}
+
+describe("grouped inventory", () => {
+  it("stacks duplicates into one row carrying the count", async () => {
+    const a = await makeItem();
+    const b = await makeItem();
+    const user = await makeUserWith([...copies(a, 5), ...copies(b, 2)]);
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    const byId = Object.fromEntries(res.body.items.map((i) => [String(i._id), i]));
+    expect(byId[String(a._id)].quantity).toBe(5);
+    expect(byId[String(b._id)].quantity).toBe(2);
+  });
+
+  it("ungrouped still returns every copy, so other screens are untouched", async () => {
+    const a = await makeItem();
+    const user = await makeUserWith(copies(a, 5));
+
+    const res = await request(app).get(`/users/inventory/${user._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(5);
+  });
+
+  it("pages over distinct items, not copies", async () => {
+    const a = await makeItem();
+    const user = await makeUserWith(copies(a, 40));
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+
+    expect(res.body.totalPages).toBe(1);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].quantity).toBe(40);
+  });
+
+  it("the row's uniqueId is the newest copy", async () => {
+    const a = await makeItem();
+    const inv = copies(a, 3);
+    const newest = inv[inv.length - 1];
+    const user = await makeUserWith(inv);
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+
+    expect(res.body.items[0].uniqueId).toBe(newest.uniqueId);
+  });
+
+  it("only sends the copy ids when asked, and caps them", async () => {
+    const a = await makeItem();
+    const user = await makeUserWith(copies(a, 150));
+
+    const plain = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+    expect(plain.body.items[0].uniqueIds).toBeUndefined();
+
+    const withIds = await request(app).get(`/users/inventory/${user._id}?grouped=true&withIds=true`);
+    expect(withIds.body.items[0].uniqueIds).toHaveLength(100);
+  });
+});
+
+describe("item copies list", () => {
+  it("returns copies newest first, paginated", async () => {
+    const a = await makeItem();
+    const inv = copies(a, 25);
+    const user = await makeUserWith(inv);
+
+    const res = await request(app).get(`/users/inventory/${user._id}/copies/${a._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(25);
+    expect(res.body.totalPages).toBe(3);
+    expect(res.body.copies).toHaveLength(10);
+    expect(res.body.copies[0].uniqueId).toBe(inv[inv.length - 1].uniqueId);
+  });
+
+  it("404s on a bad id instead of throwing", async () => {
+    const user = await makeUserWith([]);
+    const res = await request(app).get(`/users/inventory/${user._id}/copies/not-an-id`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("selling a stack", () => {
+  it("sells every copy when no quantity is given", async () => {
+    const a = await makeItem({ baseValue: 100 });
+    const user = await makeUserWith(copies(a, 4));
+
+    const res = await request(app)
+      .post("/users/inventory/sell")
+      .set(...auth(user))
+      .send({ itemId: String(a._id) });
+
+    expect(res.status).toBe(200);
+    expect(res.body.sold).toBe(4);
+    const after = await User.findById(user._id);
+    expect(after.inventory).toHaveLength(0);
+  });
+
+  it("sells only the asked-for count, newest first", async () => {
+    const a = await makeItem({ baseValue: 100 });
+    const inv = copies(a, 5);
+    const user = await makeUserWith(inv);
+
+    const res = await request(app)
+      .post("/users/inventory/sell")
+      .set(...auth(user))
+      .send({ itemId: String(a._id), quantity: 2 });
+
+    expect(res.body.sold).toBe(2);
+    const after = await User.findById(user._id);
+    expect(after.inventory).toHaveLength(3);
+    // the two newest went, the three oldest stayed
+    const left = after.inventory.map((e) => e.uniqueId);
+    expect(left).toEqual(inv.slice(0, 3).map((e) => e.uniqueId));
+  });
+
+  it("never sells more than is owned", async () => {
+    const a = await makeItem({ baseValue: 100 });
+    const user = await makeUserWith(copies(a, 2));
+
+    const res = await request(app)
+      .post("/users/inventory/sell")
+      .set(...auth(user))
+      .send({ itemId: String(a._id), quantity: 999 });
+
+    expect(res.body.sold).toBe(2);
+  });
+
+  it("leaves other items alone", async () => {
+    const a = await makeItem();
+    const b = await makeItem();
+    const user = await makeUserWith([...copies(a, 3), ...copies(b, 2)]);
+
+    await request(app)
+      .post("/users/inventory/sell")
+      .set(...auth(user))
+      .send({ itemId: String(a._id) });
+
+    const after = await User.findById(user._id);
+    expect(after.inventory).toHaveLength(2);
+    expect(after.inventory.every((e) => String(e._id) === String(b._id))).toBe(true);
+  });
+});

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -124,12 +124,29 @@ module.exports = (io) => {
         return res.status(400).json({ message: `You must be at least level ${SELL_LEVEL} to sell items` });
       }
 
-      const inventoryItem = user.inventory.find((item) => item.uniqueId === uniqueId);
-      if (!inventoryItem) {
+      // one call can list several copies of the same item at one price. the copies are
+      // resolved here rather than sent as ids, and each still goes through the pull,
+      // the bid crossing and the publish on its own, so a batch is just a loop over
+      // the single-copy path and never a shortcut around it.
+      let copies;
+      if (uniqueId) {
+        const found = user.inventory.find((item) => item.uniqueId === uniqueId);
+        copies = found ? [found] : [];
+      } else if (req.body.itemId && isValidId(req.body.itemId)) {
+        const asked = Math.floor(Number(req.body.quantity));
+        const owned = user.inventory
+          .filter((e) => e && String(e._id) === String(req.body.itemId))
+          .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+        copies = owned.slice(0, Number.isFinite(asked) && asked > 0 ? asked : 1);
+      } else {
+        copies = [];
+      }
+
+      if (!copies.length) {
         return res.status(404).json({ message: "Item not found in inventory" });
       }
 
-      const itemDocument = await Item.findById(inventoryItem._id);
+      const itemDocument = await Item.findById(copies[0]._id);
       if (!itemDocument) {
         return res.status(404).json({ message: "Item not found" });
       }
@@ -139,47 +156,77 @@ module.exports = (io) => {
         return res.status(400).json({ message: `Price too high: at most ${ceiling} K₽ for this item` });
       }
 
-      // atomically remove exactly this item; if it's already gone, abort without listing
-      const pull = await User.updateOne({ _id: user._id }, { $pull: { inventory: { uniqueId } } });
-      if (pull.modifiedCount === 0) {
+      const listOne = async (inventoryItem) => {
+        // atomically remove exactly this item; if it's already gone, skip it
+        const pull = await User.updateOne(
+          { _id: user._id },
+          { $pull: { inventory: { uniqueId: inventoryItem.uniqueId } } }
+        );
+        if (pull.modifiedCount === 0) return null;
+
+        const pending = {
+          sellerId: user._id,
+          item: itemDocument._id,
+          case: itemDocument.case,
+          price,
+          itemName: itemDocument.name,
+          itemImage: itemDocument.image,
+          rarity: itemDocument.rarity,
+          uniqueId: inventoryItem.uniqueId,
+        };
+
+        // cross the best resting bids BEFORE publishing, so nobody can front-run the
+        // bid at the lower ask. a lost claim race just means trying the next best bid.
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const order = await market.findMatchingOrder({
+            itemId: itemDocument._id,
+            price,
+            excludeUserId: user._id,
+          });
+          if (!order) break;
+          const filled = await market.fillOrderWithItem({ pending, order, io });
+          if (filled.ok) {
+            return { sold: true, soldFor: filled.price, received: sellerNet(filled.price) };
+          }
+          if (filled.reason === "seller gone") break;
+        }
+
+        const marketplaceItem = new Marketplace(pending);
+        await marketplaceItem.save();
+        return { sold: false, listing: marketplaceItem };
+      };
+
+      const results = [];
+      for (const copy of copies) {
+        const r = await listOne(copy);
+        if (r) results.push(r);
+      }
+
+      if (!results.length) {
         return res.status(404).json({ message: "Item not found in inventory" });
       }
 
-      const pending = {
-        sellerId: user._id,
-        item: itemDocument._id,
-        case: itemDocument.case,
-        price,
-        itemName: itemDocument.name,
-        itemImage: itemDocument.image,
-        rarity: itemDocument.rarity,
-        uniqueId: inventoryItem.uniqueId,
-      };
-
-      // cross the best resting bids BEFORE publishing, so nobody can front-run the
-      // bid at the lower ask. a lost claim race just means trying the next best bid.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        const order = await market.findMatchingOrder({
-          itemId: itemDocument._id,
-          price,
-          excludeUserId: user._id,
-        });
-        if (!order) break;
-        const filled = await market.fillOrderWithItem({ pending, order, io });
-        if (filled.ok) {
+      // one copy keeps the original response shape, so existing callers are untouched
+      const soldNow = results.filter((r) => r.sold);
+      if (results.length === 1) {
+        const only = results[0];
+        if (only.sold) {
           return res.json({
             soldInstantly: true,
-            soldFor: filled.price,
-            received: sellerNet(filled.price),
+            soldFor: only.soldFor,
+            received: only.received,
             itemName: itemDocument.name,
           });
         }
-        if (filled.reason === "seller gone") break;
+        return res.json(only.listing);
       }
 
-      const marketplaceItem = new Marketplace(pending);
-      await marketplaceItem.save();
-      res.json(marketplaceItem);
+      res.json({
+        listed: results.length - soldNow.length,
+        soldInstantly: soldNow.length,
+        received: soldNow.reduce((s, r) => s + r.received, 0),
+        itemName: itemDocument.name,
+      });
     } catch (err) {
       console.error(err);
       res.status(500).json({ message: "Internal server error" });

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -376,11 +376,28 @@ router.get('/transactions', authMiddleware.isAuthenticated, async (req, res) => 
 // Sell items back to the house for coins (base value x sell rate)
 router.post("/inventory/sell", authMiddleware.isAuthenticated, async (req, res) => {
   try {
-    const ids = Array.isArray(req.body.uniqueIds)
+    let ids = Array.isArray(req.body.uniqueIds)
       ? req.body.uniqueIds
       : req.body.uniqueId
         ? [req.body.uniqueId]
         : [];
+
+    // selling a whole stack by id: resolving the copies here keeps a 800-copy
+    // "sell all" from shipping 800 uuids up the wire. newest first, to match the
+    // card's single sell button.
+    if (!ids.length && req.body.itemId && ObjectId.isValid(req.body.itemId)) {
+      const asked = Math.floor(Number(req.body.quantity));
+      const owner = await User.findById(req.user._id, { inventory: 1 });
+      if (!owner) {
+        return res.status(404).json({ message: "User not found" });
+      }
+      const copies = (owner.inventory || [])
+        .filter((e) => e && String(e._id) === String(req.body.itemId))
+        .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      const take = Number.isFinite(asked) && asked > 0 ? Math.min(asked, copies.length) : copies.length;
+      ids = copies.slice(0, take).map((e) => e.uniqueId);
+    }
+
     if (!ids.length) {
       return res.status(400).json({ message: "No items selected" });
     }
@@ -574,6 +591,7 @@ router.get("/:id", async (req, res) => {
 
 // Get user inventory
 const ITEMS_PER_PAGE = 18;
+const STACK_IDS_LIMIT = 100;
 
 
 router.get("/inventory/:userId", async (req, res) => {
@@ -617,6 +635,15 @@ router.get("/inventory/:userId", async (req, res) => {
       countPipeline.push({ $match: { "inventory.rarity": rarity } });
     }
 
+    // grouped mode stacks duplicates into one row, so a page is a page of distinct
+    // items. a 21k-item inventory is ~130 distinct, which is the difference between
+    // 1200 pages and 8, and it collapses before the sort rather than after it.
+    const grouped = req.query.grouped === "true";
+    const withIds = grouped && req.query.withIds === "true";
+
+    if (grouped) {
+      countPipeline.push({ $group: { _id: "$inventory._id" } });
+    }
     countPipeline.push({ $count: "totalItems" });
 
     const totalCount = await User.aggregate(countPipeline);
@@ -649,16 +676,51 @@ router.get("/inventory/:userId", async (req, res) => {
       mostRare: { "inventory.rarity": -1 },
       mostCommon: { "inventory.rarity": 1 },
     };
-    if (sortBy && SORTS[sortBy]) {
-      pipeline.push({ $sort: SORTS[sortBy] });
-    }
-    pipeline.push(
-      { $group: { _id: null, inventory: { $push: "$inventory" } } },
-      { $project: { inventory: { $slice: ["$inventory", (page - 1) * ITEMS_PER_PAGE, ITEMS_PER_PAGE] } } }
-    );
+    let items;
+    if (grouped) {
+      // newest first before the group, so $first is the newest copy: that is the one
+      // the card's sell button and its provably-fair link point at
+      pipeline.push({ $sort: { "inventory.createdAt": -1 } });
+      pipeline.push({
+        $group: {
+          _id: "$inventory._id",
+          name: { $first: "$inventory.name" },
+          image: { $first: "$inventory.image" },
+          rarity: { $first: "$inventory.rarity" },
+          case: { $first: "$inventory.case" },
+          uniqueId: { $first: "$inventory.uniqueId" },
+          createdAt: { $first: "$inventory.createdAt" },
+          oldestAt: { $min: "$inventory.createdAt" },
+          quantity: { $sum: 1 },
+          ...(withIds ? { uniqueIds: { $push: "$inventory.uniqueId" } } : {}),
+        },
+      });
+      if (withIds) {
+        // capped: a stack can run to hundreds of copies and no screen picks that many
+        // one at a time, so shipping the whole list would be pure payload
+        pipeline.push({ $addFields: { uniqueIds: { $slice: ["$uniqueIds", STACK_IDS_LIMIT] } } });
+      }
+      const GROUPED_SORTS = {
+        older: { oldestAt: 1 },
+        newer: { createdAt: -1 },
+        mostRare: { rarity: -1 },
+        mostCommon: { rarity: 1 },
+      };
+      pipeline.push({ $sort: (sortBy && GROUPED_SORTS[sortBy]) || { createdAt: -1 } });
+      pipeline.push({ $skip: (page - 1) * ITEMS_PER_PAGE }, { $limit: ITEMS_PER_PAGE });
+      items = await User.aggregate(pipeline);
+    } else {
+      if (sortBy && SORTS[sortBy]) {
+        pipeline.push({ $sort: SORTS[sortBy] });
+      }
+      pipeline.push(
+        { $group: { _id: null, inventory: { $push: "$inventory" } } },
+        { $project: { inventory: { $slice: ["$inventory", (page - 1) * ITEMS_PER_PAGE, ITEMS_PER_PAGE] } } }
+      );
 
-    const inventoryItems = await User.aggregate(pipeline);
-    const items = inventoryItems[0]?.inventory || [];
+      const inventoryItems = await User.aggregate(pipeline);
+      items = inventoryItems[0]?.inventory || [];
+    }
 
     // attach authoritative base/sell value from the item catalog
     const ids = [...new Set(items.map((i) => String(i._id)))];
@@ -673,6 +735,49 @@ router.get("/inventory/:userId", async (req, res) => {
       items: withValue,
       currentPage: page,
       totalPages: totalPages,
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+});
+
+const COPIES_PER_PAGE = 10;
+
+// every copy of one item the user owns, newest first. the grouped card only carries a
+// count and its newest copy, so this is what backs the per-copy list: one row per
+// copy, each with its own uniqueId to verify or sell.
+router.get("/inventory/:userId/copies/:itemId", async (req, res) => {
+  try {
+    const { userId, itemId } = req.params;
+    const page = Math.max(1, Math.floor(Number(req.query.page)) || 1);
+
+    if (!ObjectId.isValid(userId) || !ObjectId.isValid(itemId)) {
+      return res.status(404).json({ message: "Not found" });
+    }
+
+    const user = await User.findById(userId, { inventory: 1 });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const copies = (user.inventory || [])
+      .filter((e) => e && String(e._id) === String(itemId))
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+    const item = await Item.findById(itemId, { baseValue: 1, name: 1, image: 1, rarity: 1 });
+    const base = item?.baseValue || 0;
+
+    const start = (page - 1) * COPIES_PER_PAGE;
+    res.json({
+      copies: copies.slice(start, start + COPIES_PER_PAGE).map((e) => ({
+        uniqueId: e.uniqueId,
+        createdAt: e.createdAt,
+      })),
+      total: copies.length,
+      currentPage: page,
+      totalPages: Math.ceil(copies.length / COPIES_PER_PAGE),
+      sellValue: sellValue(base),
     });
   } catch (error) {
     console.error(error);

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react";
 import { Link } from "react-router-dom";
 import Rarities from "./Rarities";
 import { BsPinAngleFill, BsShieldFillCheck } from "react-icons/bs";
-import { fixItem, sellItems } from "../services/users/UserServices";
+import { fixItem, sellItems, sellStack } from "../services/users/UserServices";
 import { RotatingLines } from "react-loader-spinner";
 import { toast } from "react-toastify";
 import UserContext from "../UserContext";
@@ -18,17 +18,20 @@ interface itemProps {
     uniqueId?: string;
     baseValue?: number;
     sellValue?: number;
+    quantity?: number;
   };
   fixable?: boolean;
   sellable?: boolean;
   setRefresh?: React.Dispatch<React.SetStateAction<boolean>>;
   size?: "small" | "large";
+  onClick?: () => void;
 }
 
-const Item: React.FC<itemProps> = ({ item, fixable, sellable, setRefresh, size = "large" }) => {
+const Item: React.FC<itemProps> = ({ item, fixable, sellable, setRefresh, size = "large", onClick }) => {
   const [loaded, setLoaded] = useState<boolean>(false);
   const [selling, setSelling] = useState<boolean>(false);
   const { userData, toogleUserData } = useContext(UserContext);
+  const quantity = item.quantity ?? 1;
 
   const fixPlayerItem = async (itemId: string) => {
     try {
@@ -39,11 +42,13 @@ const Item: React.FC<itemProps> = ({ item, fixable, sellable, setRefresh, size =
     }
   };
 
-  const sellPlayerItem = async () => {
-    if (!item.uniqueId || selling) return;
+  // the card's uniqueId is the newest copy, so a plain sell always sells that one
+  const sellPlayerItem = async (all = false) => {
+    if (selling) return;
+    if (!all && !item.uniqueId) return;
     setSelling(true);
     try {
-      const res = await sellItems([item.uniqueId]);
+      const res = all ? await sellStack(item._id) : await sellItems([item.uniqueId as string]);
       if (userData) {
         toogleUserData({ ...userData, walletBalance: res.walletBalance });
       }
@@ -64,9 +69,18 @@ const Item: React.FC<itemProps> = ({ item, fixable, sellable, setRefresh, size =
   return (
     <div className={`relative group ${ItemsWidthSize}`}>
       <div
-        className={`flex flex-col w-full items-center justify-center bg-[#212031] rounded-t-lg relative border-b-4 border-[color:var(--rc)] ${canSell ? "group-hover:border-[#212031]" : ""}`}
+        className={`flex flex-col w-full items-center justify-center bg-[#212031] rounded-t-lg relative border-b-4 border-[color:var(--rc)] ${canSell ? "group-hover:border-[#212031]" : ""} ${onClick ? "cursor-pointer" : ""}`}
         style={{ "--rc": color } as React.CSSProperties}
+        onClick={onClick}
       >
+        {quantity > 1 && (
+          <span
+            className="absolute top-1 left-1 z-20 min-w-[22px] h-[22px] px-1 flex items-center justify-center rounded-full text-xs font-bold bg-surface-raised text-ink"
+            style={{ boxShadow: `0 0 0 1px ${color}` }}
+          >
+            ×{quantity}
+          </span>
+        )}
         <div className="overflow-hidden">
           {!loaded && <div className={`flex  ${ItemsWidthSize} ${ItemHeightSize} items-center justify-center`}>
             <RotatingLines
@@ -119,9 +133,9 @@ const Item: React.FC<itemProps> = ({ item, fixable, sellable, setRefresh, size =
       </div>
       {canSell && (
         <div
-          className="absolute top-full inset-x-0 z-30 flex justify-center bg-[#212031] border-b-4 px-2 shadow-xl
+          className="absolute top-full inset-x-0 z-30 flex flex-col gap-1 bg-[#212031] border-b-4 px-2 shadow-xl
           max-h-0 overflow-hidden opacity-0 pointer-events-none
-          group-hover:max-h-20 group-hover:opacity-100 group-hover:pointer-events-auto group-hover:pb-2 group-hover:pt-1
+          group-hover:max-h-32 group-hover:opacity-100 group-hover:pointer-events-auto group-hover:pb-2 group-hover:pt-1
           transition-all duration-200"
           style={{ borderColor: color }}
         >
@@ -132,6 +146,15 @@ const Item: React.FC<itemProps> = ({ item, fixable, sellable, setRefresh, size =
           >
             {selling ? "Selling..." : <span className="flex items-center justify-center gap-1">Sell <Monetary value={item.sellValue ?? 0} /></span>}
           </button>
+          {quantity > 1 && (
+            <button
+              onClick={(e) => { e.stopPropagation(); sellPlayerItem(true); }}
+              disabled={selling}
+              className="w-full rounded px-3 py-1.5 text-xs md:text-sm font-semibold bg-[#19172D] hover:bg-green-700 transition-all disabled:opacity-50 whitespace-nowrap"
+            >
+              {selling ? "Selling..." : <span className="flex items-center justify-center gap-1">Sell all {quantity} <Monetary value={(item.sellValue ?? 0) * quantity} /></span>}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/pages/Market/SellItemModal.tsx
+++ b/src/pages/Market/SellItemModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { sellItem, getItemHistory, ItemHistory } from "../../services/market/MarketService";
+import { sellItem, sellItemStack, getItemHistory, ItemHistory } from "../../services/market/MarketService";
 import { getInventory } from "../../services/users/UserServices";
 import UserContext from "../../UserContext";
 import Item from "../../components/Item";
@@ -49,6 +49,7 @@ const Stat: React.FC<{ label: string; value: React.ReactNode; hint?: string; acc
 const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
   const [selectedItem, setSelectedItem] = useState<any>();
   const [price, setPrice] = useState<number | undefined>();
+  const [quantity, setQuantity] = useState<number>(1);
   const [inventory, setInventory] = useState<Inventory>();
   const [invItems, setInvItems] = useState<InventoryItem[]>([]);
   const [loadingInventory, setLoadingInventory] = useState<boolean>(true);
@@ -105,9 +106,19 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
       return toast.error("Price must be between 1 and 1.000.000", {});
     }
     try {
-      const res = await sellItem(selectedItem.uniqueId, price);
+      const res = quantity > 1
+        ? await sellItemStack(selectedItem._id, price, quantity)
+        : await sellItem(selectedItem.uniqueId, price);
       setRefresh && setRefresh(true);
-      if (res?.soldInstantly) {
+      if (quantity > 1) {
+        const sold = res?.soldInstantly || 0;
+        const listed = res?.listed || 0;
+        toast.success(
+          sold
+            ? `${sold} sold instantly for K₽${res.received}, ${listed} listed`
+            : `${listed} items listed for sale!`
+        );
+      } else if (res?.soldInstantly) {
         toast.success(`Sold instantly to a buy order for K₽${res.soldFor}! You received K₽${res.received}`);
       } else {
         toast.success("Item listed for sale!", {});
@@ -121,7 +132,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
 
   const getInventoryInfo = async (newPage?: number) => {
     try {
-      const response = await getInventory(userData.id, page, filters);
+      const response = await getInventory(userData.id, page, { ...filters, grouped: true });
       setInventory(response);
       newPage
         ? setInvItems((prev) => [...prev, ...response.items])
@@ -161,6 +172,10 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
 
   if (!isOpen) return null;
 
+  const maxQuantity = selectedItem?.quantity ?? 1;
+  const clampQuantity = (raw: string) =>
+    Math.min(Math.max(1, Math.floor(Number(raw)) || 1), maxQuantity);
+
   const stats = history?.stats;
   const feeRate = stats?.feeRate ?? 0.05;
   const p = price || 0;
@@ -194,7 +209,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
                 return (
                   <div
                     key={item._id + index}
-                    onClick={() => setSelectedItem(item)}
+                    onClick={() => { setSelectedItem(item); setQuantity(1); }}
                     className={`rounded-lg cursor-pointer transition-all p-1 border-2 ${
                       isSelected ? "border-accent bg-accent/10" : "border-transparent hover:bg-surface"
                     }`}
@@ -330,6 +345,22 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
                   className="w-full sm:w-36 bg-surface-nav border border-line focus:border-accent outline-none rounded pl-9 pr-3 py-2 text-sm"
                 />
               </div>
+              {maxQuantity > 1 && (
+                <div className="relative shrink-0">
+                  <span className="absolute inset-y-0 left-3 flex items-center text-ink-muted text-sm pointer-events-none">
+                    ×
+                  </span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={maxQuantity}
+                    value={quantity}
+                    onChange={(e) => setQuantity(clampQuantity(e.target.value))}
+                    title={`You own ${maxQuantity}`}
+                    className="w-24 bg-surface-nav border border-line focus:border-accent outline-none rounded pl-7 pr-2 py-2 text-sm"
+                  />
+                </div>
+              )}
               <button
                 onClick={CloseModal}
                 className="px-4 py-2 rounded bg-surface-raised hover:bg-red-700 text-sm font-semibold"
@@ -349,7 +380,7 @@ const SellItemModal: React.FC<Props> = ({ isOpen, onClose, setRefresh }) => {
           </div>
           {crossesBid && (
             <span className="text-xs text-accent-gold">
-              A buy order is bidding <Monetary value={stats?.bestBid || 0} /> — this sells instantly at that price.
+              A buy order is bidding <Monetary value={stats?.bestBid || 0} />, so this sells instantly at that price.
             </span>
           )}
         </div>

--- a/src/pages/Profile/ItemCopiesModal.tsx
+++ b/src/pages/Profile/ItemCopiesModal.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { BsShieldFillCheck } from "react-icons/bs";
+import { toast } from "react-toastify";
+import Modal from "../../components/Modal";
+import Monetary from "../../components/Monetary";
+import Pagination from "../../components/Pagination";
+import Rarities from "../../components/Rarities";
+import { getItemCopies, sellItems } from "../../services/users/UserServices";
+
+interface Copy {
+  uniqueId: string;
+  createdAt: string;
+}
+
+interface Props {
+  userId: string;
+  item: { _id: string; name: string; image: string; rarity: string; quantity?: number; sellValue?: number };
+  isOwner: boolean;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  onSold: () => void;
+}
+
+const ItemCopiesModal: React.FC<Props> = ({ userId, item, isOwner, open, setOpen, onSold }) => {
+  const [copies, setCopies] = useState<Copy[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(item.quantity ?? 0);
+  const [loading, setLoading] = useState(true);
+  const [sellingId, setSellingId] = useState<string | null>(null);
+
+  const color = Rarities.find((r) => r.id.toString() === item.rarity)?.color || "white";
+
+  const load = async (p: number) => {
+    setLoading(true);
+    try {
+      const res = await getItemCopies(userId, item._id, p);
+      setCopies(res.copies || []);
+      setTotalPages(res.totalPages || 1);
+      setTotal(res.total ?? 0);
+    } catch {
+      setCopies([]);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (open) load(page);
+  }, [open, page, item._id]);
+
+  const sellOne = async (uniqueId: string) => {
+    setSellingId(uniqueId);
+    try {
+      const res = await sellItems([uniqueId]);
+      toast.success(res.message, { theme: "dark" });
+      onSold();
+      // the page can empty out from under us when the last copy on it goes
+      const nextPage = copies.length === 1 && page > 1 ? page - 1 : page;
+      setPage(nextPage);
+      await load(nextPage);
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || "Could not sell item", { theme: "dark" });
+    }
+    setSellingId(null);
+  };
+
+  return (
+    <Modal open={open} setOpen={setOpen as any} width="560px">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-4">
+          <div
+            className="w-24 h-24 shrink-0 rounded-lg bg-surface-nav flex items-center justify-center"
+            style={{ boxShadow: `0 0 0 1px ${color}` }}
+          >
+            <img src={item.image} alt={item.name} className="max-h-[85%] max-w-[85%] object-contain" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-lg font-bold">{item.name}</span>
+            <span className="text-sm text-ink-muted">
+              {total} {total === 1 ? "copy" : "copies"} owned
+            </span>
+            {!!item.sellValue && (
+              <span className="text-sm text-ink-soft">
+                <Monetary value={item.sellValue} /> each
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1 border-t border-line pt-3">
+          {loading ? (
+            <span className="text-sm text-ink-muted py-4 text-center">Loading...</span>
+          ) : copies.length === 0 ? (
+            <span className="text-sm text-ink-muted py-4 text-center">No copies left.</span>
+          ) : (
+            copies.map((c) => (
+              <div
+                key={c.uniqueId}
+                className="flex items-center justify-between gap-2 bg-surface-nav rounded px-3 py-2"
+              >
+                <span className="text-xs text-ink-muted truncate">
+                  {new Date(c.createdAt).toLocaleString()}
+                </span>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Link
+                    to={`/provably-fair?item=${c.uniqueId}`}
+                    title="Verify this drop (provably fair)"
+                    className="text-green-500 hover:text-green-300 transition-colors"
+                  >
+                    <BsShieldFillCheck className="text-lg" />
+                  </Link>
+                  {isOwner && (
+                    <button
+                      onClick={() => sellOne(c.uniqueId)}
+                      disabled={sellingId === c.uniqueId}
+                      className="rounded px-2 py-1 text-xs font-semibold bg-surface-raised hover:bg-green-700 transition-colors disabled:opacity-50"
+                    >
+                      {sellingId === c.uniqueId ? "Selling..." : "Sell"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex justify-center">
+            <Pagination totalPages={totalPages} currentPage={page} setPage={setPage} />
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default ItemCopiesModal;

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -14,6 +14,7 @@ import CollectionsPanel from "../Collections/CollectionsPanel";
 import MissionsPanel from "../Missions/MissionsPanel";
 import AffiliatesPanel from "../Affiliates/AffiliatesPanel";
 import { resolveTab, Tab } from "./tabs";
+import ItemCopiesModal from "./ItemCopiesModal";
 import { User } from '../../components/Types'
 
 interface Inventory {
@@ -36,6 +37,7 @@ const Profile = () => {
   const { userData } = useContext(UserContext);
   const [isSameUser, setIsSameUser] = useState<boolean>(false);
   const [refresh, setRefresh] = useState<boolean>(false);
+  const [openItem, setOpenItem] = useState<any>(null);
   const [openFilters, setOpenFilters] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
   const activeTab = resolveTab(searchParams.get("tab"), isSameUser);
@@ -78,7 +80,7 @@ const Profile = () => {
       const response = await getInventory(
         id as string,
         page,
-        filters
+        { ...filters, grouped: true }
       );
       setInventory(response);
       newPage
@@ -264,6 +266,7 @@ const Profile = () => {
                   fixable={isSameUser}
                   sellable={isSameUser}
                   setRefresh={setRefresh}
+                  onClick={() => setOpenItem(item)}
                 />
               ))
             ) : (
@@ -279,6 +282,17 @@ const Profile = () => {
           )}
         </div>
       </div>
+
+      {openItem && (
+        <ItemCopiesModal
+          userId={id as string}
+          item={openItem}
+          isOwner={isSameUser}
+          open={!!openItem}
+          setOpen={(v) => !v && setOpenItem(null)}
+          onSold={() => setRefresh((prev) => !prev)}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/Upgrade/UserItems.tsx
+++ b/src/pages/Upgrade/UserItems.tsx
@@ -61,7 +61,11 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                 if (selectedCase) {
                     newFilters.caseId = selectedCase;
                 }
-                const inventory = await getInventory(userData.id, currentPage, newFilters);
+                const inventory = await getInventory(userData.id, currentPage, {
+                    ...newFilters,
+                    grouped: true,
+                    withIds: true,
+                });
                 setInventory(inventory.items);
                 setPageLimit(inventory.totalPages);
             } catch (error) {
@@ -71,16 +75,30 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
         setLoading(false);
     };
 
+    // a stacked card adds one copy per click and gives the copies back one per click,
+    // so the same card can be tapped up to the number owned
     const handleItemClick = (item: any) => {
-        const itemIdentifier = item.uniqueId;
-        const itemExists = selectedItems.some((selectedItem: { identifier: string }) => selectedItem.identifier === itemIdentifier);
-
-        setSelectedItems(
-            itemExists
-                ? selectedItems.filter((selectedItem: { identifier: string }) => selectedItem.identifier !== itemIdentifier)
-                : [...selectedItems, { item: item, identifier: itemIdentifier }]
+        const ids: string[] = item.uniqueIds?.length ? item.uniqueIds : [item.uniqueId];
+        const taken = new Set(
+            selectedItems.map((s: { identifier: string }) => s.identifier)
         );
+        const next = ids.find((id) => !taken.has(id));
+
+        if (!next) {
+            // every copy on this card is already in, so a further click gives them all back
+            setSelectedItems(
+                selectedItems.filter((s: { identifier: string }) => !ids.includes(s.identifier))
+            );
+            return;
+        }
+
+        setSelectedItems([...selectedItems, { item, identifier: next }]);
         setSelectedCase(item.case);
+    };
+
+    const selectedCountFor = (item: any) => {
+        const ids: string[] = item.uniqueIds?.length ? item.uniqueIds : [item.uniqueId];
+        return selectedItems.filter((s: { identifier: string }) => ids.includes(s.identifier)).length;
     };
 
     const clearCase = () => {
@@ -154,13 +172,19 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                 ) : inventory.length > 0 ? (
                     inventory.map((item: any, index: number) => {
                         if (item.case) {
+                            const picked = selectedCountFor(item);
                             return (
                                 <div
                                     key={index}
                                     onClick={() => handleItemClick(item)}
-                                    className={`cursor-pointer border-2 h-min ${selectedItems.some((selectedItem: { identifier: string }) => selectedItem.identifier === item.uniqueId) ? " border-[#606bc7]" : "border-transparent"}`}
+                                    className={`relative cursor-pointer border-2 h-min ${picked ? " border-[#606bc7]" : "border-transparent"}`}
                                 >
                                     <Item item={item} />
+                                    {picked > 0 && (
+                                        <span className="absolute top-1 right-1 z-20 min-w-[22px] h-[22px] px-1 flex items-center justify-center rounded-full text-xs font-bold bg-[#606bc7] text-white">
+                                            {picked}
+                                        </span>
+                                    )}
                                 </div>
                             );
                         }

--- a/src/services/market/MarketService.ts
+++ b/src/services/market/MarketService.ts
@@ -65,6 +65,12 @@ export async function sellItem(item: any, price: number) {
     return response.data;
 }
 
+// lists several copies of one item at the same price, resolved server-side
+export async function sellItemStack(itemId: string, price: number, quantity: number) {
+    const response = await api.post(`/marketplace/`, { itemId, price, quantity });
+    return response.data;
+}
+
 export async function buyItem(id: string) {
     const response = await api.post(`/marketplace/buy/${id}`);
     return response.data;

--- a/src/services/users/UserServices.ts
+++ b/src/services/users/UserServices.ts
@@ -105,6 +105,17 @@ export async function sellItems(uniqueIds: string[]) {
     return response.data;
 }
 
+// sells a whole stack without shipping one id per copy; omit quantity to sell them all
+export async function sellStack(itemId: string, quantity?: number) {
+    const response = await api.post(`/users/inventory/sell`, { itemId, quantity });
+    return response.data;
+}
+
+export async function getItemCopies(userId: string, itemId: string, page = 1) {
+    const response = await api.get(`/users/inventory/${userId}/copies/${itemId}?page=${page}`);
+    return response.data;
+}
+
 export async function getTransactions(page = 1, filters?: { type?: string; direction?: string }) {
     let url = `/users/transactions?page=${page}`;
 


### PR DESCRIPTION
## Problem

The inventory listed every copy separately. The largest account holds 21,463 items across only 129 distinct ones, which is 1,193 pages of mostly the same thing. The aggregation also unwound the whole array, sorted it, then rebuilt it into a single array just to slice 18 items off the front, on every page view.

## Change

Duplicates now stack into one card with a quantity badge. Grouping happens before the sort, so the same account becomes 129 rows over 8 pages and the sort and rebuild run over 129 rows instead of 21,463.

- **Profile**: the card's uniqueId is the newest copy, so hover-sell sells that one. Stacks gain a sell-all. Clicking a card opens a modal listing every copy, paginated, each with its own provably-fair link and sell button.
- **Market sell modal**: a quantity field beside the price, bounded by what is owned. Each copy still goes through the pull, bid crossing and publish on its own, so a batch is a loop over the single-copy path rather than a shortcut around it.
- **Upgrade**: one copy added per click, with a counter on the card.

Selling or listing a whole stack sends an item id and a count, since an 800-copy stack would otherwise ship 800 uniqueIds up the wire. Grouping is opt-in per request, so callers that still want a flat inventory get every copy.

## Tests

11 new integration tests cover the grouping, the copies endpoint and stack selling (correct count, newest first, never over-selling, other items untouched). Full backend suite passes at 475 tests across 66 suites. Frontend lint, build, unit and e2e all pass.