### PR TITLE
Stop storing rounds nobody bet on, and the catalog on every inventory item

### DIFF
--- a/backend/__tests__/integration/battleRecovery.test.js
+++ b/backend/__tests__/integration/battleRecovery.test.js
@@ -107,7 +107,8 @@ test("a battle interrupted mid-reveal still finishes from its preroll", async ()
   expect(done.status).toBe("finished");
   expect(done.winningTeam).toBe(0);
   const winner = await User.findById(a._id);
-  expect(winner.inventory.map((i) => i.name)).toContain("won");
+  expect(winner.inventory.map((i) => String(i._id))).toContain(String(item._id));
+  expect(winner.inventory.map((i) => i.uniqueId)).toContain(item.uniqueId);
 });
 
 test("the periodic sweep leaves a live in-progress battle for the engine to finish", async () => {

--- a/backend/__tests__/integration/dbFootprint.test.js
+++ b/backend/__tests__/integration/dbFootprint.test.js
@@ -1,0 +1,148 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Round = require("../../models/Round");
+const { pruneEmptyRounds } = require("../../utils/roundPrune");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const hoursAgo = (h) => new Date(Date.now() - h * 3600 * 1000);
+
+async function makeRound(overrides) {
+  const r = await Round.create({ game: "crash", status: "settled", bets: [], ...overrides });
+  if (overrides.createdAt) {
+    await Round.updateOne({ _id: r._id }, { $set: { createdAt: overrides.createdAt } });
+  }
+  return r;
+}
+
+describe("pruning rounds nobody bet on", () => {
+  it("removes old empty rounds", async () => {
+    await makeRound({ createdAt: hoursAgo(48) });
+    await makeRound({ createdAt: hoursAgo(30), game: "coinflip" });
+
+    expect(await pruneEmptyRounds()).toBe(2);
+    expect(await Round.countDocuments()).toBe(0);
+  });
+
+  it("keeps any round that took a bet, however old", async () => {
+    await makeRound({
+      createdAt: hoursAgo(24 * 90),
+      bets: [{ userId: "507f1f77bcf86cd799439011", username: "p", amount: 10, payout: 0 }],
+    });
+
+    expect(await pruneEmptyRounds()).toBe(0);
+    expect(await Round.countDocuments()).toBe(1);
+  });
+
+  it("keeps recent empty rounds so the history strip stays full", async () => {
+    await makeRound({ createdAt: hoursAgo(2) });
+    expect(await pruneEmptyRounds()).toBe(0);
+    expect(await Round.countDocuments()).toBe(1);
+  });
+
+  it("never touches a round still in flight", async () => {
+    await makeRound({ createdAt: hoursAgo(48), status: "betting" });
+    await makeRound({ createdAt: hoursAgo(48), status: "running" });
+
+    expect(await pruneEmptyRounds()).toBe(0);
+    expect(await Round.countDocuments()).toBe(2);
+  });
+});
+
+describe("inventory entries carry only what identifies the copy", () => {
+  async function seed() {
+    const item = await Item.create({
+      name: `Nemuno-${uniqueSuffix()}`,
+      image: "https://example.com/n.png",
+      rarity: "3",
+      baseValue: 400,
+    });
+    const s = uniqueSuffix();
+    const user = await User.create({
+      username: `user-${s}`,
+      email: `user-${s}@example.com`,
+      password: "x",
+      inventory: [{ _id: item._id, rarity: "3", uniqueId: `u-${s}`, createdAt: new Date() }],
+    });
+    return { item, user };
+  }
+
+  it("hydrates name and image from the catalog on read", async () => {
+    const { item, user } = await seed();
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+
+    expect(res.status).toBe(200);
+    const row = res.body.items[0];
+    expect(row.name).toBe(item.name);
+    expect(row.image).toBe(item.image);
+    expect(row.sellValue).toBeGreaterThan(0);
+  });
+
+  it("still finds an item by name, which now lives only on the catalog", async () => {
+    const { item, user } = await seed();
+
+    const hit = await request(app).get(`/users/inventory/${user._id}?grouped=true&name=${item.name}`);
+    expect(hit.body.items).toHaveLength(1);
+
+    const miss = await request(app).get(`/users/inventory/${user._id}?grouped=true&name=nothinglikethis`);
+    expect(miss.body.items).toHaveLength(0);
+  });
+
+  it("still filters by case through the catalog", async () => {
+    const caseId = "507f1f77bcf86cd799439099";
+    const item = await Item.create({
+      name: `Cased-${uniqueSuffix()}`,
+      image: "c.png",
+      rarity: "1",
+      baseValue: 10,
+      case: caseId,
+    });
+    const s = uniqueSuffix();
+    const user = await User.create({
+      username: `user-${s}`,
+      email: `user-${s}@example.com`,
+      password: "x",
+      inventory: [{ _id: item._id, rarity: "1", uniqueId: `u-${s}`, createdAt: new Date() }],
+    });
+
+    const hit = await request(app).get(`/users/inventory/${user._id}?grouped=true&caseId=${caseId}`);
+    expect(hit.body.items).toHaveLength(1);
+
+    const miss = await request(app).get(
+      `/users/inventory/${user._id}?grouped=true&caseId=507f1f77bcf86cd799439000`
+    );
+    expect(miss.body.items).toHaveLength(0);
+  });
+
+  it("still sorts by rarity, which stays on the entry", async () => {
+    const s = uniqueSuffix();
+    const common = await Item.create({ name: `c-${s}`, image: "c.png", rarity: "1", baseValue: 10 });
+    const rare = await Item.create({ name: `r-${s}`, image: "r.png", rarity: "5", baseValue: 900 });
+    const user = await User.create({
+      username: `user-${s}`,
+      email: `user-${s}@example.com`,
+      password: "x",
+      inventory: [
+        { _id: common._id, rarity: "1", uniqueId: `a-${s}`, createdAt: new Date() },
+        { _id: rare._id, rarity: "5", uniqueId: `b-${s}`, createdAt: new Date() },
+      ],
+    });
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true&sortBy=mostRare`);
+    expect(res.body.items[0].name).toBe(rare.name);
+  });
+});

--- a/backend/games/battleEngine.js
+++ b/backend/games/battleEngine.js
@@ -228,10 +228,7 @@ async function finishBattle(battle, io = noopIo) {
     winnerUserIds.push(w.userId);
     const invItems = (shares[i] || []).map((it) => ({
       _id: it._id,
-      name: it.name,
-      image: it.image,
       rarity: it.rarity,
-      case: it.case,
       createdAt: new Date(),
       uniqueId: it.uniqueId,
     }));

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -15,7 +15,7 @@ const MinesGameController = require("../games/mines");
 const HiloGameController = require("../games/hilo");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const referrals = require("../utils/referrals");
-const { addUniqueInfoToItem } = require("../utils/caseOpening");
+const { addUniqueInfoToItem, toInventoryEntry } = require("../utils/caseOpening");
 const { buildRangeTable } = require("../utils/caseRanges");
 const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
 const seeds = require("../utils/seeds");
@@ -93,7 +93,7 @@ module.exports = (io) => {
           { _id: user._id, walletBalance: { $gte: cost } },
           {
             $inc: { walletBalance: -cost, xp: cost * 5 },
-            $push: { inventory: { $each: winningItems } },
+            $push: { inventory: { $each: winningItems.map(toInventoryEntry) } },
           },
           { new: true, session }
         );

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -444,11 +444,16 @@ router.put("/fixedItem", authMiddleware.isAuthenticated, async (req, res) => {
     }
 
 
+    const catalogItem = await Item.findById(inventoryItemIndex._id, { name: 1, image: 1, rarity: 1 }).lean();
+    if (!catalogItem) {
+      return res.status(404).json({ message: "Item not found" });
+    }
+
     // Update fixed item, keeping the same description
     user.fixedItem = {
-      name: inventoryItemIndex.name,
-      image: inventoryItemIndex.image,
-      rarity: inventoryItemIndex.rarity,
+      name: catalogItem.name,
+      image: catalogItem.image,
+      rarity: catalogItem.rarity,
       description: user.fixedItem.description,
     };
     await user.save();
@@ -617,6 +622,17 @@ router.get("/inventory/:userId", async (req, res) => {
       ? new RegExp(String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i")
       : null;
 
+    // name and case live on the catalog, not on the entry, so they resolve to a set of
+    // item ids first and the inventory is then matched on _id
+    let idFilter = null;
+    if (nameRegex || caseFilter) {
+      const catalogQuery = {};
+      if (nameRegex) catalogQuery.name = nameRegex;
+      if (caseFilter) catalogQuery.case = caseFilter;
+      const matches = await Item.find(catalogQuery, { _id: 1 }).lean();
+      idFilter = matches.map((m) => m._id);
+    }
+
     // Count Pipeline
     let countPipeline = [
       { $match: query },
@@ -624,12 +640,8 @@ router.get("/inventory/:userId", async (req, res) => {
       { $unwind: "$inventory" }
     ];
 
-    if (caseFilter) {
-      countPipeline.push({ $match: { "inventory.case": caseFilter } });
-    }
-
-    if (nameRegex) {
-      countPipeline.push({ $match: { "inventory.name": nameRegex } });
+    if (idFilter) {
+      countPipeline.push({ $match: { "inventory._id": { $in: idFilter } } });
     }
     if (rarity) {
       countPipeline.push({ $match: { "inventory.rarity": rarity } });
@@ -657,12 +669,8 @@ router.get("/inventory/:userId", async (req, res) => {
       { $unwind: "$inventory" }
     ];
 
-    if (caseFilter) {
-      pipeline.push({ $match: { "inventory.case": caseFilter } });
-    }
-
-    if (nameRegex) {
-      pipeline.push({ $match: { "inventory.name": nameRegex } });
+    if (idFilter) {
+      pipeline.push({ $match: { "inventory._id": { $in: idFilter } } });
     }
     if (rarity) {
       pipeline.push({ $match: { "inventory.rarity": rarity } });
@@ -684,10 +692,7 @@ router.get("/inventory/:userId", async (req, res) => {
       pipeline.push({
         $group: {
           _id: "$inventory._id",
-          name: { $first: "$inventory.name" },
-          image: { $first: "$inventory.image" },
           rarity: { $first: "$inventory.rarity" },
-          case: { $first: "$inventory.case" },
           uniqueId: { $first: "$inventory.uniqueId" },
           createdAt: { $first: "$inventory.createdAt" },
           oldestAt: { $min: "$inventory.createdAt" },
@@ -722,13 +727,26 @@ router.get("/inventory/:userId", async (req, res) => {
       items = inventoryItems[0]?.inventory || [];
     }
 
-    // attach authoritative base/sell value from the item catalog
+    // the entry only identifies the copy; name, image and case come from the catalog,
+    // along with the authoritative base/sell value
     const ids = [...new Set(items.map((i) => String(i._id)))];
-    const catalog = await Item.find({ _id: { $in: ids } }, { baseValue: 1 });
-    const baseById = new Map(catalog.map((i) => [String(i._id), i.baseValue || 0]));
+    const catalog = await Item.find(
+      { _id: { $in: ids } },
+      { baseValue: 1, name: 1, image: 1, rarity: 1, case: 1 }
+    ).lean();
+    const byId = new Map(catalog.map((i) => [String(i._id), i]));
     const withValue = items.map((i) => {
-      const base = baseById.get(String(i._id)) || 0;
-      return { ...i, baseValue: base, sellValue: sellValue(base) };
+      const cat = byId.get(String(i._id)) || {};
+      const base = cat.baseValue || 0;
+      return {
+        ...i,
+        name: cat.name,
+        image: cat.image,
+        rarity: i.rarity ?? cat.rarity,
+        case: cat.case,
+        baseValue: base,
+        sellValue: sellValue(base),
+      };
     });
 
     res.json({

--- a/backend/scripts/slimInventory.js
+++ b/backend/scripts/slimInventory.js
@@ -1,0 +1,65 @@
+// one-time migration: drop name/image/case from every inventory entry. they duplicate
+// the catalog on all ~293k rows and are joined back on read. safe to re-run: the unset
+// is a no-op once a field is gone.
+//
+// usage (from backend/):
+//   node scripts/slimInventory.js           # dry run, reports what would change
+//   node scripts/slimInventory.js --apply   # actually writes the changes
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const APPLY = process.argv.includes("--apply");
+
+(async () => {
+  if (!process.env.MONGO_URI) {
+    console.error("MONGO_URI is not set (run from backend/ with its .env)");
+    process.exit(1);
+  }
+
+  await mongoose.connect(process.env.MONGO_URI);
+  console.log(APPLY ? "APPLY mode: writing changes" : "DRY RUN: no changes will be written");
+
+  const users = mongoose.connection.db.collection("users");
+  const filter = {
+    $or: [
+      { "inventory.name": { $exists: true } },
+      { "inventory.image": { $exists: true } },
+      { "inventory.case": { $exists: true } },
+    ],
+  };
+
+  const affected = await users.countDocuments(filter);
+  const entries = await users
+    .aggregate([
+      { $project: { n: { $size: { $ifNull: ["$inventory", []] } } } },
+      { $group: { _id: null, total: { $sum: "$n" } } },
+    ])
+    .toArray();
+  const total = entries[0]?.total || 0;
+
+  console.log(`users ${APPLY ? "to fix" : "with fat entries"}: ${affected}`);
+  console.log(`inventory entries in total: ${total}`);
+  console.log(`estimated saving: ~${((114 * total) / 1048576).toFixed(1)} MB`);
+
+  if (APPLY) {
+    const res = await users.updateMany(filter, {
+      $unset: {
+        "inventory.$[].name": "",
+        "inventory.$[].image": "",
+        "inventory.$[].case": "",
+      },
+    });
+    console.log(`users written: ${res.modifiedCount}`);
+    const left = await users.countDocuments(filter);
+    console.log(`users still carrying the fields: ${left}`);
+  }
+
+  console.log(APPLY ? "done." : "dry run complete, re-run with --apply to write.");
+  await mongoose.disconnect();
+})().catch(async (err) => {
+  console.error(err);
+  try {
+    await mongoose.disconnect();
+  } catch (_) {}
+  process.exit(1);
+});

--- a/backend/tasks/cronJobs.js
+++ b/backend/tasks/cronJobs.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const User = require('../models/User');
 const Notification = require("../models/Notification");
+const { pruneEmptyRounds } = require("../utils/roundPrune");
 
 module.exports = {
     startCronJobs: function (io) {
@@ -40,6 +41,15 @@ module.exports = {
                 console.log('Weekly winnings reset successfully.');
             } catch (error) {
                 console.error('Error resetting weekly winnings:', error);
+            }
+        })
+
+        cron.schedule('30 4 * * *', async () => {
+            try {
+                const removed = await pruneEmptyRounds();
+                console.log(`Pruned ${removed} rounds nobody bet on.`);
+            } catch (error) {
+                console.error('Error pruning empty rounds:', error);
             }
         })
     }

--- a/backend/utils/caseOpening.js
+++ b/backend/utils/caseOpening.js
@@ -65,8 +65,18 @@ const addUniqueInfoToItem = (item) => {
   };
 };
 
+// what actually gets stored on the user. the drawn item above is also handed to the
+// client to animate, but name, image and case are catalog data and are joined on read.
+const toInventoryEntry = (item) => ({
+  _id: item._id,
+  rarity: item.rarity,
+  uniqueId: item.uniqueId,
+  createdAt: new Date(),
+});
+
 module.exports = {
   Rarities,
   getWinningItem,
   addUniqueInfoToItem,
+  toInventoryEntry,
 };

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -26,10 +26,7 @@ async function recordMarketFee({ price, buyerId, meta }) {
 function inventoryEntryFrom(listing) {
   return {
     _id: listing.item,
-    name: listing.itemName,
-    image: listing.itemImage,
     rarity: listing.rarity,
-    case: listing.case,
     createdAt: new Date(),
     uniqueId: listing.uniqueId,
   };

--- a/backend/utils/roundPrune.js
+++ b/backend/utils/roundPrune.js
@@ -1,0 +1,18 @@
+const Round = require("../models/Round");
+
+// crash and coinflip run around the clock whether or not anyone is playing, and each
+// round is a document. 99.5% of them never took a bet, so they are pure disk.
+// the window keeps enough settled rounds for the history strips to stay full.
+const KEEP_HOURS = 24;
+
+async function pruneEmptyRounds({ keepHours = KEEP_HOURS } = {}) {
+  const before = new Date(Date.now() - keepHours * 3600 * 1000);
+  const res = await Round.deleteMany({
+    createdAt: { $lt: before },
+    status: { $in: ["settled", "voided"] },
+    $or: [{ bets: { $size: 0 } }, { bets: { $exists: false } }],
+  });
+  return res.deletedCount || 0;
+}
+
+module.exports = { pruneEmptyRounds, KEEP_HOURS };


### PR DESCRIPTION
## Problem

Atlas logical size went from 75 MB to 128 MB in a week against a 512 MB cap. Two things account for nearly all of it.

**Rounds.** Crash and coinflip write a document per round whether or not anyone is playing. 73,650 of 74,004 rounds ever created had no bets at all: 28.9 MB of data plus 3.8 MB of indexes recording nothing happening, growing by ~8,500 rows a day.

**Inventory.** Each of the 293,605 entries carried `name`, `image` and `case` copied from the catalog. That is 114 of its 186 bytes, duplicated on every row.

## Change

A nightly prune drops settled rounds with no bets older than a day. The 24 hour window keeps the coinflip history strip full, and any round that took money is never touched at any age.

Inventory entries now keep only what identifies the copy (`_id`, `rarity`, `uniqueId`, `createdAt`) and the read joins the rest back from the catalog, which the endpoint already did for `baseValue`. Filtering by name or case resolves through the catalog to a set of item ids first, the way the market browse route already does. Sorting is unaffected since `rarity` and `createdAt` stay on the entry.

The item handed to the client to animate a case opening or a battle reveal is unchanged. Only what gets stored is slimmer.

## Migration

`backend/scripts/slimInventory.js`, dry run by default, `--apply` to write. Dry run against production reports 2,092 users and ~32 MB. Safe to re-run: the unset is a no-op once a field is gone.

Expected result: users 56.3 MB to ~24 MB, rounds 28.9 MB to ~1 MB.

## Tests

8 new integration tests cover the prune (removes old empty rounds, keeps any round with a bet, keeps recent ones for the history, never touches a round in flight) and the slimmer entries (hydrates name and image on read, still filters by name and case, still sorts by rarity). Full backend suite passes at 489 tests across 67 suites. Frontend lint, build and unit all pass.