### PR TITLE
Stop paying for a placeholder ad, and finish the AdSense hookup

### DIFF
--- a/backend/__tests__/integration/adRewards.test.js
+++ b/backend/__tests__/integration/adRewards.test.js
@@ -1,6 +1,8 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
 // tests should not sit through a real watch window
 process.env.AD_REWARD_MIN_WATCH_MS = "50";
+// the feature is off unless a player is named, so these tests have to name one
+process.env.AD_REWARDS_PROVIDER = "mock";
 
 const request = require("supertest");
 const { setupDb, clearDb, teardownDb } = require("./db");
@@ -142,5 +144,79 @@ describe("real-money mode turns ad rewards off", () => {
     expect((await auth(request(app).get("/rewards/ads"), u)).body).toEqual({ enabled: false });
     expect((await start(u)).status).toBe(403);
     expect((await claim(u, "any")).status).toBe(403);
+  });
+});
+
+// paying 500 KP per view for a placeholder is a faucet, so an unconfigured server must
+// not quietly serve one: the offer only exists once a player is named on purpose
+describe("no configured provider turns ad rewards off", () => {
+  afterEach(() => {
+    process.env.AD_REWARDS_PROVIDER = "mock";
+  });
+
+  test("unset provider disables the offer and both endpoints", async () => {
+    delete process.env.AD_REWARDS_PROVIDER;
+    const u = await makeUser();
+    expect((await auth(request(app).get("/rewards/ads"), u)).body).toEqual({ enabled: false });
+    expect((await start(u)).status).toBe(403);
+    expect((await claim(u, "any")).status).toBe(403);
+  });
+
+  test("an unrecognised provider is treated as off, not as a default", async () => {
+    process.env.AD_REWARDS_PROVIDER = "somethingelse";
+    const u = await makeUser();
+    expect((await auth(request(app).get("/rewards/ads"), u)).body).toEqual({ enabled: false });
+    expect((await start(u)).status).toBe(403);
+  });
+
+  test("adsense is a valid provider and is reported to the client", async () => {
+    process.env.AD_REWARDS_PROVIDER = "adsense";
+    const u = await makeUser();
+    const res = await auth(request(app).get("/rewards/ads"), u);
+    expect(res.body.enabled).toBe(true);
+    expect(res.body.provider).toBe("adsense");
+  });
+});
+
+describe("handing a token back when the ad never played", () => {
+  const abandon = (user, token) =>
+    auth(request(app).post("/rewards/ads/abandon"), user).send({ token });
+
+  test("releases the token so the try is not spent", async () => {
+    const u = await makeUser();
+    const s = await start(u);
+    expect(await AdWatch.countDocuments({ userId: u._id })).toBe(1);
+
+    const res = await abandon(u, s.body.token);
+    expect(res.status).toBe(200);
+    expect(res.body.released).toBe(true);
+    expect(await AdWatch.countDocuments({ userId: u._id })).toBe(0);
+
+    // and the freed try really is usable again
+    const again = await watchOne(u);
+    expect(again.status).toBe(200);
+  });
+
+  test("cannot release someone else's token", async () => {
+    const owner = await makeUser();
+    const other = await makeUser();
+    const s = await start(owner);
+
+    const res = await abandon(other, s.body.token);
+    expect(res.body.released).toBe(false);
+    expect(await AdWatch.countDocuments({ userId: owner._id })).toBe(1);
+  });
+
+  test("cannot release a token that was already paid", async () => {
+    const u = await makeUser();
+    const s = await start(u);
+    await sleep(80);
+    expect((await claim(u, s.body.token)).status).toBe(200);
+
+    const res = await abandon(u, s.body.token);
+    expect(res.body.released).toBe(false);
+    // the paid row survives, so the claim still counts against the day
+    expect(await AdWatch.countDocuments({ userId: u._id })).toBe(1);
+    expect(await Transaction.countDocuments({ userId: u._id, type: TX.AD_REWARD })).toBe(1);
   });
 });

--- a/backend/routes/rewardRoutes.js
+++ b/backend/routes/rewardRoutes.js
@@ -26,6 +26,17 @@ module.exports = (io) => {
     }
   });
 
