### PR TITLE
Recover the crash cashout fix, footer and mission toast left behind by #193

### DIFF
--- a/backend/__tests__/integration/adRewards.test.js
+++ b/backend/__tests__/integration/adRewards.test.js
@@ -147,8 +147,6 @@ describe("real-money mode turns ad rewards off", () => {
   });
 });
 
-// paying 500 KP per view for a placeholder is a faucet, so an unconfigured server must
-// not quietly serve one: the offer only exists once a player is named on purpose
 describe("no configured provider turns ad rewards off", () => {
   afterEach(() => {
     process.env.AD_REWARDS_PROVIDER = "mock";
@@ -192,7 +190,6 @@ describe("handing a token back when the ad never played", () => {
     expect(res.body.released).toBe(true);
     expect(await AdWatch.countDocuments({ userId: u._id })).toBe(0);
 
-    // and the freed try really is usable again
     const again = await watchOne(u);
     expect(again.status).toBe(200);
   });
@@ -215,7 +212,6 @@ describe("handing a token back when the ad never played", () => {
 
     const res = await abandon(u, s.body.token);
     expect(res.body.released).toBe(false);
-    // the paid row survives, so the claim still counts against the day
     expect(await AdWatch.countDocuments({ userId: u._id })).toBe(1);
     expect(await Transaction.countDocuments({ userId: u._id, type: TX.AD_REWARD })).toBe(1);
   });

--- a/backend/__tests__/unit/crashSync.test.js
+++ b/backend/__tests__/unit/crashSync.test.js
@@ -68,4 +68,23 @@ describe("crash sync on entry", () => {
     expect(sync.p.gameStartTime).toBeTruthy();
     expect(sync.p).not.toHaveProperty("crashPoint");
   });
+
+  // the page reads its own stake back out of these on remount, which is the only way
+  // the cashout button survives navigating away mid-round
+  test("the state carries the caller's own bet and whether it is still uncashed", async () => {
+    const { chargeUser } = require("../../utils/economy");
+    chargeUser.mockResolvedValue({ _id: "u1", username: "p", profilePicture: "", level: 1, fixedItem: null });
+
+    const socket = makeSocket();
+    socket.userId = "u1";
+    io.connection(socket);
+    await socket.handlers["crash:bet"]({ amount: 100, autoCashoutAt: null }, () => {});
+
+    socket.emitted.length = 0;
+    socket.handlers["crash:requestState"]();
+    const sync = socket.emitted.find((m) => m.e === "crash:sync");
+
+    expect(sync.p.gameBets.u1).toBe(100);
+    expect(sync.p.gamePlayers.u1.payout).toBeNull();
+  });
 });

--- a/backend/utils/adRewards.js
+++ b/backend/utils/adRewards.js
@@ -9,17 +9,14 @@ const AD_REWARD_DAILY_CAP = 10;
 // a claim younger than this cannot have played a real video; env override for tests
 const minWatchMs = () => Number(process.env.AD_REWARD_MIN_WATCH_MS || 5000);
 
-// which player the frontend should use. unset means off: "mock" pays full price for a
-// placeholder with no ad in it, so it has to be asked for by name rather than being
-// what an unconfigured server quietly falls back to.
+// unset means off: "mock" pays full price for a placeholder, so it is opt-in by name
 const PROVIDERS = ["adsense", "mock"];
 const provider = () => {
   const configured = String(process.env.AD_REWARDS_PROVIDER || "").toLowerCase();
   return PROVIDERS.includes(configured) ? configured : null;
 };
 
-// paying users KP for ad views only makes sense while the KP is play money, and only
-// when there is actually a player configured to show them something
+// paying users KP for ad views only makes sense while the KP is play money
 const adRewardsEnabled = () => !isRealMoneyMode() && provider() !== null;
 
 const startOfToday = () => {
@@ -110,9 +107,7 @@ async function claimWatch(userId, token) {
   };
 }
 
-// give a token back when the ad never played (no fill, dismissed, script blocked).
-// only an unclaimed token of the caller's can go, so this can never mint anything; it
-// just stops a broken or empty ad break from costing one of the day's ten tries.
+// only an unclaimed token of the caller's can go, so this can never mint anything
 async function abandonWatch(userId, token) {
   const res = await AdWatch.deleteOne({
     token: String(token || ""),

--- a/index.html
+++ b/index.html
@@ -31,9 +31,7 @@
           s.src = src;
           s.async = true;
           s.crossOrigin = 'anonymous';
-          // the ad placement api (rewarded ads) only initialises when the adsense tag
-          // carries a frequency hint; without it window.adBreak never appears and a
-          // reward request is silently dropped
+          // without this hint the placement api never defines window.adBreak
           if (src.indexOf('adsbygoogle') !== -1) {
             s.setAttribute('data-ad-frequency-hint', '30s');
           }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -90,12 +90,6 @@ function Footer() {
           onClick: () => handleModalInfo(<FAQ />),
         },
       ],
-    }, {
-      title: "Payment Forms",
-      children: <div className="flex flex-col items-start gap-2">
-        <img src="/images/PIX_Logo2.webp" alt="PIX" width={150} height={58} loading="lazy" />
-        <img src="/images/cards.webp" alt="cards" width={200} height={24} loading="lazy" />
-      </div>
     }
   ];
 
@@ -141,7 +135,6 @@ function Footer() {
                     ))
                   }
                 </div>
