### PR TITLE
Send the 1.0 privacy notice to everyone, once

### DIFF
--- a/backend/__tests__/integration/emailCampaign.test.js
+++ b/backend/__tests__/integration/emailCampaign.test.js
@@ -81,20 +81,20 @@ describe("who the campaign would target", () => {
   const audienceFilter = {
     email: { $exists: true, $nin: [null, ""] },
     emailSuppressed: { $ne: true },
+    ...policyUpdate.audience,
   };
+
+  const googleUser = (s) => User.create({ username: `g-${s}`, email: `g-${s}@example.com` });
+  const registered = (s) =>
+    User.create({ username: `r-${s}`, email: `r-${s}@example.com`, password: "hashed" });
 
   it("skips suppressed addresses and anyone without an email", async () => {
     const s = uniqueSuffix();
-    const ok = await User.create({ username: `ok-${s}`, email: `ok-${s}@example.com`, password: "x" });
-    await User.create({
-      username: `sup-${s}`,
-      email: `sup-${s}@example.com`,
-      password: "x",
-      emailSuppressed: true,
-    });
+    const ok = await googleUser(s);
+    await User.create({ username: `sup-${s}`, email: `sup-${s}@example.com`, emailSuppressed: true });
     // the schema requires email now, but older docs predate that, which is what the guard is for
-    await User.collection.insertOne({ username: `none-${s}`, password: "x" });
-    await User.collection.insertOne({ username: `blank-${s}`, password: "x", email: "" });
+    await User.collection.insertOne({ username: `none-${s}` });
+    await User.collection.insertOne({ username: `blank-${s}`, email: "" });
 
     const found = await User.find(audienceFilter).select("_id");
 
@@ -102,12 +102,33 @@ describe("who the campaign would target", () => {
   });
 
   it("includes people who never opted in to marketing, because this is service mail", async () => {
-    const s = uniqueSuffix();
-    await User.create({ username: `u-${s}`, email: `u-${s}@example.com`, password: "x" });
+    await googleUser(uniqueSuffix());
 
     const found = await User.find(audienceFilter);
 
     expect(found).toHaveLength(1);
     expect(found[0].marketingOptIn).toBe(false);
+  });
+
+  it("leaves out accounts registered with a password, whose address nobody ever confirmed", async () => {
+    const s = uniqueSuffix();
+    const g = await googleUser(s);
+    await registered(s);
+
+    const found = await User.find(audienceFilter).select("_id");
+
+    expect(found.map((u) => String(u._id))).toEqual([String(g._id)]);
+  });
+
+  it("counts an account carrying a googleId even if it somehow also has a password", async () => {
+    const s = uniqueSuffix();
+    await User.create({
+      username: `both-${s}`,
+      email: `both-${s}@example.com`,
+      password: "hashed",
+      googleId: "1234567890",
+    });
+
+    expect(await User.countDocuments(audienceFilter)).toBe(1);
   });
 });

--- a/backend/__tests__/integration/emailCampaign.test.js
+++ b/backend/__tests__/integration/emailCampaign.test.js
@@ -1,0 +1,113 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+process.env.SITE_URL = "https://site.example.com";
+
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const EmailSend = require("../../models/EmailSend");
+const policyUpdate = require("../../utils/emails/policyUpdate");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+describe("the policy update template", () => {
+  it("greets the person by name in both the html and the plain text", () => {
+    const { html, text } = policyUpdate.build("Nova Drake993");
+    expect(html).toContain("Hi, Nova Drake993!");
+    expect(text).toContain("Hi, Nova Drake993!");
+  });
+
+  it("links to the policy on the site, not to the api", () => {
+    const { html, text } = policyUpdate.build("x");
+    expect(html).toContain("https://site.example.com/privacy-policy");
+    expect(text).toContain("https://site.example.com/privacy-policy");
+  });
+
+  it("always ships a text part, since a html-only bulk send looks like spam", () => {
+    const { subject, text } = policyUpdate.build("x");
+    expect(subject).toBeTruthy();
+    expect(text.length).toBeGreaterThan(200);
+  });
+});
+
+describe("campaign bookkeeping", () => {
+  const makeUser = () => {
+    const s = uniqueSuffix();
+    return User.create({ username: `user-${s}`, email: `user-${s}@example.com`, password: "x" });
+  };
+
+  it("refuses a second row for the same person and campaign, so a re-run cannot double send", async () => {
+    const u = await makeUser();
+    await EmailSend.syncIndexes();
+
+    await EmailSend.create({ campaign: "policyUpdate", user: u._id, email: u.email, status: "sent" });
+    await expect(
+      EmailSend.create({ campaign: "policyUpdate", user: u._id, email: u.email, status: "sent" })
+    ).rejects.toThrow();
+
+    expect(await EmailSend.countDocuments({ user: u._id })).toBe(1);
+  });
+
+  it("lets the same person receive a different campaign", async () => {
+    const u = await makeUser();
+    await EmailSend.syncIndexes();
+
+    await EmailSend.create({ campaign: "policyUpdate", user: u._id, email: u.email, status: "sent" });
+    await EmailSend.create({ campaign: "somethingElse", user: u._id, email: u.email, status: "sent" });
+
+    expect(await EmailSend.countDocuments({ user: u._id })).toBe(2);
+  });
+
+  it("records why a send did not happen, so skipped is not confused with failed", async () => {
+    const u = await makeUser();
+    await EmailSend.create({
+      campaign: "policyUpdate",
+      user: u._id,
+      email: u.email,
+      status: "skipped",
+      detail: "suppressed",
+    });
+
+    const row = await EmailSend.findOne({ user: u._id });
+    expect(row.status).toBe("skipped");
+    expect(row.detail).toBe("suppressed");
+  });
+});
+
+// the audience query is the thing that decides who gets mailed, so it is worth pinning
+describe("who the campaign would target", () => {
+  const audienceFilter = {
+    email: { $exists: true, $nin: [null, ""] },
+    emailSuppressed: { $ne: true },
+  };
+
+  it("skips suppressed addresses and anyone without an email", async () => {
+    const s = uniqueSuffix();
+    const ok = await User.create({ username: `ok-${s}`, email: `ok-${s}@example.com`, password: "x" });
+    await User.create({
+      username: `sup-${s}`,
+      email: `sup-${s}@example.com`,
+      password: "x",
+      emailSuppressed: true,
+    });
+    // the schema requires email now, but older docs predate that, which is what the guard is for
+    await User.collection.insertOne({ username: `none-${s}`, password: "x" });
+    await User.collection.insertOne({ username: `blank-${s}`, password: "x", email: "" });
+
+    const found = await User.find(audienceFilter).select("_id");
+
+    expect(found.map((u) => String(u._id))).toEqual([String(ok._id)]);
+  });
+
+  it("includes people who never opted in to marketing, because this is service mail", async () => {
+    const s = uniqueSuffix();
+    await User.create({ username: `u-${s}`, email: `u-${s}@example.com`, password: "x" });
+
+    const found = await User.find(audienceFilter);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].marketingOptIn).toBe(false);
+  });
+});