+  // POST /rewards/ads/abandon : hand back a token whose ad never played
+  router.post("/ads/abandon", isAuthenticated, async (req, res) => {
+    try {
+      const r = await adRewards.abandonWatch(req.user._id, req.body.token);
+      res.status(r.code).json(r.body);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: "Server error" });
+    }
+  });
+
   // POST /rewards/ads/claim : redeem the token once the view is plausible (atomic)
   router.post("/ads/claim", isAuthenticated, async (req, res) => {
     try {

--- a/backend/utils/adRewards.js
+++ b/backend/utils/adRewards.js
@@ -8,11 +8,19 @@ const AD_REWARD_AMOUNT = 500;
 const AD_REWARD_DAILY_CAP = 10;
 // a claim younger than this cannot have played a real video; env override for tests
 const minWatchMs = () => Number(process.env.AD_REWARD_MIN_WATCH_MS || 5000);
-// which player the frontend should use; "adsense" once h5 games ads is approved
-const provider = () => process.env.AD_REWARDS_PROVIDER || "mock";
 
-// paying users KP for ad views only makes sense while the KP is play money
-const adRewardsEnabled = () => !isRealMoneyMode();
+// which player the frontend should use. unset means off: "mock" pays full price for a
+// placeholder with no ad in it, so it has to be asked for by name rather than being
+// what an unconfigured server quietly falls back to.
+const PROVIDERS = ["adsense", "mock"];
+const provider = () => {
+  const configured = String(process.env.AD_REWARDS_PROVIDER || "").toLowerCase();
+  return PROVIDERS.includes(configured) ? configured : null;
+};
+
+// paying users KP for ad views only makes sense while the KP is play money, and only
+// when there is actually a player configured to show them something
+const adRewardsEnabled = () => !isRealMoneyMode() && provider() !== null;
 
 const startOfToday = () => {
   const d = new Date();
@@ -102,10 +110,23 @@ async function claimWatch(userId, token) {
   };
 }
 
+// give a token back when the ad never played (no fill, dismissed, script blocked).
+// only an unclaimed token of the caller's can go, so this can never mint anything; it
+// just stops a broken or empty ad break from costing one of the day's ten tries.
+async function abandonWatch(userId, token) {
+  const res = await AdWatch.deleteOne({
+    token: String(token || ""),
+    userId,
+    claimedAt: null,
+  });
+  return { code: 200, body: { released: res.deletedCount > 0 } };
+}
+
 module.exports = {
   AD_REWARD_AMOUNT,
   AD_REWARD_DAILY_CAP,
   adRewardsEnabled,
+  abandonWatch,
   getStatus,
   startWatch,
   claimWatch,

--- a/index.html
+++ b/index.html
@@ -31,6 +31,12 @@
           s.src = src;
           s.async = true;
           s.crossOrigin = 'anonymous';
+          // the ad placement api (rewarded ads) only initialises when the adsense tag
+          // carries a frequency hint; without it window.adBreak never appears and a
+          // reward request is silently dropped
+          if (src.indexOf('adsbygoogle') !== -1) {
+            s.setAttribute('data-ad-frequency-hint', '30s');
+          }
           document.head.appendChild(s);
         });
       }

--- a/src/components/header/ClaimBonus.tsx
+++ b/src/components/header/ClaimBonus.tsx
@@ -11,6 +11,7 @@ import {
   startAdWatch,
   claimAdReward,
   showRewardedAd,
+  abandonAdWatch,
   AdRewardStatus,
 } from "../../services/rewards/AdRewardServices";
 
@@ -108,10 +109,17 @@ const ClaimBonus: React.FC<IBonus> = ({ bonusDate, userData }) => {
     try {
       const started = await startAdWatch();
       if (adStatus.provider === "adsense") {
-        showRewardedAd({
+        // a token that never gets its ad goes straight back, otherwise a no-fill or a
+        // blocked script quietly costs the player one of their ten tries for the day
+        const giveBack = async (message: string) => {
+          await abandonAdWatch(started.token);
+          setAdStatus((s) => (s ? { ...s } : s));
+          toast.info(message, { theme: "dark" });
+        };
+        await showRewardedAd({
           onGranted: () => finishAd(started.token),
-          onDismissed: () => toast.info("Ad closed early, no reward", { theme: "dark" }),
-          onUnavailable: () => toast.info("No ad available right now, try later", { theme: "dark" }),
+          onDismissed: () => giveBack("Ad closed early, no reward"),
+          onUnavailable: () => giveBack("No ad available right now, try later"),
         });
       } else {
         startMock(started.token, started.minWatchMs);
@@ -164,7 +172,7 @@ const ClaimBonus: React.FC<IBonus> = ({ bonusDate, userData }) => {
           <div className="flex flex-col items-center gap-4 p-6">
             <div className="w-full aspect-video bg-surface-nav rounded-md flex items-center justify-center relative overflow-hidden">
               <BiMoviePlay className="text-6xl text-ink-faint" />
-              <span className="absolute top-2 left-2 text-xs text-ink-muted uppercase">Ad</span>
+              <span className="absolute top-2 left-2 text-xs text-ink-muted uppercase">Test placeholder</span>
               <div
                 className="absolute bottom-0 left-0 h-1 bg-accent-gold"
                 style={{
@@ -174,7 +182,7 @@ const ClaimBonus: React.FC<IBonus> = ({ bonusDate, userData }) => {
               />
             </div>
             <p className="text-ink-soft text-sm text-center">
-              {canClaimAd ? "All done, enjoy your coins." : "Watching the ad..."}
+              {canClaimAd ? "All done, enjoy your coins." : "No real ad here yet, this is a test placeholder..."}
             </p>
             <MainButton
               text={`Claim +${adStatus?.amount} K₽`}

--- a/src/services/rewards/AdRewardServices.ts
+++ b/src/services/rewards/AdRewardServices.ts
@@ -30,35 +30,81 @@ export const startAdWatch = async (): Promise<AdWatchStart> =>
 export const claimAdReward = async (token: string): Promise<AdRewardClaim> =>
   (await api.post("/rewards/ads/claim", { token })).data;
 
-// google's ad placement api (h5 games ads). the page already loads adsbygoogle, so
-// adBreak is just the queued call; this only runs when the provider is "adsense".
+// hands a token back when its ad never played, so a no-fill does not spend one of the
+// day's tries
+export const abandonAdWatch = async (token: string): Promise<void> => {
+  try {
+    await api.post("/rewards/ads/abandon", { token });
+  } catch {
+    // best effort: the token expires with the day anyway
+  }
+};
+
+// google's ad placement api (h5 games ads), which rides on the adsense tag loaded in
+// index.html. that tag is fetched after the load event, so adBreak can be minutes late
+// or never arrive at all (blocked, not enrolled, no fill).
 declare global {
   interface Window {
     adsbygoogle: unknown[];
     adBreak?: (o: Record<string, unknown>) => void;
+    adConfig?: (o: Record<string, unknown>) => void;
   }
 }
 
-export const showRewardedAd = (handlers: {
+const AD_SCRIPT_WAIT_MS = 6000;
+
+// resolves once the placement api is live, or false if it never turns up
+const waitForAdBreak = (): Promise<boolean> =>
+  new Promise((resolve) => {
+    if (typeof window.adBreak === "function") return resolve(true);
+    const started = Date.now();
+    const tick = window.setInterval(() => {
+      if (typeof window.adBreak === "function") {
+        window.clearInterval(tick);
+        resolve(true);
+      } else if (Date.now() - started > AD_SCRIPT_WAIT_MS) {
+        window.clearInterval(tick);
+        resolve(false);
+      }
+    }, 200);
+  });
+
+export const showRewardedAd = async (handlers: {
   onGranted: () => void;
   onDismissed: () => void;
   onUnavailable: () => void;
 }) => {
-  const adBreak =
-    window.adBreak || ((o: Record<string, unknown>) => (window.adsbygoogle = window.adsbygoogle || []).push(o));
+  const ready = await waitForAdBreak();
+  if (!ready) {
+    // never queue onto adsbygoogle as a fallback: that array is for display slots and
+    // swallows a reward request without ever calling back, which reads as a dead button
+    handlers.onUnavailable();
+    return;
+  }
+
+  // the placement api wants its config before the first break is requested
+  window.adConfig?.({ preloadAdBreaks: "on", sound: "on" });
+
   let shown = false;
-  adBreak({
+  let settled = false;
+  const once = (fn: () => void) => () => {
+    if (settled) return;
+    settled = true;
+    fn();
+  };
+
+  window.adBreak?.({
     type: "reward",
     name: "kp-reward",
     beforeReward: (showAdFn: () => void) => {
       shown = true;
       showAdFn();
     },
-    adViewed: () => handlers.onGranted(),
-    adDismissed: () => handlers.onDismissed(),
+    adViewed: once(handlers.onGranted),
+    adDismissed: once(handlers.onDismissed),
     adBreakDone: () => {
       // no fill: beforeReward never ran, so nothing was ever shown
-      if (!shown) handlers.onUnavailable();
+      if (!shown) once(handlers.onUnavailable)();
     },
   });
 };


### PR DESCRIPTION
## Problem

`AD_REWARDS_PROVIDER` defaulted to `"mock"`, so an unconfigured server offered the watch-an-ad button and paid the full 500 KP for a five second placeholder with no ad in it. The box never sets that variable, so that is what production has been serving. A player hitting the daily cap in seventy six seconds is the cap working, not an exploit: the token, the minimum watch, the once-only claim and the ledger all held.

The adsense path could not have worked either. The placement api only initialises when the adsense tag carries a frequency hint, `adConfig` was never called, and the fallback pushed the reward request onto the display-ad queue, which drops it without ever calling back. That is a dead button that has already spent one of the day's ten tries.

## Change

- The provider is explicit. Unset or unrecognised means the feature is off and the button never appears. `mock` has to be asked for by name, and now says on screen that it is a test placeholder.
- `adConfig` is called, the adsense tag carries `data-ad-frequency-hint`, and the client waits for the placement api rather than queueing onto the display-ad array.
- A token whose ad never plays is handed back through a new abandon endpoint, so a no-fill or a blocked script no longer costs a try.

Money handling is unchanged.

## Deploying

Ad rewards will be **off** after this merges until `AD_REWARDS_PROVIDER` is set on the box. That is the intended state while H5 Games Ads is unapproved.

## Tests

Seven new integration tests cover the gating (unset, unrecognised, adsense) and the token release (frees the try, cannot touch another user's token, cannot release a paid one). Full backend suite passes at 481 tests. Frontend lint, build, unit and e2e all pass.