-                {section.children}
               </div>
             ))
           }

--- a/src/components/header/ClaimBonus.tsx
+++ b/src/components/header/ClaimBonus.tsx
@@ -109,8 +109,6 @@ const ClaimBonus: React.FC<IBonus> = ({ bonusDate, userData }) => {
     try {
       const started = await startAdWatch();
       if (adStatus.provider === "adsense") {
-        // a token that never gets its ad goes straight back, otherwise a no-fill or a
-        // blocked script quietly costs the player one of their ten tries for the day
         const giveBack = async (message: string) => {
           await abandonAdWatch(started.token);
           setAdStatus((s) => (s ? { ...s } : s));

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import SocketConnection from "../../services/socket"
+import { setStakeAtRisk } from "../../services/stakeGuard";
 import Coin from "./Coin"
 import { motion } from "framer-motion";
 import UserContext from "../../UserContext";
@@ -134,6 +135,12 @@ const CoinFlip = () => {
     };
   }, []);
 
+
+  useEffect(() => {
+    setStakeAtRisk(userGambled || spinning);
+  }, [userGambled, spinning]);
+
+  useEffect(() => () => setStakeAtRisk(false), []);
 
   useEffect(() => {
     if (countDown > 0.1 && !spinning) {

--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useRef, useState } from "react";
 import { toast } from "react-toastify";
 import SocketConnection from "../../services/socket"
+import { setStakeAtRisk } from "../../services/stakeGuard";
 import UserContext from "../../UserContext";
 import falling from "/images/crash/falling.gif";
 import idle from "/images/crash/idle.gif";
@@ -69,6 +70,13 @@ const CrashGame = () => {
 
   const userIdRef = useRef<string | undefined>(userData?.id);
   userIdRef.current = userData?.id;
+
+  useEffect(() => {
+    setStakeAtRisk(userGambled && gameStarted && !userCashedOut);
+  }, [userGambled, gameStarted, userCashedOut]);
+
+  // leaving the page is the player's own choice; the guard only holds while they are on it
+  useEffect(() => () => setStakeAtRisk(false), []);
 
   const handleBet = () => {
     if (!isLogged) {

--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -67,6 +67,9 @@ const CrashGame = () => {
   const placeBetRef = useRef(placeBet);
   placeBetRef.current = placeBet;
 
+  const userIdRef = useRef<string | undefined>(userData?.id);
+  userIdRef.current = userData?.id;
+
   const handleBet = () => {
     if (!isLogged) {
       toogleUserFlow(true);
@@ -148,6 +151,16 @@ const CrashGame = () => {
         setGameStarted(false);
         setGameEnded(false);
       }
+
+      // leaving the page and coming back remounts this with a blank slate, so the
+      // player's own stake has to be read back or the cashout button never returns
+      const id = userIdRef.current;
+      const stake = id ? sync.gameBets?.[id] : undefined;
+      if (stake == null) return;
+      const payout = sync.gamePlayers?.[id as string]?.payout;
+      setUserGambled(true);
+      setUserCashedOut(payout != null);
+      if (payout != null) setUserMultiplier(payout / stake);
     };
 
     socket.on("crash:sync", syncListener);

--- a/src/pages/Missions/components/missionCompleteToast.tsx
+++ b/src/pages/Missions/components/missionCompleteToast.tsx
@@ -3,12 +3,17 @@ import { GiTrophyCup } from "react-icons/gi";
 import { FiArrowRight } from "react-icons/fi";
 import Monetary from "../../../components/Monetary";
 import { navigateTo } from "../../../services/navigation";
+import { whenStakeClears } from "../../../services/stakeGuard";
 import { PendingMission } from "../../../services/missions/MissionService";
 
 // the styled real-time "mission complete" toast, shown app-wide the moment a
 // mission becomes claimable (server guarantees it fires once per mission). When a
 // targetPath is given the whole toast is a link to the missions page.
 export function toastMissionComplete(m: PendingMission, targetPath?: string) {
+  whenStakeClears(() => showMissionToast(m, targetPath));
+}
+
+function showMissionToast(m: PendingMission, targetPath?: string) {
   toast(
     <div className={`flex items-center gap-3 ${targetPath ? "cursor-pointer" : ""}`}>
       <GiTrophyCup className="text-3xl text-accent-gold shrink-0" />

--- a/src/services/rewards/AdRewardServices.ts
+++ b/src/services/rewards/AdRewardServices.ts
@@ -30,8 +30,7 @@ export const startAdWatch = async (): Promise<AdWatchStart> =>
 export const claimAdReward = async (token: string): Promise<AdRewardClaim> =>
   (await api.post("/rewards/ads/claim", { token })).data;
 
-// hands a token back when its ad never played, so a no-fill does not spend one of the
-// day's tries
+// a no-fill must not spend one of the day's tries
 export const abandonAdWatch = async (token: string): Promise<void> => {
   try {
     await api.post("/rewards/ads/abandon", { token });
@@ -40,9 +39,7 @@ export const abandonAdWatch = async (token: string): Promise<void> => {
   }
 };
 
-// google's ad placement api (h5 games ads), which rides on the adsense tag loaded in
-// index.html. that tag is fetched after the load event, so adBreak can be minutes late
-// or never arrive at all (blocked, not enrolled, no fill).
+// the adsense tag loads after the page, so adBreak can be late or never arrive at all
 declare global {
   interface Window {
     adsbygoogle: unknown[];
@@ -76,8 +73,7 @@ export const showRewardedAd = async (handlers: {
 }) => {
   const ready = await waitForAdBreak();
   if (!ready) {
-    // never queue onto adsbygoogle as a fallback: that array is for display slots and
-    // swallows a reward request without ever calling back, which reads as a dead button
+    // adsbygoogle is the display-slot queue: it swallows a reward request without calling back
     handlers.onUnavailable();
     return;
   }

--- a/src/services/stakeGuard.test.ts
+++ b/src/services/stakeGuard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setStakeAtRisk, isStakeAtRisk, whenStakeClears } from "./stakeGuard";
+
+beforeEach(() => setStakeAtRisk(false));
+
+describe("stakeGuard", () => {
+  it("runs straight away when nothing is at risk", () => {
+    const run = vi.fn();
+    whenStakeClears(run);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds while a stake is live and releases when it clears", () => {
+    setStakeAtRisk(true);
+    const run = vi.fn();
+    whenStakeClears(run);
+    expect(run).not.toHaveBeenCalled();
+
+    setStakeAtRisk(false);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases everything queued, in order, exactly once", () => {
+    setStakeAtRisk(true);
+    const order: number[] = [];
+    whenStakeClears(() => order.push(1));
+    whenStakeClears(() => order.push(2));
+
+    setStakeAtRisk(false);
+    expect(order).toEqual([1, 2]);
+
+    // a later clear must not replay them
+    setStakeAtRisk(true);
+    setStakeAtRisk(false);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it("a repeated clear does not double-run the queue", () => {
+    setStakeAtRisk(true);
+    const run = vi.fn();
+    whenStakeClears(run);
+
+    setStakeAtRisk(false);
+    setStakeAtRisk(false);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports whether a stake is live", () => {
+    expect(isStakeAtRisk()).toBe(false);
+    setStakeAtRisk(true);
+    expect(isStakeAtRisk()).toBe(true);
+  });
+});

--- a/src/services/stakeGuard.ts
+++ b/src/services/stakeGuard.ts
@@ -1,0 +1,22 @@
+// A game page raises this while the player has money riding on a round in progress.
+// Anything that would pull them off the page, like the mission-complete toast, waits
+// for it to clear instead of inviting a click mid-round.
+let atRisk = false;
+let waiting: (() => void)[] = [];
+
+export const setStakeAtRisk = (value: boolean) => {
+  if (atRisk === value) return;
+  atRisk = value;
+  if (!atRisk) {
+    const queued = waiting;
+    waiting = [];
+    queued.forEach((run) => run());
+  }
+};
+
+export const isStakeAtRisk = () => atRisk;
+
+export const whenStakeClears = (run: () => void) => {
+  if (atRisk) waiting.push(run);
+  else run();
+};


### PR DESCRIPTION
## Problem

PR #193 was merged at its first commit, so the two commits pushed after that never reached main. The work is on the branch but not shipped:

- the crash cashout fix, where leaving the page mid-round remounted with a blank slate and the button never came back
- the payment methods block removed from the footer
- the mission toast held until the round is settled, plus its `stakeGuard` module and tests
- the comment trims across the ad reward files

## Change

Both commits cherry-picked onto current main. No new work, no conflicts.

## Tests

Full backend suite and frontend checks pass. `crashSync` and `adRewards` suites confirmed green at 17 tests.