### PR TITLE
A free case opening every day

### DIFF
--- a/backend/__tests__/integration/dailyGift.test.js
+++ b/backend/__tests__/integration/dailyGift.test.js
@@ -1,0 +1,486 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Case = require("../../models/Case");
+const Item = require("../../models/Item");
+const gift = require("../../utils/dailyGift");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+const makeUser = (over = {}) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@example.com`, password: "x", ...over });
+};
+
+async function makeCase(price, category) {
+  const s = uniqueSuffix();
+  const item = await Item.create({ name: `item-${s}`, image: "i.png", rarity: 1 });
+  return Case.create({ title: `case-${s}`, image: "c.png", price, category, items: [item._id] });
+}
+
+const seedCategory = async (category, prices) => {
+  for (const p of prices) await makeCase(p, category);
+};
+
+describe("the category picker", () => {
+  it("offers every category with a table, and publishes the odds", async () => {
+    await seedCategory("Touhou", [60, 60]);
+    await seedCategory("Uma Musume", [30, 50]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).get("/gift"), u);
+
+    expect(res.status).toBe(200);
+    expect(res.body.categories.map((c) => c.category).sort()).toEqual(["Touhou", "Uma Musume"]);
+    for (const c of res.body.categories) {
+      expect(c.slots).toHaveLength(gift.SLOTS.length);
+      const chance = c.slots.reduce((a, s) => a + s.chance, 0);
+      expect(chance).toBeGreaterThan(99.8);
+      expect(chance).toBeLessThan(100.2);
+    }
+  });
+
+  it("hides a category whose every case is above the cap", async () => {
+    await seedCategory("Touhou", [60]);
+    await seedCategory("Grails", [1324450]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).get("/gift"), u);
+    expect(res.body.categories.map((c) => c.category)).toEqual(["Touhou"]);
+  });
+
+  it("keeps every category worth about the same, so picking your own costs nothing", async () => {
+    await seedCategory("Uma Musume", [30, 30, 40, 45, 50]);
+    await seedCategory("Counter-Strike", [15, 130, 352, 690, 1859]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).get("/gift"), u);
+    const evs = res.body.categories.map((c) => c.expectedValue);
+    expect(Math.max(...evs) / Math.min(...evs)).toBeLessThan(1.35);
+  });
+});
+
+describe("what the streak is worth", () => {
+  it("says how many days it takes to reach the best odds", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).get("/gift"), u);
+
+    expect(res.body.streakMax).toBe(Math.ceil(gift.MAX_STREAK_TILT / gift.STREAK_STEP));
+  });
+
+  it("quotes a boost that climbs with the streak and tops out at the last day", async () => {
+    await seedCategory("Touhou", [60]);
+    const fresh = await makeUser({ level: 60 });
+    const halfway = await makeUser({ level: 60, giftStreak: 5 });
+
+    const a = await auth(request(app).get("/gift"), fresh);
+    const b = await auth(request(app).get("/gift"), halfway);
+
+    expect(a.body.rareBoost).toBe(1);
+    expect(b.body.rareBoost).toBeGreaterThan(a.body.rareBoost);
+    expect(a.body.atBestStreak.rareBoost).toBeGreaterThan(b.body.rareBoost);
+    // the advertised best is the same number whatever the streak is today
+    expect(b.body.atBestStreak.rareBoost).toBe(a.body.atBestStreak.rareBoost);
+  });
+
+  it("stops promising more once the streak is already there", async () => {
+    await seedCategory("Touhou", [60]);
+    const maxed = await makeUser({ level: 60, giftStreak: 10 });
+
+    const res = await auth(request(app).get("/gift"), maxed);
+
+    expect(res.body.rareBoost).toBe(res.body.atBestStreak.rareBoost);
+  });
+
+  it("quotes the weight the spin actually puts on the rarest prize", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser({ level: 60, giftStreak: 4 });
+
+    const res = await auth(request(app).get("/gift"), u);
+    const table = gift.tableFor(await Case.find({ category: "Touhou" }).lean());
+    const plain = gift.weightsFor(table, 0);
+    const streaked = gift.weightsFor(table, 4);
+    const rarest = table.length - 1;
+
+    expect(res.body.rareBoost).toBeCloseTo(streaked[rarest] / plain[rarest], 2);
+  });
+});
+
+describe("the top slot on the state", () => {
+  it("shows the whole wheel, marking what the level has not earned yet", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser({ level: 8 });
+
+    const res = await auth(request(app).get("/gift"), u);
+
+    expect(res.body.topSlot).toHaveLength(gift.TOP_SLOT.length);
+    const locked = res.body.topSlot.filter((t) => t.locked).map((t) => t.multiplier);
+    expect(locked).toEqual([3, 5, 10, 25]);
+    for (const t of res.body.topSlot.filter((x) => x.locked)) expect(t.chance).toBe(0);
+  });
+
+  it("unlocks the higher rungs as the level climbs", async () => {
+    await seedCategory("Touhou", [60]);
+    const low = await makeUser({ level: 8 });
+    const high = await makeUser({ level: 60 });
+
+    const a = await auth(request(app).get("/gift"), low);
+    const b = await auth(request(app).get("/gift"), high);
+
+    expect(a.body.topSlot.filter((t) => !t.locked)).toHaveLength(2);
+    expect(b.body.topSlot.filter((t) => !t.locked)).toHaveLength(5);
+    expect(b.body.topSlotAverage).toBeGreaterThan(a.body.topSlotAverage);
+  });
+});
+
+describe("spinning", () => {
+  it("grants free openings of one specific case", async () => {
+    await seedCategory("Touhou", [60, 60]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.opens).toBeGreaterThanOrEqual(1);
+    const after = await User.findById(u._id);
+    expect(after.freeOpens).toHaveLength(1);
+    expect(after.freeOpens[0].remaining).toBe(res.body.opens);
+    expect(String(after.freeOpens[0].caseId)).toBe(res.body.won.caseId);
+  });
+
+  it("tops up an existing grant instead of leaving two on the same case", async () => {
+    // one case in the category, so both spins have to land on it
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+
+    const first = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+    await User.updateOne({ _id: u._id }, { $unset: { giftNextAt: "" } });
+    const second = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    const after = await User.findById(u._id);
+    expect(after.freeOpens).toHaveLength(1);
+    expect(after.freeOpens[0].remaining).toBe(first.body.opens + second.body.opens);
+    expect(second.body.grantRemaining).toBe(first.body.opens + second.body.opens);
+    expect(second.body.grantId).toBe(first.body.grantId);
+
+    // and the case page sees the one merged total, not the older half of it
+    const grants = await auth(request(app).get("/gift/grants"), u);
+    expect(grants.body).toHaveLength(1);
+    expect(grants.body[0].remaining).toBe(first.body.opens + second.body.opens);
+  });
+
+  it("keeps grants for different cases apart", async () => {
+    await seedCategory("Touhou", [60]);
+    await seedCategory("Counter-Strike", [60]);
+    const u = await makeUser();
+
+    await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+    await User.updateOne({ _id: u._id }, { $unset: { giftNextAt: "" } });
+    await auth(request(app).post("/gift/spin"), u).send({ category: "Counter-Strike" });
+
+    expect((await User.findById(u._id)).freeOpens).toHaveLength(2);
+  });
+
+  it("multiplies the reel by whatever the top slot lands on", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser({ level: 60 });
+
+    const res = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    expect(res.body.opens).toBe(res.body.won.opens * res.body.topSlot.multiplier);
+    expect(res.body.topSlot.hit).toBe(res.body.topSlot.multiplier > 1);
+  });
+
+  it("never awards a multiplier the level has not unlocked", async () => {
+    await seedCategory("Touhou", [60]);
+    const allowed = gift.TOP_SLOT.filter((t) => t.minLevel <= 0).map((t) => t.multiplier);
+
+    for (let i = 0; i < 12; i++) {
+      const u = await makeUser({ level: 0 });
+      const res = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+      expect(allowed).toContain(res.body.topSlot.multiplier);
+    }
+  });
+
+  it("starts the streak and sets tomorrow's cooldown", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    expect(res.body.streak).toBe(1);
+    const after = await User.findById(u._id);
+    const window = new Date(after.giftNextAt).getTime() - Date.now();
+    expect(window).toBeGreaterThan(gift.CLAIM_WINDOW_MS - 60000);
+  });
+
+  it("refuses a second spin the same day", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+    await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    const second = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    expect(second.status).toBe(400);
+    expect((await User.findById(u._id)).freeOpens).toHaveLength(1);
+  });
+
+  it("refuses a category that does not exist", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).post("/gift/spin"), u).send({ category: "Nope" });
+    expect(res.status).toBe(400);
+  });
+
+  it("expires the grant with the day", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+    await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+
+    const g = (await User.findById(u._id)).freeOpens[0];
+    const ttl = new Date(g.expiresAt).getTime() - Date.now();
+    expect(ttl).toBeGreaterThan(gift.GRANT_TTL_MS - 60000);
+    expect(ttl).toBeLessThanOrEqual(gift.GRANT_TTL_MS);
+  });
+
+  it("never grants a case above the price cap", async () => {
+    await seedCategory("Touhou", [60, 12000]);
+    const u = await makeUser();
+
+    const res = await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+    const won = await Case.findById(res.body.won.caseId);
+    expect(won.price).toBeLessThanOrEqual(gift.MAX_CASE_PRICE);
+  });
+});
+
+describe("spending a grant", () => {
+  const grantFor = async (user, caseDoc, remaining, expiresAt) =>
+    User.findOneAndUpdate(
+      { _id: user._id },
+      {
+        $push: {
+          freeOpens: {
+            caseId: caseDoc._id,
+            remaining,
+            expiresAt: expiresAt || new Date(Date.now() + 3600000),
+          },
+        },
+      },
+      { new: true }
+    );
+
+  it("opens without touching the wallet and spends one opening", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(u, c, 3);
+
+    const res = await auth(request(app).post(`/games/openCase/${c._id}`), u).send({
+      quantity: 1,
+      grantId: withGrant.freeOpens[0].grantId,
+    });
+
+    expect(res.status).toBe(200);
+    const after = await User.findById(u._id);
+    expect(after.walletBalance).toBe(0);
+    expect(after.inventory).toHaveLength(1);
+    expect(after.freeOpens[0].remaining).toBe(2);
+  });
+
+  it("spends several at once when the quantity asks for it", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(u, c, 5);
+
+    await auth(request(app).post(`/games/openCase/${c._id}`), u).send({
+      quantity: 3,
+      grantId: withGrant.freeOpens[0].grantId,
+    });
+
+    const after = await User.findById(u._id);
+    expect(after.freeOpens[0].remaining).toBe(2);
+    expect(after.inventory).toHaveLength(3);
+  });
+
+  // the whole reason a grant names a case rather than a category
+  it("refuses to spend it on a different case", async () => {
+    const granted = await makeCase(30, "Uma Musume");
+    const other = await makeCase(1859, "Uma Musume");
+    const u = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(u, granted, 5);
+
+    const res = await auth(request(app).post(`/games/openCase/${other._id}`), u).send({
+      quantity: 1,
+      grantId: withGrant.freeOpens[0].grantId,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/different case/i);
+    expect((await User.findById(u._id)).freeOpens[0].remaining).toBe(5);
+  });
+
+  it("refuses more openings than are left", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(u, c, 2);
+
+    const res = await auth(request(app).post(`/games/openCase/${c._id}`), u).send({
+      quantity: 3,
+      grantId: withGrant.freeOpens[0].grantId,
+    });
+
+    expect(res.status).toBe(400);
+    expect((await User.findById(u._id)).freeOpens[0].remaining).toBe(2);
+  });
+
+  it("refuses an expired grant", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(u, c, 3, new Date(Date.now() - 1000));
+
+    const res = await auth(request(app).post(`/games/openCase/${c._id}`), u).send({
+      quantity: 1,
+      grantId: withGrant.freeOpens[0].grantId,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/expired/i);
+  });
+
+  it("refuses a grant belonging to somebody else", async () => {
+    const c = await makeCase(500, "Touhou");
+    const owner = await makeUser();
+    const thief = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(owner, c, 3);
+
+    const res = await auth(request(app).post(`/games/openCase/${c._id}`), thief).send({
+      quantity: 1,
+      grantId: withGrant.freeOpens[0].grantId,
+    });
+
+    expect(res.status).toBe(404);
+    expect((await User.findById(owner._id)).freeOpens[0].remaining).toBe(3);
+  });
+
+  it("cannot be overdrawn by two opens racing each other", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({ walletBalance: 0 });
+    const withGrant = await grantFor(u, c, 1);
+    const grantId = withGrant.freeOpens[0].grantId;
+
+    const [a, b] = await Promise.all([
+      auth(request(app).post(`/games/openCase/${c._id}`), u).send({ quantity: 1, grantId }),
+      auth(request(app).post(`/games/openCase/${c._id}`), u).send({ quantity: 1, grantId }),
+    ]);
+
+    expect([a.status, b.status].filter((s) => s === 200)).toHaveLength(1);
+    const after = await User.findById(u._id);
+    expect(after.freeOpens[0].remaining).toBe(0);
+    expect(after.inventory).toHaveLength(1);
+    expect(after.walletBalance).toBe(0);
+  });
+
+  it("still charges normally when no grant is passed", async () => {
+    const c = await makeCase(400, "Touhou");
+    const u = await makeUser({ walletBalance: 1000 });
+
+    const res = await auth(request(app).post(`/games/openCase/${c._id}`), u).send({ quantity: 1 });
+
+    expect(res.status).toBe(200);
+    expect((await User.findById(u._id)).walletBalance).toBe(600);
+  });
+});
+
+describe("status", () => {
+  it("says a spin is waiting before the first one", async () => {
+    const u = await makeUser();
+
+    const res = await auth(request(app).get("/gift/status"), u);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ canSpin: true, nextAt: null });
+  });
+
+  it("stops saying so once today's gift is taken", async () => {
+    await seedCategory("Touhou", [60]);
+    const u = await makeUser();
+
+    await auth(request(app).post("/gift/spin"), u).send({ category: "Touhou" });
+    const res = await auth(request(app).get("/gift/status"), u);
+
+    expect(res.body.canSpin).toBe(false);
+    expect(new Date(res.body.nextAt).getTime()).toBeGreaterThan(Date.now());
+  });
+});
+
+describe("listing grants", () => {
+  const grantFor = async (user, caseDoc, remaining, expiresAt) =>
+    User.findOneAndUpdate(
+      { _id: user._id },
+      {
+        $push: {
+          freeOpens: {
+            caseId: caseDoc._id,
+            remaining,
+            expiresAt: expiresAt || new Date(Date.now() + 3600000),
+          },
+        },
+      },
+      { new: true }
+    );
+
+  it("returns what is still open to spend", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({});
+    await grantFor(u, c, 4);
+
+    const res = await auth(request(app).get("/gift/grants"), u);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({
+      caseId: String(c._id),
+      remaining: 4,
+      title: c.title,
+      image: c.image,
+    });
+  });
+
+  it("filters to one case so the case page only sees its own", async () => {
+    const mine = await makeCase(500, "Touhou");
+    const other = await makeCase(500, "Touhou");
+    const u = await makeUser({});
+    await grantFor(u, mine, 2);
+    await grantFor(u, other, 7);
+
+    const res = await auth(request(app).get("/gift/grants").query({ caseId: String(mine._id) }), u);
+
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].remaining).toBe(2);
+  });
+
+  it("leaves out the spent and the expired", async () => {
+    const c = await makeCase(500, "Touhou");
+    const u = await makeUser({});
+    await grantFor(u, c, 0);
+    await grantFor(u, c, 3, new Date(Date.now() - 1000));
+
+    const res = await auth(request(app).get("/gift/grants"), u);
+
+    expect(res.body).toHaveLength(0);
+  });
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -12,6 +12,7 @@ const adminRoutes = require("../../routes/adminRoutes");
 const referralRoutes = require("../../routes/referralRoutes");
 const rewardRoutes = require("../../routes/rewardRoutes");
 const emailRoutes = require("../../routes/emailRoutes");
+const giftRoutes = require("../../routes/giftRoutes");
 const caseRoutes = require("../../routes/caseRoutes");
 const itemRoutes = require("../../routes/itemRoutes");
 
@@ -32,6 +33,7 @@ function makeApp() {
   app.use("/referrals", referralRoutes(io));
   app.use("/rewards", rewardRoutes(io));
   app.use("/email", emailRoutes);
+  app.use("/gift", giftRoutes);
   app.use("/cases", caseRoutes);
   app.use("/items", itemRoutes);
   return app;

--- a/backend/__tests__/unit/dailyGift.test.js
+++ b/backend/__tests__/unit/dailyGift.test.js
@@ -1,0 +1,221 @@
+const gift = require("../../utils/dailyGift");
+
+const mk = (id, price, title = `case-${id}`) => ({ _id: id, price, title, image: "i.webp" });
+
+// the five real categories, reduced to their price shapes
+const CATALOGUE = {
+  "Uma Musume": [mk(1, 30), mk(2, 30), mk(3, 40), mk(4, 45), mk(5, 50)],
+  "Blue Archive": [mk(6, 30), mk(7, 45), mk(8, 45), mk(9, 45)],
+  Touhou: [mk(10, 60), mk(11, 60), mk(12, 12000)],
+  Animals: [mk(13, 40), mk(14, 120)],
+  "Counter-Strike": [mk(15, 15), mk(16, 130), mk(17, 352), mk(18, 690), mk(19, 1859), mk(20, 1324450)],
+};
+
+describe("who is eligible", () => {
+  it("drops the grails, so a daily can never be an economy event", () => {
+    const ids = gift.eligible(CATALOGUE["Counter-Strike"]).map((c) => c._id);
+    expect(ids).not.toContain(20);
+    expect(gift.eligible(CATALOGUE.Touhou).map((c) => c._id)).not.toContain(12);
+  });
+
+  it("keeps everything at or under the cap, cheapest first", () => {
+    const prices = gift.eligible(CATALOGUE["Counter-Strike"]).map((c) => c.price);
+    expect(Math.max(...prices)).toBeLessThanOrEqual(gift.MAX_CASE_PRICE);
+    expect(prices).toEqual([...prices].sort((a, b) => a - b));
+  });
+
+  it("gives an empty table when nothing qualifies, instead of guessing", () => {
+    expect(gift.tableFor([mk(99, 999999)])).toEqual([]);
+  });
+});
+
+describe("a category's table", () => {
+  const tables = Object.fromEntries(
+    Object.entries(CATALOGUE).map(([k, v]) => [k, gift.tableFor(v)])
+  );
+
+  it("has one prize per slot", () => {
+    for (const t of Object.values(tables)) expect(t).toHaveLength(gift.SLOTS.length);
+  });
+
+  it("never hands out more openings than the cap", () => {
+    for (const t of Object.values(tables)) {
+      for (const s of t) expect(s.opens).toBeGreaterThanOrEqual(1);
+      for (const s of t) expect(s.opens).toBeLessThanOrEqual(gift.MAX_OPENS);
+    }
+  });
+
+  // the jackpot has to be visibly better than the slot below it, or there is nothing
+  // to almost hit and the spin stops being a spin
+  it("gets strictly more valuable toward the rare end", () => {
+    for (const [name, t] of Object.entries(tables)) {
+      for (let i = 1; i < t.length; i++) {
+        expect(`${name} slot ${i}: ${t[i].value}`).toBe(`${name} slot ${i}: ${t[i].value}`);
+        expect(t[i].value).toBeGreaterThan(t[i - 1].value);
+      }
+    }
+  });
+
+  it("shows off the category instead of naming one case six times", () => {
+    for (const [name, t] of Object.entries(tables)) {
+      const distinctCases = new Set(t.map((s) => s.caseId)).size;
+      const available = gift.eligible(CATALOGUE[name]).length;
+      expect(distinctCases).toBeGreaterThanOrEqual(Math.min(2, available));
+    }
+  });
+
+  it("survives a category holding a single case, which is the Animals case tomorrow", () => {
+    const t = gift.tableFor([mk(1, 40)]);
+    expect(t).toHaveLength(gift.SLOTS.length);
+    expect(new Set(t.map((s) => s.caseId)).size).toBe(1);
+    expect(t[5].opens).toBeGreaterThan(t[0].opens);
+  });
+});
+
+// this is the whole design: picking the theme you actually collect must not cost you
+describe("expected value across categories", () => {
+  const evs = Object.entries(CATALOGUE).map(([name, cases]) => ({
+    name,
+    ev: gift.expectedValue(gift.tableFor(cases), 0),
+  }));
+
+  it("lands every category in the same band", () => {
+    const values = evs.map((e) => e.ev);
+    const spread = Math.max(...values) / Math.min(...values);
+    expect(spread).toBeLessThan(1.35);
+  });
+
+  it("is worth real money to the median wallet, which holds about 175 KP", () => {
+    for (const { ev } of evs) expect(ev).toBeGreaterThan(300);
+  });
+
+  it("stays far below what a grail would have injected", () => {
+    for (const { ev } of evs) expect(ev).toBeLessThan(5000);
+  });
+});
+
+describe("the streak", () => {
+  const table = gift.tableFor(CATALOGUE["Uma Musume"]);
+
+  it("counts days and resets when one is missed", () => {
+    const d = (s) => new Date(s);
+    expect(gift.nextStreak(0, null, d("2026-07-02T10:00:00Z"))).toBe(1);
+    expect(gift.nextStreak(3, d("2026-07-01T10:00:00Z"), d("2026-07-02T10:00:00Z"))).toBe(4);
+    expect(gift.nextStreak(3, d("2026-07-02T01:00:00Z"), d("2026-07-02T23:00:00Z"))).toBe(3);
+    expect(gift.nextStreak(9, d("2026-06-29T10:00:00Z"), d("2026-07-02T10:00:00Z"))).toBe(1);
+  });
+
+  it("tilts the odds toward the rare slots without touching what they pay", () => {
+    const cold = gift.weightsFor(table, 0);
+    const hot = gift.weightsFor(table, 10);
+    const share = (w) => w[w.length - 1] / w.reduce((a, b) => a + b, 0);
+
+    expect(share(hot)).toBeGreaterThan(share(cold));
+    // the ceiling is fixed: a streak must never turn the daily into a power-up
+    expect(gift.tableFor(CATALOGUE["Uma Musume"]).map((s) => s.value)).toEqual(
+      table.map((s) => s.value)
+    );
+  });
+
+  it("raises the expected value, but nowhere near double", () => {
+    const cold = gift.expectedValue(table, 0);
+    const hot = gift.expectedValue(table, 30);
+    expect(hot).toBeGreaterThan(cold);
+    expect(hot / cold).toBeLessThan(1.6);
+  });
+
+  it("stops tilting once it caps", () => {
+    expect(gift.streakTilt(400)).toBe(gift.MAX_STREAK_TILT);
+  });
+});
+
+describe("picking a slot from a roll", () => {
+  const table = gift.tableFor(CATALOGUE["Counter-Strike"]);
+  const TOTAL = 100000;
+
+  it("covers the whole roll space and reaches every slot", () => {
+    const seen = new Set();
+    for (let r = 1; r <= TOTAL; r += 97) seen.add(gift.pickSlot(table, r, TOTAL, 0).value);
+    expect(seen.size).toBe(table.length);
+  });
+
+  it("hits the jackpot about as often as its weight says", () => {
+    const top = table[table.length - 1];
+    let hits = 0;
+    for (let r = 1; r <= TOTAL; r++) if (gift.pickSlot(table, r, TOTAL, 0).value === top.value) hits++;
+    const observed = (hits / TOTAL) * 100;
+    const weights = gift.weightsFor(table, 0);
+    const expected = (weights[weights.length - 1] / weights.reduce((a, b) => a + b, 0)) * 100;
+    expect(Math.abs(observed - expected)).toBeLessThan(0.5);
+  });
+
+  it("is a pure function of the roll, so the audit record reproduces it", () => {
+    expect(gift.pickSlot(table, 42424, TOTAL, 3)).toEqual(gift.pickSlot(table, 42424, TOTAL, 3));
+  });
+});
+
+describe("the top slot", () => {
+  it("gives a fresh account only the bottom rungs, and shows the rest locked", () => {
+    const wheel = gift.topSlotFor(0);
+    expect(wheel).toHaveLength(gift.TOP_SLOT.length);
+    expect(wheel.filter((t) => !t.locked).map((t) => t.multiplier)).toEqual([1, 2]);
+  });
+
+  it("unlocks a rung at each gate, and stops at the top", () => {
+    expect(gift.topSlotFor(10).filter((t) => !t.locked)).toHaveLength(3);
+    expect(gift.topSlotFor(30).filter((t) => !t.locked)).toHaveLength(4);
+    expect(gift.topSlotFor(60).filter((t) => !t.locked)).toHaveLength(5);
+    expect(gift.topSlotFor(100).filter((t) => !t.locked)).toHaveLength(6);
+    expect(gift.topSlotFor(166).filter((t) => !t.locked)).toHaveLength(6);
+  });
+
+  it("never rolls a rung the level has not earned", () => {
+    const wheel = gift.topSlotFor(0);
+    for (let r = 1; r <= 100000; r += 13) {
+      expect(gift.pickTopSlot(wheel, r, 100000, 30).locked).toBe(false);
+    }
+  });
+
+  // level decides how high it goes, streak decides how often it fires. keeping those
+  // separate is what makes both legible to a player
+  it("pays more the higher the level, at a fixed streak", () => {
+    const at = (lv) => gift.topSlotAverage(lv, 0);
+    expect(at(10)).toBeGreaterThan(at(0));
+    expect(at(30)).toBeGreaterThan(at(10));
+    expect(at(60)).toBeGreaterThan(at(30));
+  });
+
+  it("fires more often the longer the streak, at a fixed level", () => {
+    const wheel = gift.topSlotFor(60);
+    const nothing = (streak) => {
+      const w = gift.topSlotWeights(wheel, streak);
+      return w[0] / w.reduce((a, b) => a + b, 0);
+    };
+    expect(nothing(10)).toBeLessThan(nothing(0));
+  });
+
+  it("still leaves a real chance of nothing, so the hit means something", () => {
+    const wheel = gift.topSlotFor(60);
+    const w = gift.topSlotWeights(wheel, 30);
+    expect(w[0] / w.reduce((a, b) => a + b, 0)).toBeGreaterThan(0.25);
+  });
+
+  it("keeps the day bounded, whatever the level and streak", () => {
+    const table = gift.tableFor([
+      { _id: 1, price: 30, title: "a", image: "i" },
+      { _id: 2, price: 45, title: "b", image: "i" },
+    ]);
+    const ceiling = gift.ceilingFor(table, 999);
+    const best = Math.max(...table.map((s) => s.value));
+    expect(ceiling).toBe(best * 25);
+    // the whole point of the cap: one day can never rewrite a wallet
+    expect(ceiling).toBeLessThan(100000);
+  });
+
+  it("is a pure function of the roll, so the audit record reproduces it", () => {
+    const wheel = gift.topSlotFor(60);
+    expect(gift.pickTopSlot(wheel, 77777, 100000, 4)).toEqual(
+      gift.pickTopSlot(wheel, 77777, 100000, 4)
+    );
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -89,6 +89,7 @@ const collectionsRoutes = require("./routes/collectionsRoutes");
 const missionsRoutes = require("./routes/missionsRoutes")(io);
 const referralRoutes = require("./routes/referralRoutes")(io);
 const rewardRoutes = require("./routes/rewardRoutes")(io);
+const giftRoutes = require("./routes/giftRoutes");
 const emailRoutes = require("./routes/emailRoutes");
 
 // Connect to MongoDB
@@ -160,6 +161,7 @@ app.use("/collections", collectionsRoutes);
 app.use("/missions", missionsRoutes);
 app.use("/referrals", referralRoutes);
 app.use("/rewards", rewardRoutes);
+app.use("/gift", giftRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -8,7 +8,7 @@ const RollSchema = new mongoose.Schema(
   {
     rollId: { type: String, required: true, unique: true }, // public short id, e.g. R821872881
     userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
-    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice", "mines", "hilo"], required: true },
+    game: { type: String, enum: ["case", "upgrade", "slots", "battle", "plinko", "blackjack", "dice", "mines", "hilo", "gift"], required: true },
 
     seedId: { type: mongoose.Schema.Types.ObjectId, ref: "Seed", required: true },
     clientSeed: { type: String, required: true },

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -133,6 +133,26 @@ const UserSchema = new mongoose.Schema({
   emailSuppressedReason: String,
   emailSuppressedAt: Date,
 
+  // the daily gift. one spin every 24h; the streak tilts the odds toward the rarer
+  // slots and resets the moment a calendar day is missed.
+  giftNextAt: Date,
+  giftLastAt: Date,
+  giftStreak: {
+    type: Number,
+    default: 0,
+  },
+  // free openings of one specific case. the grant is per case, never per category, so a
+  // cheap win cannot be spent on the dearest thing in the same theme.
+  freeOpens: [
+    {
+      grantId: { type: String, default: () => uuid.v4() },
+      caseId: { type: mongoose.Schema.Types.ObjectId, ref: "Case", required: true },
+      remaining: { type: Number, required: true, min: 0 },
+      wonAt: { type: Date, default: Date.now },
+      expiresAt: { type: Date, required: true },
+    },
+  ],
+
 });
 
 UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -54,7 +54,25 @@ module.exports = (io) => {
         return res.status(400).json({ message: "You need to open at least 1 case" });
       }
 
-      const cost = caseData.price * quantityToOpen;
+      // a daily-gift grant pays for openings of one specific case and nothing else, so a
+      // cheap win cannot be spent on the dearest case in the same category
+      const grantId = req.body.grantId;
+      let grant = null;
+      if (grantId) {
+        grant = (user.freeOpens || []).find((g) => g.grantId === grantId);
+        if (!grant) return res.status(404).json({ message: "Gift not found" });
+        if (String(grant.caseId) !== String(caseData._id)) {
+          return res.status(400).json({ message: "That gift is for a different case" });
+        }
+        if (new Date(grant.expiresAt) <= new Date()) {
+          return res.status(400).json({ message: "That gift has expired" });
+        }
+        if (grant.remaining < quantityToOpen) {
+          return res.status(400).json({ message: "That gift has fewer openings left" });
+        }
+      }
+
+      const cost = grant ? 0 : caseData.price * quantityToOpen;
 
       // reserve the nonces atomically up front (never rolled back), then derive each
       // item from the case's committed range table (provably fair, one draw per open)
@@ -89,26 +107,42 @@ module.exports = (io) => {
       // charge the cost, add the items and write the ledger row together: a failed row
       // rolls the charge back, so the player is never charged without a record
       const updatedUser = await runAtomic(async (session) => {
-        const u = await User.findOneAndUpdate(
-          { _id: user._id, walletBalance: { $gte: cost } },
-          {
-            $inc: { walletBalance: -cost, xp: cost * 5 },
-            $push: { inventory: { $each: winningItems.map(toInventoryEntry) } },
-          },
-          { new: true, session }
-        );
+        const filter = { _id: user._id, walletBalance: { $gte: cost } };
+        const update = {
+          $inc: { walletBalance: -cost, xp: cost * 5 },
+          $push: { inventory: { $each: winningItems.map(toInventoryEntry) } },
+        };
+        const options = { new: true, session };
+
+        // spend the openings in the same update that hands over the items, and require
+        // the count to still cover it, so two concurrent opens cannot overdraw one grant
+        if (grant) {
+          filter.freeOpens = {
+            $elemMatch: { grantId: grant.grantId, remaining: { $gte: quantityToOpen } },
+          };
+          update.$inc["freeOpens.$[g].remaining"] = -quantityToOpen;
+          options.arrayFilters = [
+            { "g.grantId": grant.grantId, "g.remaining": { $gte: quantityToOpen } },
+          ];
+        }
+
+        const u = await User.findOneAndUpdate(filter, update, options);
         if (!u) return null;
-        await recordTransaction(
-          {
-            userId: user._id,
-            type: TX.CASE_OPEN,
-            direction: "debit",
-            amount: cost,
-            balanceAfter: u.walletBalance,
-            meta: { caseId: caseData._id, caseTitle: caseData.title, quantity: quantityToOpen },
-          },
-          session
-        );
+        // a gift open moves no coins, so it gets no ledger row: the ledger records
+        // balance changes and a zero one would only be noise
+        if (cost > 0) {
+          await recordTransaction(
+            {
+              userId: user._id,
+              type: TX.CASE_OPEN,
+              direction: "debit",
+              amount: cost,
+              balanceAfter: u.walletBalance,
+              meta: { caseId: caseData._id, caseTitle: caseData.title, quantity: quantityToOpen },
+            },
+            session
+          );
+        }
         return u;
       });
 

--- a/backend/routes/giftRoutes.js
+++ b/backend/routes/giftRoutes.js
@@ -1,0 +1,265 @@
+const express = require("express");
+const router = express.Router();
+const { isAuthenticated } = require("../middleware/authMiddleware");
+
+const User = require("../models/User");
+const Case = require("../models/Case");
+const gift = require("../utils/dailyGift");
+const { roll, TOTAL } = require("../utils/provablyFair");
+const seeds = require("../utils/seeds");
+const rolls = require("../utils/rolls");
+
+const living = (user, now = new Date()) =>
+  (user.freeOpens || []).filter((g) => g.remaining > 0 && new Date(g.expiresAt) > now);
+
+async function casesByCategory() {
+  const all = await Case.find({}).select("title image price category").lean();
+  return all.reduce((acc, c) => {
+    if (!c.category) return acc;
+    (acc[c.category] = acc[c.category] || []).push(c);
+    return acc;
+  }, {});
+}
+
+// the categories a player can choose between, each with the table it would spin and a
+// cover to show. the table is public on purpose: the odds are the pitch.
+async function state(userId) {
+  const user = await User.findById(userId);
+  if (!user) return null;
+
+  const now = new Date();
+  const grouped = await casesByCategory();
+  const streak = user.giftStreak || 0;
+  const byId = new Map(
+    Object.values(grouped)
+      .flat()
+      .map((c) => [String(c._id), c])
+  );
+
+  const categories = Object.entries(grouped)
+    .map(([category, cases]) => {
+      const table = gift.tableFor(cases);
+      if (!table.length) return null;
+      const weights = gift.weightsFor(table, streak);
+      const total = weights.reduce((a, b) => a + b, 0);
+      return {
+        category,
+        cover: table[table.length - 1].image,
+        eligible: gift.eligible(cases).length,
+        expectedValue: Math.round(gift.expectedValue(table, streak)),
+        slots: table.map((s, i) => ({
+          caseId: s.caseId,
+          title: s.title,
+          image: s.image,
+          price: s.price,
+          opens: s.opens,
+          value: s.value,
+          chance: Number(((weights[i] / total) * 100).toFixed(2)),
+        })),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.category.localeCompare(b.category));
+
+  const wheel = gift.topSlotFor(user.level || 0);
+
+  // the streak's whole effect stated as one number: how much likelier it makes the rarest
+  // prize, which is exactly the weight multiplier it puts on the top slot of either wheel
+  const rareBoost = (days) => Number((1 + gift.streakTilt(days) * 2).toFixed(2));
+  const streakMax = Math.ceil(gift.MAX_STREAK_TILT / gift.STREAK_STEP);
+
+  return {
+    level: user.level || 0,
+    streak,
+    streakTilt: gift.streakTilt(streak),
+    // the locked rungs stay visible: they are the reason to keep levelling
+    topSlot: wheel.map((t) => ({
+      multiplier: t.multiplier,
+      minLevel: t.minLevel,
+      locked: t.locked,
+      chance: (() => {
+        const w = gift.topSlotWeights(wheel, streak);
+        const total = w.reduce((a, b) => a + b, 0);
+        const i = wheel.indexOf(t);
+        return total ? Number(((w[i] / total) * 100).toFixed(2)) : 0;
+      })(),
+    })),
+    topSlotAverage: Number(gift.topSlotAverage(user.level || 0, streak).toFixed(2)),
+    maxStreakTilt: gift.MAX_STREAK_TILT,
+    streakMax,
+    rareBoost: rareBoost(streak),
+    atBestStreak: {
+      rareBoost: rareBoost(streakMax),
+      topSlotAverage: Number(gift.topSlotAverage(user.level || 0, streakMax).toFixed(2)),
+    },
+    canSpin: !user.giftNextAt || new Date(user.giftNextAt) <= now,
+    nextAt: user.giftNextAt || null,
+    categories,
+    grants: living(user, now)
+      .sort((a, b) => new Date(a.expiresAt) - new Date(b.expiresAt))
+      .map((g) => ({
+        grantId: g.grantId,
+        caseId: String(g.caseId),
+        title: byId.get(String(g.caseId))?.title || "",
+        image: byId.get(String(g.caseId))?.image || "",
+        remaining: g.remaining,
+        expiresAt: g.expiresAt,
+      })),
+  };
+}
+
+router.get("/", isAuthenticated, async (req, res) => {
+  const s = await state(req.user._id);
+  if (!s) return res.status(404).json({ message: "User not found" });
+  res.json(s);
+});
+
+// only whether a spin is waiting. the navbar asks on every page, and it has no business
+// building every category's prize table to light up a badge
+router.get("/status", isAuthenticated, async (req, res) => {
+  const user = await User.findById(req.user._id).select("giftNextAt");
+  if (!user) return res.status(404).json({ message: "User not found" });
+  const now = new Date();
+  res.json({
+    canSpin: !user.giftNextAt || new Date(user.giftNextAt) <= now,
+    nextAt: user.giftNextAt || null,
+  });
+});
+
+// just the unspent grants, so the case page can show what is free there without paying
+// for the whole prize-table computation
+router.get("/grants", isAuthenticated, async (req, res) => {
+  const user = await User.findById(req.user._id).select("freeOpens");
+  if (!user) return res.status(404).json({ message: "User not found" });
+  const caseId = req.query.caseId ? String(req.query.caseId) : null;
+  const mine = living(user)
+    .filter((g) => !caseId || String(g.caseId) === caseId)
+    .sort((a, b) => new Date(a.expiresAt) - new Date(b.expiresAt));
+
+  const cases = await Case.find({ _id: { $in: mine.map((g) => g.caseId) } })
+    .select("title image")
+    .lean();
+  const byId = new Map(cases.map((c) => [String(c._id), c]));
+
+  res.json(
+    mine.map((g) => ({
+      grantId: g.grantId,
+      caseId: String(g.caseId),
+      title: byId.get(String(g.caseId))?.title || "",
+      image: byId.get(String(g.caseId))?.image || "",
+      remaining: g.remaining,
+      expiresAt: g.expiresAt,
+    }))
+  );
+});
+
+router.post("/spin", isAuthenticated, async (req, res) => {
+  try {
+    const category = String(req.body?.category || "");
+    const user = await User.findById(req.user._id);
+    if (!user) return res.status(404).json({ message: "User not found" });
+
+    const now = new Date();
+    if (user.giftNextAt && new Date(user.giftNextAt) > now) {
+      return res.status(400).json({ message: "You already opened today's gift" });
+    }
+
+    const grouped = await casesByCategory();
+    const cases = grouped[category];
+    if (!cases) return res.status(400).json({ message: "Unknown category" });
+
+    const table = gift.tableFor(cases);
+    if (!table.length) return res.status(400).json({ message: "Nothing to give in that category" });
+
+    const streak = gift.nextStreak(user.giftStreak, user.giftLastAt, now);
+
+    // two draws, one per stage, so each is independently verifiable on the fair page
+    const reserved = await seeds.reserveNonces(user._id, 2);
+    const reelRoll = roll(reserved.serverSeed, reserved.clientSeed, reserved.startNonce);
+    const topRoll = roll(reserved.serverSeed, reserved.clientSeed, reserved.startNonce + 1);
+
+    const won = gift.pickSlot(table, reelRoll, TOTAL, streak);
+    const wheel = gift.topSlotFor(user.level || 0);
+
+  // the streak's whole effect stated as one number: how much likelier it makes the rarest
+  // prize, which is exactly the weight multiplier it puts on the top slot of either wheel
+  const rareBoost = (days) => Number((1 + gift.streakTilt(days) * 2).toFixed(2));
+  const streakMax = Math.ceil(gift.MAX_STREAK_TILT / gift.STREAK_STEP);
+    const top = gift.pickTopSlot(wheel, topRoll, TOTAL, streak);
+    const opens = won.opens * top.multiplier;
+
+    const expiresAt = new Date(now.getTime() + gift.GRANT_TTL_MS);
+
+    // winning the same case twice tops the grant up instead of opening a rival one, so the
+    // case page has a single number to show and to spend
+    const existing = living(user, now).find((g) => String(g.caseId) === String(won.caseId));
+    const update = {
+      $set: {
+        giftNextAt: new Date(now.getTime() + gift.CLAIM_WINDOW_MS),
+        giftLastAt: now,
+        giftStreak: streak,
+      },
+    };
+    const options = { new: true };
+    if (existing) {
+      update.$inc = { "freeOpens.$[g].remaining": opens };
+      update.$set["freeOpens.$[g].expiresAt"] = expiresAt;
+      options.arrayFilters = [{ "g.grantId": existing.grantId }];
+    } else {
+      update.$push = { freeOpens: { caseId: won.caseId, remaining: opens, wonAt: now, expiresAt } };
+    }
+
+    // the cooldown, the streak and the grant land together, and the cooldown is keyed on
+    // giftNextAt so a crash between them cannot hand out a second spin
+    const updated = await User.findOneAndUpdate(
+      { _id: user._id, $or: [{ giftNextAt: { $exists: false } }, { giftNextAt: { $lte: now } }] },
+      update,
+      options
+    );
+    if (!updated) return res.status(400).json({ message: "You already opened today's gift" });
+
+    const granted = existing
+      ? updated.freeOpens.find((g) => g.grantId === existing.grantId)
+      : updated.freeOpens[updated.freeOpens.length - 1];
+
+    for (const [nonce, value] of [
+      [reserved.startNonce, reelRoll],
+      [reserved.startNonce + 1, topRoll],
+    ]) {
+      await rolls.recordRoll({
+        game: "gift",
+        userId: user._id,
+        seedId: reserved.seedId,
+        clientSeed: reserved.clientSeed,
+        serverSeedHash: reserved.serverSeedHash,
+        nonce,
+        roll: value,
+        total: TOTAL,
+        algoVersion: gift.GIFT_ALGO_VERSION,
+      });
+    }
+
+    res.json({
+      category,
+      won: {
+        caseId: won.caseId,
+        title: won.title,
+        image: won.image,
+        opens: won.opens,
+        value: won.value,
+      },
+      topSlot: { multiplier: top.multiplier, hit: top.multiplier > 1 },
+      opens,
+      grantId: granted.grantId,
+      grantRemaining: granted.remaining,
+      expiresAt: granted.expiresAt,
+      streak,
+      state: await state(user._id),
+    });
+  } catch (err) {
+    console.error("gift spin:", err.message);
+    res.status(500).json({ message: "Could not open the gift" });
+  }
+});
+
+module.exports = router;

--- a/backend/utils/dailyGift.js
+++ b/backend/utils/dailyGift.js
@@ -1,0 +1,236 @@
+// the daily gift. the player picks a category, spins once, and wins free openings of a
+// specific case from that category. picking your own franchise has to cost you nothing,
+// so every category's table is built to roughly the same expected value: cheap
+// categories pay it as volume, expensive ones as rarity.
+//
+// see .docs/retention.md for the churn numbers this exists to move.
+
+const GIFT_ALGO_VERSION = 1;
+
+// no case dearer than this is ever in a table. counter-strike runs to 1,324,450 KP and
+// the median player holds 175, so a grail drop would be an economy event, not a reward.
+const MAX_CASE_PRICE = 2000;
+
+// no single prize hands over more than this many openings, whatever the arithmetic says.
+// it has to clear the dearest slot divided by the cheapest category's case price, or the
+// top slots collapse into each other and the jackpot stops being one.
+const MAX_OPENS = 99;
+
+// the six slots, cheapest to rarest. `target` is the KP the slot aims to be worth and
+// `weight` its share of the roll space; together they set the expected value per spin.
+const SLOTS = [
+  { target: 200, weight: 40 },
+  { target: 400, weight: 27 },
+  { target: 800, weight: 18 },
+  { target: 1400, weight: 9 },
+  { target: 2000, weight: 5 },
+  { target: 2500, weight: 1 },
+];
+
+// the second stage. after the reel lands, this multiplies what it gave. the two levers
+// do deliberately different jobs: the streak decides how OFTEN it fires, the level
+// decides how HIGH it can go. a locked tier a player can see beats a hidden advantage,
+// which is why level gates whole multipliers rather than nudging odds.
+const TOP_SLOT = [
+  { multiplier: 1, weight: 60, minLevel: 0 },
+  { multiplier: 2, weight: 25, minLevel: 0 },
+  { multiplier: 3, weight: 10, minLevel: 10 },
+  { multiplier: 5, weight: 4, minLevel: 30 },
+  { multiplier: 10, weight: 1, minLevel: 60 },
+  // the billboard rung. two accounts have ever passed level 100, and at this weight it
+  // lands roughly never, which is the point: it is there to be seen, not won
+  { multiplier: 25, weight: 0.3, minLevel: 100 },
+];
+
+const CLAIM_WINDOW_MS = 24 * 60 * 60 * 1000;
+// a grant dies with the day it was won, which is the whole reason to come back tomorrow
+const GRANT_TTL_MS = 24 * 60 * 60 * 1000;
+
+// a streak shifts weight toward the better slots. it never raises what a slot is worth:
+// a growing ceiling turns the daily into a power-up and the economy wears it.
+const STREAK_STEP = 0.06;
+const MAX_STREAK_TILT = 0.6;
+
+const streakTilt = (streak) => Math.min((streak || 0) * STREAK_STEP, MAX_STREAK_TILT);
+
+const eligible = (cases) =>
+  cases
+    .filter((c) => Number.isFinite(c.price) && c.price > 0 && c.price <= MAX_CASE_PRICE)
+    .sort((a, b) => a.price - b.price);
+
+// walk the category's cases from cheapest to dearest as the slots get rarer, so a table
+// shows off the whole category instead of naming the same case six times
+function caseForSlot(sorted, slotIndex, slotCount) {
+  if (sorted.length === 1) return sorted[0];
+  const span = (slotIndex * (sorted.length - 1)) / (slotCount - 1);
+  return sorted[Math.min(sorted.length - 1, Math.floor(span))];
+}
+
+// a rarer slot has to be worth more than the one below it, or there is nothing to
+// almost hit. rounding can invert them: a dear case at one opening can come to less
+// than a cheaper case at several, so the order is repaired rather than hoped for.
+function enforceRising(table) {
+  for (let i = 1; i < table.length; i++) {
+    const prev = table[i - 1];
+    const cur = table[i];
+    if (cur.value > prev.value) continue;
+
+    const needed = Math.floor(prev.value / cur.price) + 1;
+    if (needed <= MAX_OPENS) {
+      cur.opens = needed;
+    } else {
+      // this case cannot outgrow the slot below even at the cap, so carry the cheaper
+      // one up and pay an extra opening instead
+      Object.assign(cur, { caseId: prev.caseId, title: prev.title, image: prev.image, price: prev.price });
+      cur.opens = Math.min(MAX_OPENS, prev.opens + 1);
+    }
+    cur.value = cur.price * cur.opens;
+  }
+  return table;
+}
+
+// build one category's prize table. every slot names a case and how many free openings
+// of it the player wins.
+function tableFor(cases) {
+  const sorted = eligible(cases);
+  if (!sorted.length) return [];
+
+  const table = SLOTS.map((slot, i) => {
+    const picked = caseForSlot(sorted, i, SLOTS.length);
+    const opens = Math.max(1, Math.min(MAX_OPENS, Math.round(slot.target / picked.price)));
+    return {
+      caseId: String(picked._id),
+      title: picked.title,
+      image: picked.image,
+      price: picked.price,
+      opens,
+      value: picked.price * opens,
+      weight: slot.weight,
+    };
+  });
+
+  return enforceRising(table);
+}
+
+// what a spin is worth on average, which is the number that has to stay comparable
+// across categories or the choice is theatre
+function expectedValue(table, streak = 0) {
+  const w = weightsFor(table, streak);
+  const total = w.reduce((a, b) => a + b, 0);
+  return total ? table.reduce((sum, s, i) => sum + (w[i] / total) * s.value, 0) : 0;
+}
+
+// the streak leaves the cheap slots alone and lifts the rare ones
+function weightsFor(table, streak = 0) {
+  const tilt = streakTilt(streak);
+  const last = table.length - 1;
+  return table.map((s, i) => {
+    const rank = last ? i / last : 0; // 0 for the commonest slot, 1 for the rarest
+    return s.weight * (1 + tilt * rank * 2);
+  });
+}
+
+// the whole wheel, with the rungs the player has not earned marked rather than hidden:
+// seeing 10x locked behind level 60 is the reason to keep levelling
+function topSlotFor(level = 0) {
+  return TOP_SLOT.map((t) => ({ ...t, locked: (level || 0) < t.minLevel }));
+}
+
+// the streak lifts every multiplier above 1x, so the odds of landing on nothing fall
+function topSlotWeights(wheel, streak = 0) {
+  const tilt = streakTilt(streak);
+  const live = wheel.filter((t) => !t.locked);
+  const last = live.length - 1;
+  return wheel.map((t) => {
+    if (t.locked) return 0;
+    const rank = last ? live.indexOf(t) / last : 0;
+    return t.weight * (1 + tilt * rank * 2);
+  });
+}
+
+function pickTopSlot(wheel, rollValue, total, streak = 0) {
+  const w = topSlotWeights(wheel, streak);
+  const sum = w.reduce((a, b) => a + b, 0);
+  if (!sum) return wheel[0];
+  const scaled = ((rollValue - 1) / total) * sum;
+  let acc = 0;
+  for (let i = 0; i < wheel.length; i++) {
+    acc += w[i];
+    if (w[i] > 0 && scaled < acc) return wheel[i];
+  }
+  return wheel.find((t) => !t.locked) || wheel[0];
+}
+
+// what the top slot multiplies the reel by on average, for the copy and the tests
+function topSlotAverage(level = 0, streak = 0) {
+  const wheel = topSlotFor(level);
+  const w = topSlotWeights(wheel, streak);
+  const sum = w.reduce((a, b) => a + b, 0);
+  return sum ? wheel.reduce((acc, t, i) => acc + (w[i] / sum) * t.multiplier, 0) : 1;
+}
+
+// the most a single day can ever pay: the best reel prize times the best multiplier.
+// bounded on purpose, so nobody wakes up a millionaire.
+function ceilingFor(table, level = 0) {
+  if (!table.length) return 0;
+  const best = Math.max(...table.map((s) => s.value));
+  const wheel = topSlotFor(level).filter((t) => !t.locked);
+  return best * Math.max(...wheel.map((t) => t.multiplier));
+}
+
+// maps a roll in 1..total onto the weighted table
+function pickSlot(table, rollValue, total, streak = 0) {
+  const w = weightsFor(table, streak);
+  const sum = w.reduce((a, b) => a + b, 0);
+  const scaled = ((rollValue - 1) / total) * sum;
+  let acc = 0;
+  for (let i = 0; i < table.length; i++) {
+    acc += w[i];
+    if (scaled < acc) return table[i];
+  }
+  return table[table.length - 1];
+}
+
+// consecutive-day counter on UTC calendar days, so it is not clock-drift sensitive
+function nextStreak(streak, lastAt, now = new Date()) {
+  if (!lastAt) return 1;
+  const day = (d) => Math.floor(new Date(d).getTime() / 86400000);
+  const gap = day(now) - day(lastAt);
+  if (gap <= 0) return streak || 1;
+  if (gap === 1) return (streak || 0) + 1;
+  return 1;
+}
+
+const claimableAt = (last) => (last ? new Date(new Date(last).getTime() + CLAIM_WINDOW_MS) : null);
+const isClaimable = (last, now = new Date()) => {
+  const at = claimableAt(last);
+  return !at || at <= now;
+};
+
+module.exports = {
+  GIFT_ALGO_VERSION,
+  TOP_SLOT,
+  topSlotFor,
+  topSlotWeights,
+  pickTopSlot,
+  topSlotAverage,
+  ceilingFor,
+  MAX_CASE_PRICE,
+  MAX_OPENS,
+  SLOTS,
+  CLAIM_WINDOW_MS,
+  GRANT_TTL_MS,
+  STREAK_STEP,
+  MAX_STREAK_TILT,
+  streakTilt,
+  eligible,
+  caseForSlot,
+  enforceRising,
+  tableFor,
+  expectedValue,
+  weightsFor,
+  pickSlot,
+  nextStreak,
+  claimableAt,
+  isClaimable,
+};

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -14,6 +14,7 @@ import Mines from "./pages/Mines";
 import Hilo from "./pages/Hilo";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
 import Unsubscribe from "./pages/About/Unsubscribe"
+import Gift from "./pages/Gift"
 import ItemPage from "./pages/Market/ItemPage";
 import Battles from "./pages/Battles/Battles";
 import BattleRoom from "./pages/Battles/BattleRoom";
@@ -44,6 +45,7 @@ const defaultRoutes = (
     <Route path="/backoffice" element={<Backoffice />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/unsubscribe" element={<Unsubscribe />} />
+    <Route path="/gift" element={<Gift />} />
   </>
 );
 

--- a/src/components/Roulette.tsx
+++ b/src/components/Roulette.tsx
@@ -8,9 +8,12 @@ interface Roulette {
   spin: boolean;
   className?: string;
   direction?: "horizontal" | "vertical";
+  // optional per-item badge. the daily gift needs the prize size on the face of each
+  // slot; cases and battles pass nothing and render exactly as before.
+  overlay?: (item: BasicItem) => React.ReactNode;
 }
 
-const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, direction = "horizontal" }) => {
+const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, direction = "horizontal", overlay }) => {
   const [rouletteItems, setRouletteItems] = useState<BasicItem[]>([]);
   const [translateValue, setTranslateValue] = useState<string>("-6180px");
   const rouletteRef = useRef<HTMLDivElement | null>(null);
@@ -90,6 +93,7 @@ const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, dire
               alt={item && item.name}
               className={`object-cover w-full h-full`}
             />
+            {overlay && overlay(item)}
           </div>
         ))}
         <style>{`

