### PR TITLE
Make the email path actually work end to end

### DIFF
--- a/backend/__tests__/integration/emailDelivery.test.js
+++ b/backend/__tests__/integration/emailDelivery.test.js
@@ -1,0 +1,103 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+process.env.API_URL = "https://api.example.com";
+process.env.SITE_URL = "https://site.example.com";
+
+const mockSent = [];
+jest.mock("@aws-sdk/client-sesv2", () => ({
+  SESv2Client: class {
+    async send(cmd) {
+      mockSent.push(cmd.input);
+      return {};
+    }
+  },
+  SendEmailCommand: class {
+    constructor(input) {
+      this.input = input;
+    }
+  },
+}));
+
+const fs = require("fs");
+const path = require("path");
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const { sendMail } = require("../../utils/mailer");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+beforeEach(() => {
+  mockSent.length = 0;
+  process.env.MAIL_ENABLED = "true";
+});
+afterEach(async () => {
+  delete process.env.MAIL_ENABLED;
+  await clearDb();
+});
+afterAll(teardownDb);
+
+const makeUser = () => {
+  const s = uniqueSuffix();
+  return User.create({ username: `user-${s}`, email: `user-${s}@example.com`, password: "x" });
+};
+
+const headerValue = (name) => mockSent[0].Content.Simple.Headers.find((h) => h.Name === name)?.Value;
+
+describe("one-click unsubscribe", () => {
+  it("points the header at the api, not at the page, since the provider POSTs it itself", async () => {
+    const u = await makeUser();
+    await sendMail({ to: u.email, subject: "s", html: "h", text: "t" });
+
+    const url = headerValue("List-Unsubscribe").replace(/^<|>$/g, "");
+
+    expect(url.startsWith("https://api.example.com/email/unsubscribe")).toBe(true);
+    expect(url.startsWith("https://site.example.com")).toBe(false);
+    expect(headerValue("List-Unsubscribe-Post")).toBe("List-Unsubscribe=One-Click");
+  });
+
+  it("actually opts the user out when that exact url is POSTed back", async () => {
+    const u = await makeUser();
+    await User.updateOne({ _id: u._id }, { $set: { marketingOptIn: true } });
+    await sendMail({ to: u.email, subject: "s", html: "h", text: "t" });
+
+    const url = new URL(headerValue("List-Unsubscribe").replace(/^<|>$/g, ""));
+    const res = await request(app).post(url.pathname + url.search);
+
+    expect(res.status).toBe(200);
+    expect((await User.findById(u._id)).marketingOptIn).toBe(false);
+  });
+
+  it("still sends a human to the page, which is nicer than a json body", async () => {
+    const u = await makeUser();
+    await sendMail({ to: u.email, subject: "s", html: "h", text: "t" });
+
+    expect(mockSent[0].Content.Simple.Body.Html.Data).toContain("https://site.example.com/unsubscribe");
+  });
+});
+
+// the two machine-facing endpoints get no api key: SNS does not send one, and neither
+// does a mail provider POSTing the unsubscribe header.
+describe("route order in index.js", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../../index.js"), "utf8");
+
+  it("mounts /email above the api-key gate", () => {
+    const mount = source.indexOf('app.use("/email"');
+    const gate = source.indexOf("app.use(checkApiKey)");
+    expect(mount).toBeGreaterThan(-1);
+    expect(gate).toBeGreaterThan(-1);
+    expect(mount).toBeLessThan(gate);
+  });
+
+  it("still mounts the money routes below it", () => {
+    const gate = source.indexOf("app.use(checkApiKey)");
+    for (const route of ['app.use("/games"', 'app.use("/marketplace"', 'app.use("/users"']) {
+      expect(source.indexOf(route)).toBeGreaterThan(gate);
+    }
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -127,6 +127,10 @@ app.post("/internal/notice", (req, res) => {
   res.json({ ok: true });
 });
 
+// SNS and mail clients hitting the one-click unsubscribe carry no api key, so this
+// mounts above the gate. everything inside that touches a session still needs a JWT.
+app.use("/email", emailRoutes);
+
 // block requests from outside
 app.use(checkApiKey);
 
@@ -144,7 +148,6 @@ app.use("/collections", collectionsRoutes);
 app.use("/missions", missionsRoutes);
 app.use("/referrals", referralRoutes);
 app.use("/rewards", rewardRoutes);
-app.use("/email", emailRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -3,6 +3,7 @@ const User = require("../models/User");
 
 const FROM = process.env.MAIL_FROM || "KaniCasino <no-reply@kanicasino.com>";
 const SITE = process.env.SITE_URL || "https://kanicasino.com";
+const API = process.env.API_URL || "https://kanicasino.cfhxo.com";
 const REGION = process.env.AWS_REGION || "sa-east-1";
 
 // unset means email is off, so a misconfigured box stays silent instead of throwing
@@ -12,6 +13,10 @@ let client = null;
 const ses = () => (client = client || new SESv2Client({ region: REGION }));
 
 const unsubscribeUrl = (user) => `${SITE}/unsubscribe?u=${user._id}&t=${user.unsubscribeToken}`;
+
+// the header URL is POSTed by the mail provider itself, so it has to be the api and not
+// the SPA, which would answer 200 with a page nobody runs and drop the opt-out.
+const oneClickUrl = (user) => `${API}/email/unsubscribe?u=${user._id}&t=${user.unsubscribeToken}`;
 
 // "service" is account mail nobody opts out of (password resets, policy notices);
 // "marketing" needs consent and is refused without it.
@@ -27,7 +32,7 @@ async function sendMail({ to, subject, html, text, kind = "service" }) {
 
   const unsub = unsubscribeUrl(user);
   const headers = [
-    { Name: "List-Unsubscribe", Value: `<${unsub}>` },
+    { Name: "List-Unsubscribe", Value: `<${oneClickUrl(user)}>` },
     { Name: "List-Unsubscribe-Post", Value: "List-Unsubscribe=One-Click" },
   ];
 
@@ -59,4 +64,4 @@ function withFooter(html, unsub, kind) {
 <p style="font:12px sans-serif;color:#84819a">${line}</p>`;
 }
 
-module.exports = { sendMail, unsubscribeUrl, enabled };
+module.exports = { sendMail, unsubscribeUrl, oneClickUrl, enabled };

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -2,6 +2,8 @@ const { SESv2Client, SendEmailCommand } = require("@aws-sdk/client-sesv2");
 const User = require("../models/User");
 
 const FROM = process.env.MAIL_FROM || "KaniCasino <no-reply@kanicasino.com>";
+// the from address can send but cannot receive, so replies need somewhere real to go
+const REPLY_TO = process.env.MAIL_REPLY_TO;
 const SITE = process.env.SITE_URL || "https://kanicasino.com";
 const API = process.env.API_URL || "https://kanicasino.cfhxo.com";
 const REGION = process.env.AWS_REGION || "sa-east-1";
@@ -40,6 +42,7 @@ async function sendMail({ to, subject, html, text, kind = "service" }) {
     new SendEmailCommand({
       FromEmailAddress: FROM,
       Destination: { ToAddresses: [to] },
+      ...(REPLY_TO ? { ReplyToAddresses: [REPLY_TO] } : {}),
       Content: {
         Simple: {
           Subject: { Data: subject, Charset: "UTF-8" },

--- a/src/components/modalsChilden/TermsOfPrivacy.tsx
+++ b/src/components/modalsChilden/TermsOfPrivacy.tsx
@@ -24,7 +24,7 @@ const TermsOfPrivacy = () => {
                 the rights you have over it. It is written to meet the Brazilian General Data
                 Protection Law (LGPD, Law 13.709/2018). For anything in this policy, including the
                 rights in section 8, write to{" "}
-                <span className="text-blue-500">privacy@kanicasino.com</span> and a person will
+                <span className="text-blue-500">novadrake77@gmail.com</span> and a person will
                 answer you.
             </span>
 
@@ -139,7 +139,7 @@ const TermsOfPrivacy = () => {
                     Under LGPD Art. 18 you can ask us to confirm whether we process your data,
                     access it, correct it, anonymise or delete it, receive it in a portable form,
                     know who we have shared it with, and withdraw consent. To exercise any of these,
-                    email <span className="text-blue-500">privacy@kanicasino.com</span>. We answer
+                    email <span className="text-blue-500">novadrake77@gmail.com</span>. We answer
                     within 15 days. You may also complain to the ANPD, Brazil's data protection
                     authority.
                 </span>
@@ -172,9 +172,8 @@ const TermsOfPrivacy = () => {
 
             <Section title="12. Contact">
                 <span>
-                    Privacy questions and rights requests:{" "}
-                    <span className="text-blue-500">privacy@kanicasino.com</span>. Anything else:{" "}
-                    <span className="text-blue-500">contact@kanicasino.com</span>.
+                    Privacy questions, rights requests and anything else:{" "}
+                    <span className="text-blue-500">novadrake77@gmail.com</span>.
                 </span>
             </Section>
         </div>


### PR DESCRIPTION
## Problem

Three defects in #197, all of which fail silently rather than erroring.

The api-key gate is mounted in front of every route, so it also covered `/email`. SNS does not send an api key, so the bounce/complaint subscription would never confirm and no address would ever be suppressed. A mail provider POSTing the unsubscribe header does not send one either.

The `List-Unsubscribe` header pointed at the frontend SPA. Under RFC 8058 the provider POSTs that URL itself; a static page answers 200 without running the script that performs the opt-out. Gmail would record a successful unsubscribe while the user stayed subscribed.

`privacy@` and `contact@kanicasino.com` were written into the privacy policy, but the domain has no MX record, so both bounce. A policy whose only contact channel rejects mail reads as a working route to exercise LGPD rights and is not one. The DMARC `rua` had the same problem.

## Change

`/email` mounts above the gate, matching the existing internal notice hook. Endpoints that touch a session still require a JWT.

The `List-Unsubscribe` header points at the api endpoint. The footer link still points at the page, which is the one a human clicks.

The policy points at an address that receives mail today. DMARC `rua` is dropped rather than redirected, since external reporting to a gmail address needs an authorization record only Google can publish. Outgoing mail carries a Reply-To, because the from address can send but not receive.

## Tests

The header test takes the URL out of the sent message, POSTs it, and asserts the user is opted out, so it fails if the two drift apart. Route order is asserted against `index.js` itself rather than a rebuilt test app, since the test app has no gate and that is what hid this. Both were checked against the pre-fix code and fail there. Backend 510 passing, frontend build clean.