### PR TITLE
Email plumbing, marketing consent, and a real privacy policy

### DIFF
--- a/backend/__tests__/integration/emailPrefs.test.js
+++ b/backend/__tests__/integration/emailPrefs.test.js
@@ -1,0 +1,176 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    ...overrides,
+  });
+}
+
+describe("marketing consent", () => {
+  it("is off for a new account, and nobody is opted in by default", async () => {
+    const u = await makeUser();
+    expect(u.marketingOptIn).toBe(false);
+    expect(u.unsubscribeToken).toBeTruthy();
+  });
+
+  it("the owner can turn it on and off, and the time is recorded", async () => {
+    const u = await makeUser();
+
+    const on = await auth(request(app).put("/email/preferences"), u).send({ marketingOptIn: true });
+    expect(on.body.marketingOptIn).toBe(true);
+    expect((await User.findById(u._id)).marketingOptInAt).toBeTruthy();
+
+    const off = await auth(request(app).put("/email/preferences"), u).send({ marketingOptIn: false });
+    expect(off.body.marketingOptIn).toBe(false);
+  });
+
+  it("only accepts a real boolean, so a stray value cannot opt someone in", async () => {
+    const u = await makeUser();
+    await auth(request(app).put("/email/preferences"), u).send({ marketingOptIn: "yes" });
+    expect((await User.findById(u._id)).marketingOptIn).toBe(false);
+  });
+
+  it("needs a login to read or change", async () => {
+    expect((await request(app).get("/email/preferences")).status).toBe(401);
+    expect((await request(app).put("/email/preferences").send({ marketingOptIn: true })).status).toBe(401);
+  });
+});
+
+describe("one-click unsubscribe", () => {
+  it("turns marketing off with only the token, no session", async () => {
+    const u = await makeUser({ marketingOptIn: true });
+
+    const res = await request(app).post(`/email/unsubscribe?u=${u._id}&t=${u.unsubscribeToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.unsubscribed).toBe(true);
+    expect((await User.findById(u._id)).marketingOptIn).toBe(false);
+  });
+
+  it("refuses a wrong token, so the link cannot be guessed", async () => {
+    const u = await makeUser({ marketingOptIn: true });
+
+    const res = await request(app).post(`/email/unsubscribe?u=${u._id}&t=not-the-token`);
+
+    expect(res.status).toBe(404);
+    expect((await User.findById(u._id)).marketingOptIn).toBe(true);
+  });
+
+  it("answers GET too, since some clients prefetch the link", async () => {
+    const u = await makeUser({ marketingOptIn: true });
+    const res = await request(app).get(`/email/unsubscribe?u=${u._id}&t=${u.unsubscribeToken}`);
+    expect(res.body.unsubscribed).toBe(true);
+  });
+});
+
+describe("bounces and complaints", () => {
+  const snsEvent = (message) =>
+    request(app)
+      .post("/email/ses-events")
+      .set("Content-Type", "text/plain")
+      .send(JSON.stringify({ Type: "Notification", Message: JSON.stringify(message) }));
+
+  it("suppresses an address that hard-bounces", async () => {
+    const u = await makeUser();
+
+    await snsEvent({
+      notificationType: "Bounce",
+      bounce: { bounceType: "Permanent", bouncedRecipients: [{ emailAddress: u.email }] },
+    });
+
+    const after = await User.findById(u._id);
+    expect(after.emailSuppressed).toBe(true);
+    expect(after.emailSuppressedReason).toBe("bounce");
+  });
+
+  it("leaves a soft bounce alone", async () => {
+    const u = await makeUser();
+
+    await snsEvent({
+      notificationType: "Bounce",
+      bounce: { bounceType: "Transient", bouncedRecipients: [{ emailAddress: u.email }] },
+    });
+
+    expect((await User.findById(u._id)).emailSuppressed).toBe(false);
+  });
+
+  it("suppresses an address that reports spam", async () => {
+    const u = await makeUser({ marketingOptIn: true });
+
+    await snsEvent({
+      notificationType: "Complaint",
+      complaint: { complainedRecipients: [{ emailAddress: u.email }] },
+    });
+
+    const after = await User.findById(u._id);
+    expect(after.emailSuppressed).toBe(true);
+    expect(after.emailSuppressedReason).toBe("complaint");
+  });
+
+  it("swallows an unparseable payload rather than making SNS retry forever", async () => {
+    const res = await request(app)
+      .post("/email/ses-events")
+      .set("Content-Type", "text/plain")
+      .send("not json at all");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("the mailer refuses to send where it should not", () => {
+  const { sendMail } = require("../../utils/mailer");
+
+  beforeEach(() => {
+    process.env.MAIL_ENABLED = "true";
+  });
+  afterEach(() => {
+    delete process.env.MAIL_ENABLED;
+  });
+
+  it("does nothing at all when email is switched off", async () => {
+    delete process.env.MAIL_ENABLED;
+    const u = await makeUser();
+    expect(await sendMail({ to: u.email, subject: "s", html: "h", text: "t" })).toEqual({
+      skipped: "disabled",
+    });
+  });
+
+  it("refuses marketing to someone who never opted in", async () => {
+    const u = await makeUser();
+    const res = await sendMail({ to: u.email, subject: "s", html: "h", text: "t", kind: "marketing" });
+    expect(res).toEqual({ skipped: "no consent" });
+  });
+
+  it("refuses anything to a suppressed address, service mail included", async () => {
+    const u = await makeUser({ emailSuppressed: true, marketingOptIn: true });
+    expect(await sendMail({ to: u.email, subject: "s", html: "h", text: "t" })).toEqual({
+      skipped: "suppressed",
+    });
+  });
+
+  it("refuses an address that belongs to nobody", async () => {
+    expect(await sendMail({ to: "stranger@example.com", subject: "s", html: "h", text: "t" })).toEqual({
+      skipped: "unknown recipient",
+    });
+  });
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -11,6 +11,7 @@ const missionsRoutes = require("../../routes/missionsRoutes");
 const adminRoutes = require("../../routes/adminRoutes");
 const referralRoutes = require("../../routes/referralRoutes");
 const rewardRoutes = require("../../routes/rewardRoutes");
+const emailRoutes = require("../../routes/emailRoutes");
 const caseRoutes = require("../../routes/caseRoutes");
 const itemRoutes = require("../../routes/itemRoutes");
 
@@ -30,6 +31,7 @@ function makeApp() {
   app.use("/admin", adminRoutes);
   app.use("/referrals", referralRoutes(io));
   app.use("/rewards", rewardRoutes(io));
+  app.use("/email", emailRoutes);
   app.use("/cases", caseRoutes);
   app.use("/items", itemRoutes);
   return app;

--- a/backend/index.js
+++ b/backend/index.js
@@ -88,6 +88,7 @@ const collectionsRoutes = require("./routes/collectionsRoutes");
 const missionsRoutes = require("./routes/missionsRoutes")(io);
 const referralRoutes = require("./routes/referralRoutes")(io);
 const rewardRoutes = require("./routes/rewardRoutes")(io);
+const emailRoutes = require("./routes/emailRoutes");
 
 // Connect to MongoDB
 mongoose
@@ -143,6 +144,7 @@ app.use("/collections", collectionsRoutes);
 app.use("/missions", missionsRoutes);
 app.use("/referrals", referralRoutes);
 app.use("/rewards", rewardRoutes);
+app.use("/email", emailRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -113,6 +113,26 @@ const UserSchema = new mongoose.Schema({
     default: false,
   },
 
+  // marketing consent is opt-in and defaults to off: nobody who signed up before it
+  // existed is treated as having agreed. service mail does not consult it.
+  marketingOptIn: {
+    type: Boolean,
+    default: false,
+  },
+  marketingOptInAt: Date,
+  // secret in the one-click unsubscribe link, so it works without a login
+  unsubscribeToken: {
+    type: String,
+    default: () => uuid.v4(),
+  },
+  // set by the SES bounce/complaint feed; nothing is ever sent to a suppressed address
+  emailSuppressed: {
+    type: Boolean,
+    default: false,
+  },
+  emailSuppressedReason: String,
+  emailSuppressedAt: Date,
+
 });
 
 UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-sesv2": "^3.1095.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "crypto-js": "^4.2.0",
@@ -29,6 +30,279 @@
         "mongodb-memory-server": "^10.4.3",
         "socket.io-client": "^4.8.3",
         "supertest": "^7.2.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sesv2": {
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1095.0.tgz",
+      "integrity": "sha512-fFXKKt/YdIV9ivyhQzMyL8w4PsjnL+MBC4bsvb//Tt3/+I06OX0KMs15zExfOgxC/AVbivU4d1TfPWfLY4j4Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-node": "^3.972.72",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
+      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
+      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
+      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-login": "^3.972.68",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
+      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
+      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.61",
+        "@aws-sdk/credential-provider-http": "^3.972.63",
+        "@aws-sdk/credential-provider-ini": "^3.973.6",
+        "@aws-sdk/credential-provider-process": "^3.972.61",
+        "@aws-sdk/credential-provider-sso": "^3.973.5",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
+      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
+      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
+      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
+      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1095.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
+      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1043,6 +1317,87 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
+      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
+      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
+      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -1629,6 +1984,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -5916,7 +6277,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-detect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-sesv2": "^3.1095.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "crypto-js": "^4.2.0",

--- a/backend/routes/emailRoutes.js
+++ b/backend/routes/emailRoutes.js
@@ -1,0 +1,78 @@
+const express = require("express");
+const https = require("https");
+const User = require("../models/User");
+const { isAuthenticated } = require("../middleware/authMiddleware");
+
+const router = express.Router();
+
+// Gmail's one-click unsubscribe POSTs here with no session, so the token in the link
+// is the only credential. it only ever turns marketing off.
+async function optOut(userId, token) {
+  if (!userId || !token) return false;
+  const res = await User.updateOne(
+    { _id: userId, unsubscribeToken: String(token) },
+    { $set: { marketingOptIn: false } }
+  );
+  return res.matchedCount > 0;
+}
+
+router.post("/unsubscribe", async (req, res) => {
+  const ok = await optOut(req.query.u || req.body.u, req.query.t || req.body.t);
+  res.status(ok ? 200 : 404).json({ unsubscribed: ok });
+});
+
+router.get("/unsubscribe", async (req, res) => {
+  const ok = await optOut(req.query.u, req.query.t);
+  res.status(ok ? 200 : 404).json({ unsubscribed: ok });
+});
+
+router.get("/preferences", isAuthenticated, async (req, res) => {
+  const user = await User.findById(req.user._id).select("marketingOptIn emailSuppressed");
+  if (!user) return res.status(404).json({ message: "User not found" });
+  res.json({ marketingOptIn: !!user.marketingOptIn, emailSuppressed: !!user.emailSuppressed });
+});
+
+router.put("/preferences", isAuthenticated, async (req, res) => {
+  const optIn = req.body.marketingOptIn === true;
+  await User.updateOne(
+    { _id: req.user._id },
+    { $set: { marketingOptIn: optIn, marketingOptInAt: optIn ? new Date() : null } }
+  );
+  res.json({ marketingOptIn: optIn });
+});
+
+// SES publishes delivery events here through SNS. a hard bounce or a complaint
+// suppresses the address permanently: continuing to mail either one is what destroys
+// a sending domain's reputation.
+router.post("/ses-events", express.text({ type: "*/*" }), async (req, res) => {
+  try {
+    const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+
+    if (body.Type === "SubscriptionConfirmation" && body.SubscribeURL) {
+      https.get(body.SubscribeURL, () => {}).on("error", () => {});
+      return res.json({ confirmed: true });
+    }
+
+    const message = typeof body.Message === "string" ? JSON.parse(body.Message) : body.Message || {};
+    const suppress = async (addresses, reason) => {
+      if (!addresses || !addresses.length) return;
+      await User.updateMany(
+        { email: { $in: addresses } },
+        { $set: { emailSuppressed: true, emailSuppressedReason: reason, emailSuppressedAt: new Date() } }
+      );
+    };
+
+    if (message.notificationType === "Bounce" && message.bounce?.bounceType === "Permanent") {
+      await suppress((message.bounce.bouncedRecipients || []).map((r) => r.emailAddress), "bounce");
+    } else if (message.notificationType === "Complaint") {
+      await suppress((message.complaint.complainedRecipients || []).map((r) => r.emailAddress), "complaint");
+    }
+
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("ses-events:", err.message);
+    res.json({ ok: true }); // never make SNS retry a message we cannot parse
+  }
+});
+
+module.exports = router;

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -1,0 +1,62 @@
+const { SESv2Client, SendEmailCommand } = require("@aws-sdk/client-sesv2");
+const User = require("../models/User");
+
+const FROM = process.env.MAIL_FROM || "KaniCasino <no-reply@kanicasino.com>";
+const SITE = process.env.SITE_URL || "https://kanicasino.com";
+const REGION = process.env.AWS_REGION || "sa-east-1";
+
+// unset means email is off, so a misconfigured box stays silent instead of throwing
+const enabled = () => process.env.MAIL_ENABLED === "true";
+
+let client = null;
+const ses = () => (client = client || new SESv2Client({ region: REGION }));
+
+const unsubscribeUrl = (user) => `${SITE}/unsubscribe?u=${user._id}&t=${user.unsubscribeToken}`;
+
+// "service" is account mail nobody opts out of (password resets, policy notices);
+// "marketing" needs consent and is refused without it.
+async function sendMail({ to, subject, html, text, kind = "service" }) {
+  if (!enabled()) return { skipped: "disabled" };
+
+  const user = await User.findOne({ email: to }).select(
+    "email marketingOptIn emailSuppressed unsubscribeToken"
+  );
+  if (!user) return { skipped: "unknown recipient" };
+  if (user.emailSuppressed) return { skipped: "suppressed" };
+  if (kind === "marketing" && !user.marketingOptIn) return { skipped: "no consent" };
+
+  const unsub = unsubscribeUrl(user);
+  const headers = [
+    { Name: "List-Unsubscribe", Value: `<${unsub}>` },
+    { Name: "List-Unsubscribe-Post", Value: "List-Unsubscribe=One-Click" },
+  ];
+
+  await ses().send(
+    new SendEmailCommand({
+      FromEmailAddress: FROM,
+      Destination: { ToAddresses: [to] },
+      Content: {
+        Simple: {
+          Subject: { Data: subject, Charset: "UTF-8" },
+          Body: {
+            Html: { Data: withFooter(html, unsub, kind), Charset: "UTF-8" },
+            Text: { Data: `${text}\n\nUnsubscribe: ${unsub}`, Charset: "UTF-8" },
+          },
+          Headers: headers,
+        },
+      },
+    })
+  );
+  return { sent: true };
+}
+
+function withFooter(html, unsub, kind) {
+  const line =
+    kind === "marketing"
+      ? `You are getting this because you opted in to updates from KaniCasino. <a href="${unsub}">Unsubscribe</a>.`
+      : `This is a service message about your KaniCasino account. <a href="${unsub}">Manage email preferences</a>.`;
+  return `${html}<hr style="border:none;border-top:1px solid #2A2840;margin:24px 0" />
+<p style="font:12px sans-serif;color:#84819a">${line}</p>`;
+}
+
+module.exports = { sendMail, unsubscribeUrl, enabled };

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -13,6 +13,7 @@ import Dice from "./pages/Dice";
 import Mines from "./pages/Mines";
 import Hilo from "./pages/Hilo";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
+import Unsubscribe from "./pages/About/Unsubscribe"
 import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
 import BattleRoom from "./pages/Battles/BattleRoom";
@@ -42,6 +43,7 @@ const defaultRoutes = (
     <Route path="/r/:code" element={<ReferralRedirect />} />
     <Route path="/backoffice" element={<Backoffice />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+    <Route path="/unsubscribe" element={<Unsubscribe />} />
   </>
 );
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -144,7 +144,7 @@ function Footer() {
       <div className="w-full mt-4 flex flex-col items-center justify-center gap-3">
         <div className="w-full h-[1px] bg-gray-500 opacity-10" />
         <span className="text-sm text-center">
-          KaniCasino Comercio De Jogos E Skins Ltda - CNPJ: 40.981.116/0001-73 © All Rights Reserved. {new Date().getFullYear()}
+          KaniCasino © All Rights Reserved. {new Date().getFullYear()}
         </span>
       </div>
 

--- a/src/components/modalsChilden/TermsOfPrivacy.tsx
+++ b/src/components/modalsChilden/TermsOfPrivacy.tsx
@@ -1,45 +1,181 @@
-const PrivacyPolicySection = ({ title, content }: { title: string, content: string | JSX.Element[] }) => (
-    <div className="mb-2">
-        <span className="font-bold text-base">{title}:</span>
-        <span className="ml-2 text-justify">{content}</span>
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div className="mb-4">
+        <span className="font-bold text-base block mb-1">{title}</span>
+        <div className="text-justify flex flex-col gap-2">{children}</div>
+    </div>
+);
+
+const Row = ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+        <span className="font-semibold">{label}: </span>
+        <span>{children}</span>
     </div>
 );
 
 const TermsOfPrivacy = () => {
     return (
-        <div className="flex flex-col text-sm ">
-            <span className="font-bold text-lg mb-4">Privacy Policy for KaniCasino</span>
-            <span className="mb-2 italic">Last Updated: 04/02/2024</span>
-            <span className="mb-2">
-                Welcome to KaniCasino! This Privacy Policy outlines how we collect, use, and protect your personal information when you use our open-source online casino at <span className="text-blue-500">kanicasino.com</span>.
+        <div className="flex flex-col text-sm">
+            <span className="font-bold text-lg mb-1">Privacy Policy</span>
+            <span className="mb-1 italic">Last updated: 26 July 2026</span>
+            <span className="mb-4 text-ink-muted">
+                KaniCasino Comercio De Jogos E Skins Ltda, CNPJ 40.981.116/0001-73 ("KaniCasino",
+                "we"), is the controller of the personal data described below. This policy explains
+                what we collect when you use <span className="text-blue-500">kanicasino.com</span>,
+                why, and the rights you have over it. It is written to meet the Brazilian General
+                Data Protection Law (LGPD, Law 13.709/2018).
             </span>
 
-            {[
-                {
-                    title: '1. Information We Collect', content: [
-                        { title: '1.1 Personal Information', content: 'We do not collect any personally identifiable information, such as names, addresses, or contact details, as KaniCasino does not involve real money transactions.' },
-                        { title: '1.2 Gameplay Data', content: 'We may collect and store data related to your gameplay, including game statistics, in-game actions, and other relevant information to enhance your gaming experience and improve our services.' },
-                    ]
-                },
-                {
-                    title: '2. Use of Information', content: [
-                        { title: '2.1 Gameplay Optimization', content: 'We use the collected gameplay data to optimize the user experience, provide better game features, and troubleshoot any issues that may arise during gameplay.' },
-                        { title: '2.2 Communication', content: 'We may use your contact information if provided (e.g., email address) to communicate important updates, notifications, or respond to inquiries related to KaniCasino.' },
-                    ]
-                },
-                { title: '3. Data Security', content: 'We take reasonable measures to safeguard the information we collect to prevent unauthorized access, disclosure, alteration, or destruction of your data.' },
-                { title: '4. Third-Party Services', content: 'KaniCasino may utilize third-party services for analytics, hosting, or other purposes. These services have their own privacy policies, and we encourage you to review them.' },
-                { title: '5. Changes to Privacy Policy', content: 'This Privacy Policy may be updated from time to time. Any changes will be reflected on this page, and it is your responsibility to review this policy periodically.' },
-                { title: '6. Contact Us', content: 'If you have any questions or concerns about this Privacy Policy, please contact us at novadrake76@gmail.com' },
-            ].map((section, index) => (
-                <PrivacyPolicySection key={index} title={section.title} content={Array.isArray(section.content) ? section.content.map((item, i) => (<PrivacyPolicySection key={i} title={item.title} content={item.content} />)) : section.content} />
-            ))}
+            <Section title="1. What KaniCasino is">
+                <span>
+                    KaniCasino is a free, open-source game using a fictional currency called K₽.
+                    There is no deposit, no withdrawal, and no way to convert K₽ into money or
+                    anything of real value. We never ask for payment details and we do not process
+                    payments.
+                </span>
+            </Section>
 
-            <span className="mt-4">
-                By using KaniCasino, you agree to the terms outlined in this Privacy Policy.
-            </span>
+            <Section title="2. Data we collect">
+                <Row label="2.1 Account data">
+                    Your email address, a username, and a profile picture. If you sign in with
+                    Google we receive your email address, name and profile picture from Google, and
+                    store a Google account identifier. If you register directly we store a hashed
+                    password, never the password itself.
+                </Row>
+                <Row label="2.2 Gameplay data">
+                    Your K₽ balance, inventory, level and experience, game results, provably-fair
+                    roll records, marketplace listings and trades, missions, referrals, and a
+                    ledger of every K₽ movement on your account.
+                </Row>
+                <Row label="2.3 Technical data">
+                    Server logs and connection data, including IP address, needed to operate the
+                    site and prevent abuse. Analytics and advertising providers set cookies and
+                    similar identifiers in your browser (see section 5).
+                </Row>
+                <Row label="2.4 Communications">
+                    Messages you send us, and whether our emails to you were delivered, bounced or
+                    reported as spam.
+                </Row>
+            </Section>
+
+            <Section title="3. Why we use it, and our legal basis">
+                <Row label="3.1 To run the service">
+                    Creating and securing your account, saving your progress, running the games and
+                    the marketplace, and keeping the provably-fair records that let you verify any
+                    result. Legal basis: performance of a contract with you (LGPD Art. 7, V).
+                </Row>
+                <Row label="3.2 To keep the game fair and secure">
+                    Detecting abuse, cheating and duplicate accounts, and investigating problems.
+                    Legal basis: our legitimate interest in a working, fair service (Art. 7, IX).
+                </Row>
+                <Row label="3.3 Service messages">
+                    Account and security notices, and changes to this policy. These are part of
+                    running your account and are not marketing, so they are not optional while your
+                    account exists.
+                </Row>
+                <Row label="3.4 Optional updates about the game">
+                    News about new cases, games and features. We send these only if you switch them
+                    on in your profile settings. Legal basis: your consent (Art. 7, I), which you
+                    can withdraw at any time.
+                </Row>
+            </Section>
+
+            <Section title="4. Marketing email and how to stop it">
+                <span>
+                    Optional updates are off by default and stay off unless you turn them on. Every
+                    such email carries a one-click unsubscribe link and honours the unsubscribe
+                    header your mail provider uses. You can also switch them off at any time in your
+                    profile settings. Withdrawing consent does not affect service messages, and it
+                    never affects your account or your ability to play.
+                </span>
+            </Section>
+
+            <Section title="5. Who else processes your data">
+                <span>
+                    We use the following providers, each acting on our behalf or as an independent
+                    controller under their own policies:
+                </span>
+                <ul className="list-disc ml-5 flex flex-col gap-1">
+                    <li>Amazon Web Services (hosting, file storage and outbound email), United States and Brazil</li>
+                    <li>MongoDB Atlas (database hosting)</li>
+                    <li>Cloudflare (content delivery and protection)</li>
+                    <li>Google Analytics (usage measurement) and Google AdSense (advertising)</li>
+                    <li>Google Sign-In, if you choose to use it</li>
+                </ul>
+                <span>
+                    We do not sell your personal data and we do not share it for anyone else's
+                    independent marketing.
+                </span>
+            </Section>
+
+            <Section title="6. International transfers">
+                <span>
+                    Some of these providers store or process data outside Brazil, mainly in the
+                    United States. Where that happens we rely on the transfer safeguards those
+                    providers offer under LGPD Art. 33.
+                </span>
+            </Section>
+
+            <Section title="7. How long we keep it">
+                <Row label="Account data">
+                    For as long as your account exists. If you delete your account we remove or
+                    anonymise your personal data.
+                </Row>
+                <Row label="Gameplay and ledger records">
+                    Kept while the account exists so balances and provably-fair verification stay
+                    meaningful. Some game round records are deleted automatically after a short
+                    period.
+                </Row>
+                <Row label="Suppressed email addresses">
+                    If your address hard-bounces or you report our mail as spam, we keep a record of
+                    that so we never email you again.
+                </Row>
+            </Section>
+
+            <Section title="8. Your rights">
+                <span>
+                    Under LGPD Art. 18 you can ask us to confirm whether we process your data,
+                    access it, correct it, anonymise or delete it, receive it in a portable form,
+                    know who we have shared it with, and withdraw consent. To exercise any of these,
+                    email <span className="text-blue-500">privacy@kanicasino.com</span>. We answer
+                    within 15 days. You may also complain to the ANPD, Brazil's data protection
+                    authority.
+                </span>
+            </Section>
+
+            <Section title="9. Security">
+                <span>
+                    Passwords are stored hashed. Traffic is encrypted in transit. Access to the
+                    production database is restricted. No system is perfectly secure, so we cannot
+                    promise absolute safety, but if a breach puts your rights at material risk we
+                    will notify you and the ANPD as the law requires.
+                </span>
+            </Section>
+
+            <Section title="10. Age">
+                <span>
+                    KaniCasino is not intended for children. You must be old enough to use
+                    gambling-styled games where you live, and at least 18. We do not knowingly
+                    collect data from children; if we learn that we have, we delete it.
+                </span>
+            </Section>
+
+            <Section title="11. Changes">
+                <span>
+                    We may update this policy. If a change materially affects your rights we will
+                    tell you by email or in the site before it takes effect, and the date at the top
+                    always shows the current version.
+                </span>
+            </Section>
+
+            <Section title="12. Contact">
+                <span>
+                    Privacy questions and rights requests:{" "}
+                    <span className="text-blue-500">privacy@kanicasino.com</span>. Anything else:{" "}
+                    <span className="text-blue-500">contact@kanicasino.com</span>.
+                </span>
+            </Section>
         </div>
     );
-}
+};
 
 export default TermsOfPrivacy;

--- a/src/components/modalsChilden/TermsOfPrivacy.tsx
+++ b/src/components/modalsChilden/TermsOfPrivacy.tsx
@@ -18,11 +18,14 @@ const TermsOfPrivacy = () => {
             <span className="font-bold text-lg mb-1">Privacy Policy</span>
             <span className="mb-1 italic">Last updated: 26 July 2026</span>
             <span className="mb-4 text-ink-muted">
-                KaniCasino Comercio De Jogos E Skins Ltda, CNPJ 40.981.116/0001-73 ("KaniCasino",
-                "we"), is the controller of the personal data described below. This policy explains
-                what we collect when you use <span className="text-blue-500">kanicasino.com</span>,
-                why, and the rights you have over it. It is written to meet the Brazilian General
-                Data Protection Law (LGPD, Law 13.709/2018).
+                KaniCasino ("we") is an independent project run from Brazil, and is the controller
+                of the personal data described below. This policy explains what we
+                collect when you use <span className="text-blue-500">kanicasino.com</span>, why, and
+                the rights you have over it. It is written to meet the Brazilian General Data
+                Protection Law (LGPD, Law 13.709/2018). For anything in this policy, including the
+                rights in section 8, write to{" "}
+                <span className="text-blue-500">privacy@kanicasino.com</span> and a person will
+                answer you.
             </span>
 
             <Section title="1. What KaniCasino is">

--- a/src/pages/About/PrivacyPolicy.tsx
+++ b/src/pages/About/PrivacyPolicy.tsx
@@ -1,48 +1,13 @@
-const PrivacyPolicySection = ({ title, content }: { title: string, content: string | JSX.Element[] }) => (
-    <div className="mb-2">
-        <span className="font-bold text-base">{title}:</span>
-        <span className="ml-2 text-justify">{content}</span>
+import TermsOfPrivacy from "../../components/modalsChilden/TermsOfPrivacy";
+
+// the routed page and the footer modal render the same document, so the two cannot
+// drift apart again
+const PrivacyPolicy = () => (
+    <div className="flex items-start justify-center w-full px-4 py-8">
+        <div className="max-w-3xl w-full">
+            <TermsOfPrivacy />
+        </div>
     </div>
 );
-
-
-const PrivacyPolicy = () => {
-    return (
-       <div className='flex items-center justify-center w-full'>
-         <div className="flex flex-col text-sm ">
-        <span className="font-bold text-lg mb-4">Privacy Policy for KaniCasino</span>
-        <span className="mb-2 italic">Last Updated: 04/02/2024</span>
-        <span className="mb-2">
-            Welcome to KaniCasino! This Privacy Policy outlines how we collect, use, and protect your personal information when you use our open-source online casino at <span className="text-blue-500">kanicasino.com</span>.
-        </span>
-
-        {[
-            {
-                title: '1. Information We Collect', content: [
-                    { title: '1.1 Personal Information', content: 'We do not collect any personally identifiable information, such as names, addresses, or contact details, as KaniCasino does not involve real money transactions.' },
-                    { title: '1.2 Gameplay Data', content: 'We may collect and store data related to your gameplay, including game statistics, in-game actions, and other relevant information to enhance your gaming experience and improve our services.' },
-                ]
-            },
-            {
-                title: '2. Use of Information', content: [
-                    { title: '2.1 Gameplay Optimization', content: 'We use the collected gameplay data to optimize the user experience, provide better game features, and troubleshoot any issues that may arise during gameplay.' },
-                    { title: '2.2 Communication', content: 'We may use your contact information if provided (e.g., email address) to communicate important updates, notifications, or respond to inquiries related to KaniCasino.' },
-                ]
-            },
-            { title: '3. Data Security', content: 'We take reasonable measures to safeguard the information we collect to prevent unauthorized access, disclosure, alteration, or destruction of your data.' },
-            { title: '4. Third-Party Services', content: 'KaniCasino may utilize third-party services for analytics, hosting, or other purposes. These services have their own privacy policies, and we encourage you to review them.' },
-            { title: '5. Changes to Privacy Policy', content: 'This Privacy Policy may be updated from time to time. Any changes will be reflected on this page, and it is your responsibility to review this policy periodically.' },
-            { title: '6. Contact Us', content: 'If you have any questions or concerns about this Privacy Policy, please contact us at novadrake76@gmail.com' },
-        ].map((section, index) => (
-            <PrivacyPolicySection key={index} title={section.title} content={Array.isArray(section.content) ? section.content.map((item, i) => (<PrivacyPolicySection key={i} title={item.title} content={item.content} />)) : section.content} />
-        ))}
-
-        <span className="mt-4">
-            By using KaniCasino, you agree to the terms outlined in this Privacy Policy.
-        </span>
-    </div>
-       </div>
-    );
-};
 
 export default PrivacyPolicy;

--- a/src/pages/About/Unsubscribe.tsx
+++ b/src/pages/About/Unsubscribe.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { unsubscribeByToken } from "../../services/email/EmailService";
+
+type State = "working" | "done" | "failed";
+
+const Unsubscribe = () => {
+    const [params] = useSearchParams();
+    const [state, setState] = useState<State>("working");
+
+    useEffect(() => {
+        const u = params.get("u");
+        const t = params.get("t");
+        if (!u || !t) return setState("failed");
+        unsubscribeByToken(u, t)
+            .then(() => setState("done"))
+            .catch(() => setState("failed"));
+    }, [params]);
+
+    return (
+        <div className="w-full flex items-center justify-center px-4 py-16">
+            <div className="max-w-md w-full flex flex-col items-center gap-3 text-center bg-surface border border-line rounded-lg p-8">
+                {state === "working" && <span className="text-ink-soft">Updating your preferences...</span>}
+                {state === "done" && (
+                    <>
+                        <span className="text-xl font-bold">You are unsubscribed</span>
+                        <span className="text-sm text-ink-soft">
+                            We will not send you any more updates about new cases and games. You will
+                            still get service messages about your account, like security and policy
+                            notices.
+                        </span>
+                        <span className="text-sm text-ink-muted">
+                            Changed your mind? You can turn updates back on in your profile settings.
+                        </span>
+                    </>
+                )}
+                {state === "failed" && (
+                    <>
+                        <span className="text-xl font-bold">That link did not work</span>
+                        <span className="text-sm text-ink-soft">
+                            It may have already been used. You can always manage email in your profile
+                            settings.
+                        </span>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default Unsubscribe;

--- a/src/pages/Profile/EmailSettings.tsx
+++ b/src/pages/Profile/EmailSettings.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { getEmailPreferences, setMarketingOptIn } from "../../services/email/EmailService";
+
+const EmailSettings = () => {
+    const [optIn, setOptIn] = useState(false);
+    const [suppressed, setSuppressed] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        getEmailPreferences()
+            .then((p) => {
+                setOptIn(p.marketingOptIn);
+                setSuppressed(p.emailSuppressed);
+            })
+            .catch(() => undefined)
+            .finally(() => setLoading(false));
+    }, []);
+
+    const toggle = async () => {
+        const next = !optIn;
+        setSaving(true);
+        setOptIn(next);
+        try {
+            await setMarketingOptIn(next);
+            toast.success(next ? "You will get updates about new cases and games" : "Updates turned off", {
+                theme: "dark",
+            });
+        } catch {
+            setOptIn(!next);
+            toast.error("Could not save that, try again", { theme: "dark" });
+        }
+        setSaving(false);
+    };
+
+    if (loading) return <span className="text-ink-muted text-sm">Loading...</span>;
+
+    return (
+        <div className="w-full max-w-2xl flex flex-col gap-4">
+            <span className="text-lg font-bold">Email</span>
+
+            <div className="flex items-start justify-between gap-4 bg-surface border border-line rounded-lg p-4">
+                <div className="flex flex-col gap-1">
+                    <span className="font-semibold">Updates about new cases and games</span>
+                    <span className="text-sm text-ink-muted">
+                        Occasional email when something new ships. Off unless you turn it on, and you
+                        can stop it any time.
+                    </span>
+                </div>
+                <button
+                    role="switch"
+                    aria-checked={optIn}
+                    aria-label="Updates about new cases and games"
+                    onClick={toggle}
+                    disabled={saving}
+                    className={`relative w-12 h-6 shrink-0 rounded-full border border-line transition-colors disabled:opacity-50 ${
+                        optIn ? "bg-accent" : "bg-surface-nav"
+                    }`}
+                >
+                    <span
+                        className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                            optIn ? "translate-x-6" : ""
+                        }`}
+                    />
+                </button>
+            </div>
+
+            <p className="text-sm text-ink-muted">
+                Service messages about your account, such as security and policy notices, are sent
+                whatever this is set to.
+            </p>
+
+            {suppressed && (
+                <p className="text-sm text-red-400">
+                    We are not sending to your address because a previous email bounced or was
+                    reported as spam. Contact us if you think that is wrong.
+                </p>
+            )}
+        </div>
+    );
+};
+
+export default EmailSettings;

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -15,6 +15,7 @@ import MissionsPanel from "../Missions/MissionsPanel";
 import AffiliatesPanel from "../Affiliates/AffiliatesPanel";
 import { resolveTab, Tab } from "./tabs";
 import ItemCopiesModal from "./ItemCopiesModal";
+import EmailSettings from "./EmailSettings";
 import { User } from '../../components/Types'
 
 interface Inventory {
@@ -152,6 +153,7 @@ const Profile = () => {
           { key: "missions" as const, label: "Missions" },
           { key: "affiliates" as const, label: "Affiliates" },
           { key: "history" as const, label: "Balance history" },
+          { key: "settings" as const, label: "Settings" },
         ]
       : []),
   ];
@@ -230,6 +232,8 @@ const Profile = () => {
             <MissionsPanel userId={id as string} isOwner={isSameUser} />
           ) : activeTab === "affiliates" ? (
             <AffiliatesPanel isOwner={isSameUser} />
+          ) : activeTab === "settings" ? (
+            <EmailSettings />
           ) : activeTab === "collections" ? (
             <CollectionsPanel userId={id as string} isOwner={isSameUser} />
           ) : (

--- a/src/pages/Profile/tabs.ts
+++ b/src/pages/Profile/tabs.ts
@@ -1,4 +1,4 @@
-export type Tab = "inventory" | "collections" | "history" | "missions" | "affiliates";
+export type Tab = "inventory" | "collections" | "history" | "missions" | "affiliates" | "settings";
 
 // the url is the source of truth for the tab. owner-only tabs collapse to inventory
 // whenever isOwner is false, which covers both "not the owner" and "ownership not
@@ -6,6 +6,6 @@ export type Tab = "inventory" | "collections" | "history" | "missions" | "affili
 export const resolveTab = (param: string | null, isOwner: boolean): Tab =>
   param === "collections"
     ? "collections"
-    : (param === "missions" || param === "history" || param === "affiliates") && isOwner
+    : (param === "missions" || param === "history" || param === "affiliates" || param === "settings") && isOwner
     ? param
     : "inventory";

--- a/src/services/email/EmailService.ts
+++ b/src/services/email/EmailService.ts
@@ -1,0 +1,16 @@
+import api from "../api";
+
+export interface EmailPreferences {
+  marketingOptIn: boolean;
+  emailSuppressed: boolean;
+}
+
+export const getEmailPreferences = async (): Promise<EmailPreferences> =>
+  (await api.get("/email/preferences")).data;
+
+export const setMarketingOptIn = async (marketingOptIn: boolean): Promise<EmailPreferences> =>
+  (await api.put("/email/preferences", { marketingOptIn })).data;
+
+// the unsubscribe link carries its own credential, so this works logged out
+export const unsubscribeByToken = async (u: string, t: string) =>
+  (await api.post(`/email/unsubscribe?u=${encodeURIComponent(u)}&t=${encodeURIComponent(t)}`)).data;


### PR DESCRIPTION
## Problem

The privacy policy said "we do not collect any personally identifiable information, such as names, addresses, or contact details". The site stores email addresses, usernames, profile pictures and Google account data. It also existed twice, as a footer modal and a routed page, with the same wrong claim in both.

There was also no way to email users. No consent field, no unsubscribe, no bounce handling.

## Change

Privacy policy rewritten as an LGPD-aware document: what is collected, why, legal basis, named processors, international transfers, retention, Art. 18 rights, contact and response time. The routed page now renders the same component as the modal.

Backend: `utils/mailer.js` sends through SES and refuses at the send boundary, so consent is not something a caller can forget. Marketing needs an explicit opt-in, service mail does not, and a suppressed address gets nothing either way. Nothing sends unless `MAIL_ENABLED` is set.

`routes/emailRoutes.js`: one-click unsubscribe by token with no session, authed preferences read/write, and an SNS endpoint that suppresses on hard bounce or complaint.

Frontend: Settings tab on the profile with the opt-in toggle, and an `/unsubscribe` page for the link in the footer.

## Tests

15 new integration tests covering consent defaults, the toggle, token unsubscribe including a wrong token, hard vs soft bounce, complaints, and each mailer refusal. Backend 505 passing, frontend 93 unit and 7 e2e, lint and build clean.