--- a/backend/models/EmailSend.js
+++ b/backend/models/EmailSend.js
@@ -1,0 +1,19 @@
+const mongoose = require("mongoose");
+
+// one row per user per campaign. the unique index is what makes a re-run safe: a second
+// attempt collides instead of sending twice, so resuming never needs a trustworthy log.
+const emailSendSchema = new mongoose.Schema(
+  {
+    campaign: { type: String, required: true },
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    email: { type: String, required: true },
+    status: { type: String, enum: ["sent", "skipped", "failed"], required: true },
+    detail: String,
+    sentAt: { type: Date, default: Date.now },
+  },
+  { versionKey: false }
+);
+
+emailSendSchema.index({ campaign: 1, user: 1 }, { unique: true });
+
+module.exports = mongoose.model("EmailSend", emailSendSchema);

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -183,6 +183,7 @@ router.post('/googlelogin', async (req, res) => {
       // a referral only counts at account creation, never on a later login
       const referrer = referralCode ? await findReferrer(referralCode) : null;
       user = new User({
+        googleId: googlePayload.sub,
         email: googlePayload.email,
         username: username,
         profilePicture: googlePayload.picture,
@@ -200,6 +201,9 @@ router.post('/googlelogin', async (req, res) => {
       });
 
       if (referrer) await payReferralBonuses(user, referrer);
+    } else if (!user.googleId) {
+      // the field was never written before, so it backfills as older accounts sign in
+      await User.updateOne({ _id: user._id }, { $set: { googleId: googlePayload.sub } });
     }
     // Generate and send JWT
     const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };

--- a/backend/scripts/sendCampaign.js
+++ b/backend/scripts/sendCampaign.js
@@ -46,7 +46,11 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
   const filter = ONLY
     ? { email: ONLY }
-    : { email: { $exists: true, $nin: [null, ""] }, emailSuppressed: { $ne: true } };
+    : {
+        email: { $exists: true, $nin: [null, ""] },
+        emailSuppressed: { $ne: true },
+        ...(template.audience || {}),
+      };
 
   const already = new Set(
     (await EmailSend.find({ campaign, status: "sent" }).select("user")).map((r) => String(r.user))

--- a/backend/scripts/sendCampaign.js
+++ b/backend/scripts/sendCampaign.js
@@ -1,0 +1,106 @@
+// sends one campaign to every account that can receive it, one message at a time.
+// safe to re-run: each send is recorded and the unique index on (campaign, user) means a
+// second pass skips whoever already got it rather than mailing them twice.
+//
+// usage (from backend/):
+//   node scripts/sendCampaign.js policyUpdate                      # dry run, reports the audience
+//   node scripts/sendCampaign.js policyUpdate --only a@b.com       # one address, really sends
+//   node scripts/sendCampaign.js policyUpdate --apply --limit 20   # first 20, really sends
+//   node scripts/sendCampaign.js policyUpdate --apply              # the whole list
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const User = require("../models/User");
+const EmailSend = require("../models/EmailSend");
+const { sendMail } = require("../utils/mailer");
+
+const TEMPLATES = { policyUpdate: require("../utils/emails/policyUpdate") };
+
+const arg = (name) => {
+  const i = process.argv.indexOf(name);
+  return i === -1 ? null : process.argv[i + 1];
+};
+
+const campaign = process.argv[2];
+const APPLY = process.argv.includes("--apply");
+const ONLY = arg("--only");
+const LIMIT = Number(arg("--limit")) || 0;
+// 14/sec is the account ceiling, so ~9/sec leaves room for live traffic sending too
+const GAP_MS = Number(arg("--gap")) || 110;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+(async () => {
+  const template = TEMPLATES[campaign];
+  if (!template) {
+    console.error(`unknown campaign "${campaign}". known: ${Object.keys(TEMPLATES).join(", ")}`);
+    process.exit(1);
+  }
+  if (!process.env.MONGO_URI) {
+    console.error("MONGO_URI is not set (run from backend/ with its .env)");
+    process.exit(1);
+  }
+
+  await mongoose.connect(process.env.MONGO_URI);
+  await EmailSend.syncIndexes();
+
+  const filter = ONLY
+    ? { email: ONLY }
+    : { email: { $exists: true, $nin: [null, ""] }, emailSuppressed: { $ne: true } };
+
+  const already = new Set(
+    (await EmailSend.find({ campaign, status: "sent" }).select("user")).map((r) => String(r.user))
+  );
+
+  let audience = await User.find(filter).select("username email").sort({ _id: 1 });
+  audience = audience.filter((u) => !already.has(String(u._id)));
+  if (LIMIT) audience = audience.slice(0, LIMIT);
+
+  console.log(`campaign: ${campaign}`);
+  console.log(`subject:  ${template.subject}`);
+  console.log(`already sent in a previous run: ${already.size}`);
+  console.log(`to send now: ${audience.length}`);
+
+  const live = APPLY || ONLY;
+  if (!live) {
+    console.log("\nDRY RUN: nothing sent. re-run with --apply");
+    console.log("sample:", audience.slice(0, 5).map((u) => u.email));
+    process.exit(0);
+  }
+
+  const tally = { sent: 0, skipped: 0, failed: 0 };
+  for (let i = 0; i < audience.length; i++) {
+    const u = audience[i];
+    const { subject, html, text } = template.build(u.username);
+    let status = "sent";
+    let detail;
+
+    try {
+      const res = await sendMail({ to: u.email, subject, html, text, kind: "service" });
+      if (res.skipped) {
+        status = "skipped";
+        detail = res.skipped;
+      }
+    } catch (err) {
+      status = "failed";
+      detail = err.message;
+    }
+
+    tally[status] += 1;
+    // a duplicate key here means another run already covered this user, which is fine
+    await EmailSend.create({ campaign, user: u._id, email: u.email, status, detail }).catch(() => {});
+
+    if ((i + 1) % 50 === 0 || i === audience.length - 1) {
+      console.log(`${i + 1}/${audience.length}  sent ${tally.sent}  skipped ${tally.skipped}  failed ${tally.failed}`);
+    }
+    if (i < audience.length - 1) await sleep(GAP_MS);
+  }
+
+  console.log(`\ndone. sent ${tally.sent}, skipped ${tally.skipped}, failed ${tally.failed}`);
+  if (tally.failed) console.log("re-run the same command to retry only the ones that did not send");
+  await mongoose.disconnect();
+  process.exit(0);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/utils/emails/policyUpdate.js
+++ b/backend/utils/emails/policyUpdate.js
@@ -1,0 +1,57 @@
+const SITE = process.env.SITE_URL || "https://kanicasino.com";
+
+const subject = "KaniCasino 1.0, and an updated Privacy Policy";
+
+const build = (name) => {
+  const url = `${SITE}/privacy-policy`;
+
+  const html = `
+<div style="background:#F1F0F5;padding:32px 16px;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <div style="max-width:560px;margin:0 auto">
+    <div style="font:700 20px/1 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#4F46E5;padding:0 8px 20px">KaniCasino</div>
+    <div style="background:#FFFFFF;border-radius:10px;padding:36px 32px">
+      <h1 style="margin:0 0 28px;font-size:23px;line-height:1.3;color:#16151F">KaniCasino 1.0 is here, with a new Privacy Policy</h1>
+
+      <p style="margin:0 0 16px;font-size:15px;line-height:1.65;color:#3C3A4B"><strong>Hi, ${name}!</strong></p>
+
+      <p style="margin:0 0 8px;font-size:15px;line-height:1.65;color:#3C3A4B">KaniCasino has reached its first stable release. Alongside it we have rewritten our Privacy Policy, and we want you to know what it says:</p>
+
+      <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:26px 0">
+        <tr><td align="center" bgcolor="#4F46E5" style="border-radius:6px">
+          <a href="${url}" style="display:inline-block;padding:14px 30px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none">Read the Privacy Policy &#8594;</a>
+        </td></tr>
+      </table>
+
+      <h2 style="margin:32px 0 10px;font-size:17px;color:#16151F">What changed?</h2>
+      <p style="margin:0 0 16px;font-size:15px;line-height:1.65;color:#3C3A4B">The new policy properly describes how KaniCasino works. It sets out what your account holds, why we keep it, which companies process it for us, how long it is kept, and how to ask for a copy of your data or have it deleted under the LGPD.</p>
+      <p style="margin:0 0 16px;font-size:15px;line-height:1.65;color:#3C3A4B">You can also now choose whether to hear about new cases and games by email. That is off unless you turn it on, under Settings in your profile.</p>
+
+      <h2 style="margin:32px 0 10px;font-size:17px;color:#16151F">What do I need to do now?</h2>
+      <p style="margin:0 0 16px;font-size:15px;line-height:1.65;color:#3C3A4B">Nothing. Your account and the way you play are unchanged. KP is still fictional, there are no deposits or withdrawals, and we never ask for payment details.</p>
+
+      <p style="margin:24px 0 0;font-size:15px;line-height:1.65;color:#3C3A4B">If anything here is unclear, just reply to this email and we will explain.</p>
+    </div>
+  </div>
+</div>`;
+
+  const text = `KaniCasino 1.0 is here, with a new Privacy Policy
+
+Hi, ${name}!
+
+KaniCasino has reached its first stable release. Alongside it we have rewritten our Privacy Policy, and we want you to know what it says. You can read it in full here:
+${url}
+
+What changed?
+The new policy properly describes how KaniCasino works. It sets out what your account holds, why we keep it, which companies process it for us, how long it is kept, and how to ask for a copy of your data or have it deleted under the LGPD.
+
+You can also now choose whether to hear about new cases and games by email. That is off unless you turn it on, under Settings in your profile.
+
+What do I need to do now?
+Nothing. Your account and the way you play are unchanged. KP is still fictional, there are no deposits or withdrawals, and we never ask for payment details.
+
+If anything here is unclear, just reply to this email and we will explain.`;
+
+  return { subject, html, text };
+};
+
+module.exports = { subject, build };

--- a/backend/utils/emails/policyUpdate.js
+++ b/backend/utils/emails/policyUpdate.js
@@ -2,6 +2,13 @@ const SITE = process.env.SITE_URL || "https://kanicasino.com";
 
 const subject = "KaniCasino 1.0, and an updated Privacy Policy";
 
+// google accounts only. nothing else here is a confirmed address, and mailing unverified
+// ones would put the bounce rate, and the sending domain with it, at risk on the first run.
+// google never sets a password, and no route has ever written one after registration.
+const audience = {
+  $or: [{ googleId: { $exists: true, $nin: [null, ""] } }, { password: { $in: [null, ""] } }, { password: { $exists: false } }],
+};
+
 const build = (name) => {
   const url = `${SITE}/privacy-policy`;
 
@@ -54,4 +61,4 @@ If anything here is unclear, just reply to this email and we will explain.`;
   return { subject, html, text };
 };
 
-module.exports = { subject, build };
+module.exports = { subject, audience, build };

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -63,8 +63,10 @@ function withFooter(html, unsub, kind) {
     kind === "marketing"
       ? `You are getting this because you opted in to updates from KaniCasino. <a href="${unsub}">Unsubscribe</a>.`
       : `This is a service message about your KaniCasino account. <a href="${unsub}">Manage email preferences</a>.`;
-  return `${html}<hr style="border:none;border-top:1px solid #2A2840;margin:24px 0" />
-<p style="font:12px sans-serif;color:#84819a">${line}</p>`;
+  return `${html}
+<div style="background:#F1F0F5;padding:0 16px 32px;font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+  <p style="max-width:560px;margin:0 auto;padding:0 8px;font-size:12px;line-height:1.6;color:#6B6880">${line}</p>
+</div>`;
 }
 
 module.exports = { sendMail, unsubscribeUrl, oneClickUrl, enabled };


### PR DESCRIPTION
## Problem

The policy notice existed only as a script pasted over SSH. That is fine for one test address and not fine for 2,825, where a crash partway through leaves you guessing who already received it.

## Change

The template moves into the repo as `utils/emails/policyUpdate.js`, framed around the 1.0 release with the policy as the single call to action.

`scripts/sendCampaign.js` sends it. Safety comes from the database rather than the script keeping careful notes: a unique index on `(campaign, user)` means a second pass collides instead of mailing anyone twice, so a run that dies at message 1,400 is resumed by running the same command again. Every attempt is recorded with why it did not send, keeping a suppressed address distinct from a real failure.

Dry run is the default. `--only` takes one address, `--limit` takes the first n, and sends are spaced to roughly 9/sec against an account ceiling of 14 so live traffic still gets through.

The audience excludes suppressed addresses and older accounts that predate email being required. It ignores the marketing opt-in deliberately: this is a service notice about the policy, not promotion, which is also why the only link in it is the policy.

The mail footer was styled for a dark background while every template is light, so the rule above it rendered as a dark navy line.

## Tests

8 new tests covering the template, the unique-index guarantee against double sends, that a different campaign to the same person is still allowed, and that the audience query excludes suppressed and email-less accounts while including people who never opted in to marketing. Backend 518 passing.

## Note

Nothing sends on merge. The script is manual and dry-run by default.