--- a/src/components/header/GiftTag.tsx
+++ b/src/components/header/GiftTag.tsx
@@ -1,0 +1,11 @@
+// the indicator beside the daily gift link. it pings only while a spin is unclaimed.
+const GiftTag = () => (
+  <span className="relative -ml-1 self-start inline-flex items-center">
+    <span className="absolute inset-0 animate-ping rounded bg-accent-gold opacity-75" />
+    <span className="relative rounded bg-accent-gold px-1 py-px text-[8px] font-extrabold leading-none tracking-[0.08em] text-[#2a2100]">
+      FREE
+    </span>
+  </span>
+);
+
+export default GiftTag;

--- a/src/components/header/Navbar/Navbar.tsx
+++ b/src/components/header/Navbar/Navbar.tsx
@@ -11,10 +11,12 @@ import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { BsCoin } from "react-icons/bs";
 import { SlPlane } from "react-icons/sl";
 import { GiUpgrade, GiCrossedSwords } from 'react-icons/gi';
-import { TbCat, TbGridDots } from "react-icons/tb";
+import { TbCat } from "react-icons/tb";
 import { toast } from "react-toastify";
-import { FaBars } from 'react-icons/fa';
+import { FaBars, FaGift } from 'react-icons/fa';
 import RightContent from "./RightContent";
+import GiftTag from "../GiftTag";
+import useGiftReady from "../useGiftReady";
 
 interface Navbar {
   openNotifications: boolean;
@@ -28,6 +30,7 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
   const [loading, setLoading] = useState<boolean>(true);
 
   const { isLogged, toggleLogin, toogleUserData, userData, openUserFlow, toogleUserFlow } = useContext(UserContext);
+  const giftReady = useGiftReady();
 
   const handleHover = () => {
     setIsHovering(!isHovering);
@@ -64,7 +67,7 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
   };
 
 
-  const links = [
+  const links: { name: string; path: string; icon: JSX.Element; badge?: JSX.Element }[] = [
     {
       name: "Market",
       path: "/marketplace",
@@ -91,9 +94,10 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
       icon: <TbCat className="text-2xl" />,
     },
     {
-      name: "Plinko",
-      path: "/plinko",
-      icon: <TbGridDots className="text-2xl" />,
+      name: "Daily Gift",
+      path: "/gift",
+      icon: <FaGift className="text-2xl" />,
+      badge: giftReady ? <GiftTag /> : undefined,
     },
     {
       name: "Case Battles",
@@ -169,6 +173,7 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
                   <span className="text-white hover:text-gray-200 transition-all ">
                     {link.name}
                   </span>
+                  {link.badge}
                 </Link>
                 ))}
               </div>

--- a/src/components/header/Sidebar.tsx
+++ b/src/components/header/Sidebar.tsx
@@ -2,13 +2,15 @@ import { BsCoin } from "react-icons/bs";
 import { GiUpgrade, GiCrossedSwords } from "react-icons/gi";
 import { MdOutlineSell, MdOutlineAdminPanelSettings } from "react-icons/md";
 import { SlPlane } from "react-icons/sl";
-import { FaHome } from "react-icons/fa";
+import { FaHome, FaGift } from "react-icons/fa";
 import { Link } from "react-router-dom";
-import { TbCat, TbGridDots } from "react-icons/tb";
+import { TbCat } from "react-icons/tb";
 import ClaimBonus from "../header/ClaimBonus";
 import { useContext } from "react";
 import UserContext from "../../UserContext";
 import Monetary from "../Monetary";
+import GiftTag from "./GiftTag";
+import useGiftReady from "./useGiftReady";
 
 interface Sidebar {
     closeSidebar: () => void;
@@ -16,9 +18,10 @@ interface Sidebar {
 
 const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
     const { userData } = useContext(UserContext);
+    const giftReady = useGiftReady();
 
 
-    const links = [
+    const links: { name: string; path: string; icon: JSX.Element; badge?: JSX.Element }[] = [
         {
             name: "Home",
             path: "/",
@@ -50,9 +53,10 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
             icon: <TbCat className="text-2xl" />,
         },
         {
-            name: "Plinko",
-            path: "/plinko",
-            icon: <TbGridDots className="text-2xl" />,
+            name: "Daily Gift",
+            path: "/gift",
+            icon: <FaGift className="text-2xl" />,
+            badge: giftReady ? <GiftTag /> : undefined,
         },
         {
             name: "Case Battles",
@@ -104,6 +108,7 @@ const Sidebar: React.FC<Sidebar> = ({ closeSidebar }) => {
                                 <div className="flex items-center gap-4 p-2 text-white">
                                     {link.icon}
                                     <p className="">{link.name}</p>
+                                    {link.badge}
                                 </div>
                             </Link>
                         ))}

--- a/src/components/header/useGiftReady.ts
+++ b/src/components/header/useGiftReady.ts
@@ -1,0 +1,37 @@
+import { useContext, useEffect, useState } from "react";
+import UserContext from "../../UserContext";
+import { GIFT_CLAIMED_EVENT, getGiftStatus } from "../../services/gift/GiftService";
+
+// whether a daily gift is waiting, so the nav can flag it without every page asking.
+// it goes dark the moment the gift is claimed and lights up again when the cooldown ends.
+export const useGiftReady = (): boolean => {
+  const { userData } = useContext(UserContext);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (!userData?.id) return setReady(false);
+
+    let timer: ReturnType<typeof setTimeout>;
+    const check = () =>
+      getGiftStatus()
+        .then((s) => {
+          setReady(s.canSpin);
+          const wait = s.nextAt ? new Date(s.nextAt).getTime() - Date.now() : 0;
+          if (!s.canSpin && wait > 0) timer = setTimeout(check, wait + 1000);
+        })
+        .catch(() => setReady(false));
+
+    const claimed = () => setReady(false);
+    window.addEventListener(GIFT_CLAIMED_EVENT, claimed);
+    check();
+
+    return () => {
+      window.removeEventListener(GIFT_CLAIMED_EVENT, claimed);
+      clearTimeout(timer);
+    };
+  }, [userData?.id]);
+
+  return ready;
+};
+
+export default useGiftReady;

--- a/src/pages/CasePage/CasePage.tsx
+++ b/src/pages/CasePage/CasePage.tsx
@@ -13,6 +13,10 @@ import { BasicItem } from "../../components/Types";
 import QuantityButton from "../../components/QuantityButton";
 import RouletteContainer from "./RoulleteContainer";
 import Monetary from '../../components/Monetary';
+import { FaGift } from "react-icons/fa";
+import { getGrants } from "../../services/gift/GiftService";
+import type { GiftGrant } from "../../services/gift/GiftService";
+import FreeOpenings from "./FreeOpenings";
 import { applyMeta } from "../../seo/meta";
 import { caseMeta } from "../../seo/caseMeta";
 
@@ -26,6 +30,7 @@ const CasePage = () => {
   const [animationAux2, setAnimationAux2] = useState<boolean>(false);
   const [loadingButton, setLoadingButton] = useState<boolean>(false);
   const [quantity, setQuantity] = useState<number>(1);
+  const [grant, setGrant] = useState<GiftGrant | null>(null);
 
   const { userData, toogleUserFlow, toogleUserData } = useContext(UserContext);
   const [sellingAll, setSellingAll] = useState<boolean>(false);
@@ -47,11 +52,22 @@ const CasePage = () => {
       });
   };
 
+  // a daily-gift grant pays for this case, so the page has to know about it before the
+  // open button decides whether it is charging anything
+  const getGrant = () => {
+    if (!userData?.id) return setGrant(null);
+    getGrants(id)
+      .then((gs) => setGrant(gs[0] || null))
+      .catch(() => setGrant(null));
+  };
+
   useEffect(() => {
     getCaseInfo();
     //scroll to top
     window.scrollTo(0, 0);
   }, []);
+
+  useEffect(getGrant, [userData?.id, id]);
 
   // prerender bakes the real name into the html; PageMeta's generic /case/ entry would
   // overwrite it on hydration, so put it back once the case itself has loaded
@@ -106,6 +122,9 @@ const CasePage = () => {
 
   const openedSellTotal = openedItems.reduce((s, i) => s + (i.sellValue || 0), 0);
 
+  // the gift covers the open only while it has enough left for the chosen quantity
+  const freeNow = !!grant && grant.remaining >= quantity;
+
   const openCase = async () => {
 
     if (userData == null) {
@@ -116,8 +135,9 @@ const CasePage = () => {
     setLoadingButton(true);
 
     try {
-      const response = await openBox(id, quantity);
+      const response = await openBox(id, quantity, freeNow ? grant?.grantId : undefined);
       setOpenedItems(response.items);
+      if (freeNow) getGrant();
     } catch (error: any) {
       console.log(error);
       setLoadingButton(false);
@@ -145,6 +165,12 @@ const CasePage = () => {
           {loading ? <Skeleton width={200} height={30} /> : data && data.title}
         </h1>
 
+        {grant && !started && (
+          <div className="mb-2">
+            <FreeOpenings grant={grant} />
+          </div>
+        )}
+
         <RouletteContainer started={started} showPrize={showPrize} loading={loading} data={data} openedItems={openedItems} animationAux={animationAux} animationAux2={animationAux2} quantity={quantity} />
         <div
           className={`flex flex-col md:flex-row justify-center items-center gap-4 w-68 mt-8  ${started ? "opacity-0" : "opacity-100"} transition-all`}
@@ -155,14 +181,19 @@ const CasePage = () => {
           ) : (
             <div className="w-60 ml-0 md:ml-20">
               <MainButton
-                text={userData == null ? "Sign in to play" : <div className="flex items-center justify-center text-base">
+                text={userData == null ? "Sign in to play" : freeNow ? (
+                  <div className="flex items-center justify-center gap-1 text-base">
+                    <FaGift />
+                    <span>Open free{quantity > 1 ? ` x${quantity}` : ""}</span>
+                  </div>
+                ) : <div className="flex items-center justify-center text-base">
                 <span className="mr-1">Open case - </span>{<Monetary value={data.price * quantity}/>}
                 </div>}
                 onClick={openCase}
                 loading={loadingButton}
                 disabled={
                   loadingButton ||
-                  (userData && data.price > userData.walletBalance)
+                  (!freeNow && userData && data.price > userData.walletBalance)
                 }
               />
             </div>

--- a/src/pages/CasePage/FreeOpenings.tsx
+++ b/src/pages/CasePage/FreeOpenings.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { FaGift } from "react-icons/fa";
+import { countdown } from "../Gift/Gift.services";
+import type { GiftGrant } from "../../services/gift/GiftService";
+
+interface FreeOpeningsProps {
+  grant: GiftGrant;
+}
+
+// what the daily gift left on this case, kept beside the open button so the free
+// openings are visible where they are spent
+const FreeOpenings: React.FC<FreeOpeningsProps> = ({ grant }) => {
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    const t = setInterval(() => tick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  return (
+    <div className="notched bg-accent-gold p-px">
+      <div className="notched flex items-center gap-3 bg-[#19172D] px-5 py-3">
+        <FaGift className="text-xl text-accent-gold" />
+        <div className="flex flex-col leading-tight">
+          <span className="font-bold">
+            {grant.remaining} free {grant.remaining === 1 ? "opening" : "openings"} on this case
+          </span>
+          <span className="font-mono text-[11px] text-[#84819a]">
+            expires in {countdown(grant.expiresAt) || "moments"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FreeOpenings;

--- a/src/pages/Gift/Gift.services.ts
+++ b/src/pages/Gift/Gift.services.ts
@@ -1,0 +1,43 @@
+import type { BasicItem } from "../../components/Types";
+import type { GiftSlot } from "./Gift.types";
+
+export const kp = (n: number) => Math.round(n).toLocaleString("en-US");
+
+// 1.12 reads as 1.1x, 2 as 2x: the trailing zero makes it look like a price
+export const boost = (n: number) => `${Number(n.toFixed(1))}x`;
+
+export function countdown(until?: string | null, now: number = Date.now()): string {
+  if (!until) return "";
+  const ms = new Date(until).getTime() - now;
+  if (ms <= 0) return "";
+  const s = Math.floor(ms / 1000);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(Math.floor(s / 3600))}:${pad(Math.floor((s % 3600) / 60))}:${pad(s % 60)}`;
+}
+
+// the shared Roulette renders BasicItems, so a prize slot borrows that shape: the case art
+// is the picture and the slot's rank becomes the rarity colour on its bottom border
+const asItem = (slot: GiftSlot, rank: number, key: string): BasicItem => ({
+  case: slot.caseId,
+  image: slot.image,
+  name: `${slot.opens}x ${slot.title}`,
+  rarity: Math.min(5, rank + 1),
+  _id: slot.caseId,
+  uniqueId: key,
+});
+
+export const reelItems = (slots: GiftSlot[], landing?: BasicItem | null): BasicItem[] => {
+  const faces = slots.map((s, i) => asItem(s, i, `slot-${i}`));
+  return landing ? [landing, ...faces] : faces;
+};
+
+export const wonItem = (slots: GiftSlot[], caseId: string, opens: number): BasicItem => {
+  const rank = Math.max(0, slots.findIndex((s) => s.caseId === caseId && s.opens === opens));
+  const slot = slots[rank] || slots[0];
+  return asItem({ ...slot, opens }, rank, "won");
+};
+
+// the streak's effect, stated as the odds it moves rather than a raw tilt number
+export const chargedRungs = (
+  rungs: { multiplier: number; chance: number; locked: boolean; minLevel: number }[]
+) => rungs.filter((r) => !r.locked);

--- a/src/pages/Gift/Gift.types.ts
+++ b/src/pages/Gift/Gift.types.ts
@@ -1,0 +1,30 @@
+import type { BasicItem } from "../../components/Types";
+import type {
+  GiftCategory,
+  GiftGrant,
+  GiftSlot,
+  GiftState,
+  SpinResult,
+  TopSlotRung,
+} from "../../services/gift/GiftService";
+
+export type { GiftCategory, GiftGrant, GiftSlot, GiftState, SpinResult, TopSlotRung };
+
+// picker -> the chosen category with its odds -> the reel -> what it paid
+export type GiftStage = "picking" | "charging" | "spinning" | "won";
+
+export interface GiftViewProps {
+  loading: boolean;
+  state: GiftState | null;
+  stage: GiftStage;
+  category: GiftCategory | null;
+  reel: BasicItem[];
+  landing: BasicItem | null;
+  spinning: boolean;
+  pending: boolean;
+  result: SpinResult | null;
+  onPick: (category: string) => void;
+  onBack: () => void;
+  onSpin: () => void;
+  onOpen: (caseId: string) => void;
+}

--- a/src/pages/Gift/Gift.view.tsx
+++ b/src/pages/Gift/Gift.view.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useState } from "react";
+import Skeleton from "react-loading-skeleton";
+import Title from "../../components/Title";
+import Roulette from "../../components/Roulette";
+import GameButton from "../../components/game/GameButton";
+import { boost, countdown, kp } from "./Gift.services";
+import type { GiftViewProps, TopSlotRung } from "./Gift.types";
+
+const useTick = () => {
+  const [, set] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => set((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, []);
+};
+
+// counts the reel's figure up to what the level multiplied it to, so the player watches
+// their level do the work instead of reading about it
+const usePump = (from: number, to: number, run: boolean) => {
+  const [shown, setShown] = useState(from);
+  useEffect(() => {
+    if (!run || to <= from) return setShown(to);
+    setShown(from);
+    let id: ReturnType<typeof setInterval>;
+    // the case lands first, then the level visibly pushes the number up
+    const hold = setTimeout(() => {
+      const started = Date.now();
+      id = setInterval(() => {
+        const t = Math.min(1, (Date.now() - started) / 1100);
+        setShown(Math.round(from + (to - from) * (1 - Math.pow(1 - t, 3))));
+        if (t >= 1) clearInterval(id);
+      }, 40);
+    }, 600);
+    return () => {
+      clearTimeout(hold);
+      clearInterval(id);
+    };
+  }, [from, to, run]);
+  return shown;
+};
+
+// the top slot is drawn on every spin, so the row runs across its rungs and settles on
+// the one that came up, 1x included
+const useTopSlotCursor = (count: number, spinning: boolean, landedAt: number | null) => {
+  const [cursor, setCursor] = useState(-1);
+  useEffect(() => {
+    if (landedAt !== null) return setCursor(landedAt);
+    if (!spinning || count === 0) return setCursor(-1);
+    let step = 0;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      setCursor(step % count);
+      step += 1;
+      // from a blur to a crawl, so it reads as running down rather than stopping dead
+      timer = setTimeout(tick, 70 + step * 6);
+    };
+    tick();
+    return () => clearTimeout(timer);
+  }, [count, spinning, landedAt]);
+  return cursor;
+};
+
+interface RungProps {
+  rung: TopSlotRung;
+  charging: boolean;
+  active: boolean;
+  landed: boolean;
+}
+
+const rungEdge = (rung: TopSlotRung, active: boolean, landed: boolean) => {
+  if (landed) return "#FFCC00";
+  if (active) return "#FFFFFF";
+  if (rung.locked) return "#2A2840";
+  return rung.multiplier > 1 ? "#4F46E5" : "#3A365A";
+};
+
+const Rung = ({ rung, charging, active, landed }: RungProps) => (
+  <div
+    className={`flex-1 py-3 text-center transition-all ${rung.locked && !active && !landed ? "opacity-50" : ""} ${
+      charging && !rung.locked && rung.multiplier > 1 ? "gift-charge" : ""
+    } ${landed ? "gift-slam bg-[#2a2340]" : active ? "-translate-y-1 bg-[#241f3b]" : "bg-surface-nav"}`}
+    style={{ borderTop: `3px solid ${rungEdge(rung, active, landed)}` }}
+  >
+    <div
+      className={`text-lg font-extrabold ${
+        landed || active ? "text-white" : rung.locked || rung.multiplier === 1 ? "text-ink-faint" : "text-white"
+      }`}
+    >
+      {rung.multiplier}x
+    </div>
+    <div className="mt-0.5 text-[10px] text-ink-muted">
+      {rung.locked ? `Level ${rung.minLevel}` : rung.multiplier === 1 ? "no bonus" : `${rung.chance}%`}
+    </div>
+  </div>
+);
+
+const GiftView = ({
+  loading,
+  state,
+  stage,
+  category,
+  reel,
+  landing,
+  spinning,
+  pending,
+  result,
+  onPick,
+  onBack,
+  onSpin,
+  onOpen,
+}: GiftViewProps) => {
+  useTick();
+  const pumped = usePump(result?.won.opens ?? 0, result?.opens ?? 0, !!result);
+  const rungs = state?.topSlot || [];
+  const landedAt = result ? rungs.findIndex((r) => r.multiplier === result.topSlot.multiplier) : -1;
+  const cursor = useTopSlotCursor(
+    rungs.filter((r) => !r.locked).length,
+    stage === "spinning",
+    landedAt >= 0 ? landedAt : null
+  );
+
+  if (loading) {
+    return (
+      <div className="w-full max-w-[1312px] p-8">
+        <Skeleton height={420} baseColor="#1c1a31" highlightColor="#161427" />
+      </div>
+    );
+  }
+  if (!state) return <span className="p-8 text-ink-muted">Could not load your daily gift.</span>;
+
+  const pips = Array.from({ length: state.streakMax }, (_, i) => i < state.streak);
+  const atBestStreak = state.streak >= state.streakMax;
+
+  return (
+    <div className="flex w-full max-w-[1312px] flex-col items-center px-4 pb-16 md:px-8">
+      <style>{`
+        @keyframes giftCharge {
+          0%, 100% { transform: translateY(0); box-shadow: none; }
+          50% { transform: translateY(-4px); box-shadow: 0 0 22px 0 rgba(236,168,35,0.45); }
+        }
+        .gift-charge { animation: giftCharge 1.6s ease-in-out infinite; }
+        @keyframes giftSlam {
+          0% { transform: scale(2.4); opacity: 0; }
+          45% { transform: scale(0.92); opacity: 1; }
+          65% { transform: scale(1.06); }
+          100% { transform: scale(1); opacity: 1; }
+        }
+        .gift-slam { animation: giftSlam 700ms cubic-bezier(0.2, 0, 0.1, 1) both; }
+        @keyframes giftFlare { from { opacity: 0; } to { opacity: 0.6; } }
+        .gift-flare { animation: giftFlare 900ms ease-out both; }
+      `}</style>
+
+      <Title title="Daily Gift" />
+
+      <div className="mb-8 grid w-full grid-cols-1 gap-5 lg:grid-cols-[380px_minmax(0,1fr)]">
+        <div className="notched flex flex-col gap-4 bg-surface p-6">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-ink-muted">Streak</span>
+            <span className="text-[11px] text-ink-faint">
+              {atBestStreak ? (
+                <b className="text-accent-gold">full streak</b>
+              ) : (
+                <>
+                  day <b className="text-ink-soft">{state.streak}</b> of {state.streakMax}
+                </>
+              )}
+            </span>
+          </div>
+
+          <div className="flex gap-1.5">
+            {pips.map((lit, i) => (
+              <div key={i} className={`h-1.5 flex-1 ${lit ? "bg-accent-amber" : "bg-line"}`} />
+            ))}
+          </div>
+
+          <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-ink-muted">
+            Rare prizes likelier
+          </span>
+          <div className={`flex items-end ${atBestStreak ? "justify-center" : "justify-between"}`}>
+            <div className={`flex flex-col gap-1 ${atBestStreak ? "items-center" : ""}`}>
+              <span
+                className={`text-4xl font-extrabold leading-none ${
+                  atBestStreak ? "text-accent-gold" : "text-accent-amber"
+                }`}
+              >
+                {boost(state.rareBoost)}
+              </span>
+              <span className="text-[11px] uppercase tracking-[0.14em] text-ink-faint">now</span>
+            </div>
+            {!atBestStreak && (
+              <>
+                <span className="pb-4 text-xl text-line-strong">&rarr;</span>
+                <div className="flex flex-col items-end gap-1">
+                  <span className="text-4xl font-extrabold leading-none text-accent-gold">
+                    {boost(state.atBestStreak.rareBoost)}
+                  </span>
+                  <span className="text-[11px] uppercase tracking-[0.14em] text-ink-faint">
+                    day {state.streakMax}
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="notched flex flex-col gap-3 bg-surface p-6">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-ink-muted">Top slot</span>
+            <span className="text-[11px] text-ink-faint">
+              your level <b className="text-ink-soft">{state.level}</b>
+            </span>
+          </div>
+          <div className="flex gap-2">
+            {state.topSlot.map((r, i) => (
+              <Rung
+                key={r.multiplier}
+                rung={r}
+                charging={stage === "charging"}
+                active={cursor === i && stage === "spinning"}
+                landed={cursor === i && stage === "won"}
+              />
+            ))}
+          </div>
+          <span className="text-[13px] text-ink-muted">
+            Multiplies whatever the reel gives you. Higher levels unlock bigger multipliers.
+          </span>
+        </div>
+      </div>
+
+      {!state.canSpin && stage === "picking" && (
+        <div className="notched mb-8 flex w-full flex-col items-center gap-2 bg-surface p-8">
+          <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-ink-muted">Next gift in</span>
+          <span className="font-mono text-3xl font-bold text-accent-gold">
+            {countdown(state.nextAt) || "any moment"}
+          </span>
+        </div>
+      )}
+
+      {stage === "picking" && state.canSpin && (
+        <>
+          <div className="mb-3 w-full text-[11px] font-bold uppercase tracking-[0.16em] text-ink-muted">
+            Choose a collection
+          </div>
+          <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {state.categories.map((c) => (
+              <div key={c.category} className="notched group bg-line p-px transition-colors hover:bg-accent-gold">
+                <div className="notched flex h-full flex-col gap-4 bg-surface p-5">
+                  <div className="flex h-28 items-center justify-center bg-surface-nav">
+                    <img
+                      src={c.cover}
+                      alt={c.category}
+                      className="h-24 object-contain transition-transform group-hover:scale-105"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-[17px] font-bold">{c.category}</span>
+                    <span className="text-xs text-ink-faint">{c.eligible} cases in the pool</span>
+                  </div>
+                  <div className="mt-auto">
+                    <GameButton onClick={() => onPick(c.category)}>Spin</GameButton>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {stage !== "picking" && category && (
+        <div className="flex w-full flex-col gap-6">
+          <div className="flex items-center justify-between text-[13px] text-ink-muted">
+            <button onClick={onBack} className="bg-transparent transition-colors hover:text-white" disabled={spinning}>
+              &larr; Collections <span className="text-line-strong">/</span>{" "}
+              <span className="font-semibold text-white">{category.category}</span>
+            </button>
+            <span>
+              Streak <b className="text-accent-amber">{state.streak}</b>
+            </span>
+          </div>
+
+          {stage !== "won" && (
+            <div className="relative flex h-72 items-center justify-center overflow-hidden border-y-4 border-[#16152c] bg-surface-deep">
+            <Roulette
+              items={reel}
+              openedItem={landing || reel[0]}
+              spin={spinning}
+              overlay={(item) => (
+                <div className="pointer-events-none absolute inset-x-0 bottom-1 flex flex-col items-center">
+                  <span className="text-xl font-extrabold text-white drop-shadow-[0_2px_3px_rgba(0,0,0,0.9)]">
+                    {item.name.split(" ")[0]}
+                  </span>
+                </div>
+              )}
+            />
+            <div className="absolute inset-y-0 left-1/2 z-20 -ml-px w-0.5 bg-[#CF3464]" />
+            </div>
+          )}
+
+          {stage === "charging" && (
+            <div className="flex flex-col items-center gap-3">
+              <span className="text-[13px] text-ink-muted">
+                Your streak is charging the top slot. Every day back widens the good rungs.
+              </span>
+              <div className="w-full max-w-xs">
+                <GameButton onClick={onSpin} disabled={pending || spinning}>
+                  Spin the daily gift
+                </GameButton>
+              </div>
+            </div>
+          )}
+
+          {stage === "won" && result && (
+            <div className="flex flex-col items-center gap-10 py-8">
+              <div className="animate-fade-in relative flex items-center justify-center">
+                <img
+                  src={result.won.image}
+                  alt={result.won.title}
+                  className="h-32 w-32 object-contain md:h-48 md:w-48"
+                />
+                <div
+                  className="notched absolute left-[210px] z-20 hidden h-48 w-48 animate-fade-in-left items-center justify-center md:flex"
+                  style={{ background: result.topSlot.hit ? "#FFCC00" : "#3A365A" }}
+                >
+                  <div className="notched z-30 flex h-[184px] w-[184px] flex-col items-center justify-center gap-1 bg-[#151225] px-3 text-center">
+                    <span className="text-xl font-bold text-[#e1dde9]">{result.won.title}</span>
+                    <span className="text-[11px] uppercase tracking-[0.16em] text-ink-muted">the reel gave</span>
+                    <span className="text-3xl font-extrabold leading-none">{result.won.opens}x</span>
+                    <span
+                      className={`text-sm font-bold ${result.topSlot.hit ? "text-accent-gold" : "text-ink-muted"}`}
+                    >
+                      top slot {result.topSlot.multiplier}x
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="animate-fade-in-down flex flex-col items-center gap-2">
+                <span
+                  className={`gift-slam px-3 py-1 text-[11px] font-extrabold tracking-[0.16em] ${
+                    result.topSlot.hit ? "bg-accent-gold text-[#2a2100]" : "bg-line-strong text-ink-soft"
+                  }`}
+                >
+                  {result.topSlot.hit
+                    ? `LEVEL ${state.level} · ${result.topSlot.multiplier}x TOP SLOT`
+                    : "TOP SLOT 1x · NO BONUS"}
+                </span>
+                <div className="relative flex items-baseline gap-3">
+                  {result.topSlot.hit && (
+                    <div className="gift-flare pointer-events-none absolute -inset-8 bg-[radial-gradient(circle,rgba(255,204,0,0.22),transparent_68%)]" />
+                  )}
+                  <span className="relative text-6xl font-extrabold leading-none text-accent-gold">
+                    {kp(pumped)}
+                  </span>
+                  <span className="relative text-xl font-bold">free openings</span>
+                </div>
+                <span className="text-[13px] text-ink-muted">
+                  Expires in <b className="text-ink-soft">{countdown(result.expiresAt) || "any moment"}</b>
+                </span>
+                {result.grantRemaining > result.opens && (
+                  <span className="text-[13px] text-accent-amber">
+                    {kp(result.grantRemaining)} waiting on this case in total
+                  </span>
+                )}
+              </div>
+
+              <div className="w-full max-w-xs">
+                <GameButton onClick={() => onOpen(result.won.caseId)}>Open them now</GameButton>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {state.grants.length > 0 && stage !== "won" && (
+        <div className="notched mt-8 flex w-full flex-col gap-3 bg-surface p-5">
+          <span className="text-[11px] font-bold uppercase tracking-[0.16em] text-accent-gold">
+            Free openings waiting
+          </span>
+          <div className="flex flex-wrap gap-3">
+            {state.grants.map((g) => (
+              <button
+                key={g.grantId}
+                onClick={() => onOpen(g.caseId)}
+                className="flex items-center gap-3 border border-line bg-surface-nav px-4 py-3 text-left transition-colors hover:border-accent-gold"
+              >
+                <img src={g.image} alt={g.title} className="h-10 w-10 object-contain" loading="lazy" />
+                <div className="flex flex-col gap-0.5">
+                  <span className="font-bold">{g.title}</span>
+                  <span className="text-[13px] text-accent-gold">
+                    {g.remaining} {g.remaining === 1 ? "opening" : "openings"} left
+                  </span>
+                  <span className="font-mono text-[11px] text-ink-muted">
+                    expires in {countdown(g.expiresAt) || "moments"}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GiftView;

--- a/src/pages/Gift/index.tsx
+++ b/src/pages/Gift/index.tsx
@@ -1,0 +1,109 @@
+import { useContext, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
+import UserContext from "../../UserContext";
+import { getGift, spinGift } from "../../services/gift/GiftService";
+import { reelItems, wonItem } from "./Gift.services";
+import GiftView from "./Gift.view";
+import type { BasicItem } from "../../components/Types";
+import type { GiftCategory, GiftStage, GiftState, SpinResult } from "./Gift.types";
+
+// the reel animation the shared Roulette runs, so the prize lands with it rather than before
+const REEL_MS = 7100;
+
+const Gift = () => {
+  const { userData } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  const [state, setState] = useState<GiftState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [stage, setStage] = useState<GiftStage>("picking");
+  const [category, setCategory] = useState<GiftCategory | null>(null);
+  const [pending, setPending] = useState(false);
+  const [spinning, setSpinning] = useState(false);
+  const [landing, setLanding] = useState<BasicItem | null>(null);
+  const [result, setResult] = useState<SpinResult | null>(null);
+
+  // memoised because the reel reshuffles on every new items array, which was re-randomising
+  // the faces on each tick; it is rebuilt once when the winning face is known
+  const reel = useMemo(
+    () => (category ? reelItems(category.slots, landing) : []),
+    [category, landing]
+  );
+
+  useEffect(() => {
+    if (!userData?.id) return;
+    getGift()
+      .then(setState)
+      .catch(() => setState(null))
+      .finally(() => setLoading(false));
+  }, [userData?.id]);
+
+  const onPick = (name: string) => {
+    const found = state?.categories.find((c) => c.category === name) || null;
+    if (!found) return;
+    setCategory(found);
+    setResult(null);
+    setLanding(null);
+    setStage("charging");
+  };
+
+  const onBack = () => {
+    setCategory(null);
+    setResult(null);
+    setLanding(null);
+    setStage("picking");
+  };
+
+  const onSpin = async () => {
+    if (!category || pending || spinning) return;
+    setPending(true);
+    try {
+      const res = await spinGift(category.category);
+      // the reel only plants the winner when it rebuilds, so it starts after the answer lands
+      setLanding(wonItem(category.slots, res.won.caseId, res.won.opens));
+      setStage("spinning");
+      setSpinning(true);
+      setTimeout(() => {
+        setResult(res);
+        setState(res.state);
+        setStage("won");
+        setSpinning(false);
+        setPending(false);
+      }, REEL_MS);
+    } catch (err: any) {
+      toast.error(err?.response?.data?.message || "Could not open your gift", { theme: "dark" });
+      setPending(false);
+    }
+  };
+
+  if (!userData?.id) {
+    return (
+      <div className="flex w-full justify-center p-16">
+        <span className="text-ink-muted">Log in to open your daily gift.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full justify-center">
+      <GiftView
+        loading={loading}
+        state={state}
+        stage={stage}
+        category={category}
+        reel={reel}
+        landing={landing}
+        spinning={spinning}
+        pending={pending}
+        result={result}
+        onPick={onPick}
+        onBack={onBack}
+        onSpin={onSpin}
+        onOpen={(caseId) => navigate(`/case/${caseId}`)}
+      />
+    </div>
+  );
+};
+
+export default Gift;

--- a/src/services/games/GamesServices.ts
+++ b/src/services/games/GamesServices.ts
@@ -1,8 +1,9 @@
 import api from '../api';
 
-export async function openBox(id: string, quantity: number) {
+export async function openBox(id: string, quantity: number, grantId?: string) {
     const response = await api.post(`/games/openCase/${id}`, {
-        quantity: quantity || 1
+        quantity: quantity || 1,
+        ...(grantId ? { grantId } : {})
     });
     return response.data;
 }

--- a/src/services/gift/GiftService.ts
+++ b/src/services/gift/GiftService.ts
@@ -1,0 +1,84 @@
+import api from "../api";
+
+export interface GiftSlot {
+  caseId: string;
+  title: string;
+  image: string;
+  price: number;
+  opens: number;
+  value: number;
+  chance: number;
+}
+
+export interface GiftCategory {
+  category: string;
+  cover: string;
+  eligible: number;
+  expectedValue: number;
+  slots: GiftSlot[];
+}
+
+export interface TopSlotRung {
+  multiplier: number;
+  minLevel: number;
+  locked: boolean;
+  chance: number;
+}
+
+export interface GiftGrant {
+  grantId: string;
+  caseId: string;
+  title: string;
+  image: string;
+  remaining: number;
+  expiresAt: string;
+}
+
+export interface GiftState {
+  level: number;
+  streak: number;
+  streakTilt: number;
+  maxStreakTilt: number;
+  topSlot: TopSlotRung[];
+  topSlotAverage: number;
+  streakMax: number;
+  rareBoost: number;
+  atBestStreak: { rareBoost: number; topSlotAverage: number };
+  canSpin: boolean;
+  nextAt: string | null;
+  categories: GiftCategory[];
+  grants: GiftGrant[];
+}
+
+export interface SpinResult {
+  category: string;
+  won: { caseId: string; title: string; image: string; opens: number; value: number };
+  topSlot: { multiplier: number; hit: boolean };
+  opens: number;
+  grantId: string;
+  grantRemaining: number;
+  expiresAt: string;
+  streak: number;
+  state: GiftState;
+}
+
+export const getGift = async (): Promise<GiftState> => (await api.get("/gift")).data;
+
+// fired the moment a spin is claimed, so the navbar badge can go dark without a reload
+export const GIFT_CLAIMED_EVENT = "kani.giftClaimed";
+
+export interface GiftStatus {
+  canSpin: boolean;
+  nextAt: string | null;
+}
+
+export const getGiftStatus = async (): Promise<GiftStatus> => (await api.get("/gift/status")).data;
+
+export const getGrants = async (caseId?: string): Promise<GiftGrant[]> =>
+  (await api.get("/gift/grants", { params: caseId ? { caseId } : {} })).data;
+
+export const spinGift = async (category: string): Promise<SpinResult> => {
+  const result = (await api.post("/gift/spin", { category })).data;
+  window.dispatchEvent(new Event(GIFT_CLAIMED_EVENT));
+  return result;
+};


### PR DESCRIPTION
Balance refills every 8 minutes, but there was nothing to bring a player back tomorrow specifically. This adds a daily gift.

**Change**

A gift entry in the navbar (replacing Plinko, which keeps its route) leads to a page where you pick a collection and spin. The reel pays free openings of one specific case; a top slot multiplies the result, with higher rungs unlocked by account level up to 100. Both draws are provably-fair rolls recorded as `gift`.

The prizes are normalised so every category is worth about the same per spin, which the tests hold to within 35%. Grants live on the user, expire after a day, and top up an existing grant rather than opening a second one for the same case. The case page shows what's waiting on it and spends it instead of charging.

A streak makes the rarer prizes likelier, reaching 2.2x on day ten.

**Tests**

`backend/__tests__/unit/dailyGift.test.js` and `backend/__tests__/integration/dailyGift.test.js`: prize table shape and monotonicity, per-category value parity, level gating, streak effect, the once-a-day guard, grant spending, expiry, cross-case and cross-user refusal, and two concurrent opens racing one grant.