### PR TITLE
Stop the layout pushing the page sideways

### DIFF
--- a/src/components/TopPlayer.tsx
+++ b/src/components/TopPlayer.tsx
@@ -11,7 +11,7 @@ interface CardProps {
 const TopPlayer: React.FC<CardProps> = ({ user, rank }) => {
 
     return (
-        <div className={`relative w-64 ${rank === 1 ? '-mt-10' : 'hidden md:block'}`}>
+        <div className={`relative w-48 md:w-56 xl:w-64 ${rank === 1 ? '-mt-10' : 'hidden md:block'}`}>
             <div className='relative  z-50 flex flex-col items-center justify-center'>
                 <Player user={user} size="large" direction='column' showLevel={false} />
                 <div className='flex flex-col items-center gap-2'>

--- a/src/components/header/Navbar/Navbar.tsx
+++ b/src/components/header/Navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 
 
 import { Link } from "react-router-dom";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import UserContext from "../../../UserContext";
 import MainButton from "../../MainButton";
 import { clearTokens } from "../../../services/auth/authUtils";
@@ -15,6 +15,7 @@ import { TbCat } from "react-icons/tb";
 import { toast } from "react-toastify";
 import { FaBars, FaGift } from 'react-icons/fa';
 import RightContent from "./RightContent";
+import { useTranslation } from "react-i18next";
 import GiftTag from "../GiftTag";
 import useGiftReady from "../useGiftReady";
 import i18n from "../../../i18n";
@@ -32,6 +33,9 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
 
   const { isLogged, toggleLogin, toogleUserData, userData, openUserFlow, toogleUserFlow } = useContext(UserContext);
   const giftReady = useGiftReady();
+  const { i18n: translator } = useTranslation();
+
+  const linksRef = useRef<HTMLDivElement | null>(null);
 
   const handleHover = () => {
     setIsHovering(!isHovering);
@@ -114,6 +118,22 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
   ];
 
 
+  // the labelled row needs 1430px to 1890px depending on the language, so no css breakpoint
+  // fits them all. a class hides the labels, keeping the measurement out of react's render.
+  useLayoutEffect(() => {
+    const row = linksRef.current;
+    if (!row) return;
+    const fit = () => {
+      row.classList.remove("nav-icons-only");
+      if (row.scrollWidth > row.clientWidth) row.classList.add("nav-icons-only");
+    };
+    fit();
+    const done = document.fonts?.ready;
+    if (done) done.then(fit).catch(() => undefined);
+    window.addEventListener("resize", fit);
+    return () => window.removeEventListener("resize", fit);
+  }, [links.length, translator.language, giftReady]);
+
   useEffect(() => {
 
     if (isLogged == true) {
@@ -128,11 +148,11 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
     <div className="w-full flex justify-center">
       <nav className=" py-4 px-8 bg-[#19172D] w-[calc(100vw-2rem)] max-w-[1920px] flex justify-center notched ">
         <div className="flex items-center justify-between w-full ">
-          <div className="md:hidden">
+          <div className="xl:hidden">
             <FaBars onClick={toggleSidebar} className="text-2xl cursor-pointer" />
           </div>
-          <div className="hidden md:flex">
-            <Link to="/">
+          <div className="hidden xl:flex min-w-0 flex-1 items-center">
+            <Link to="/" className="shrink-0">
               <div
                 className="flex items-center gap-2 "
                 onMouseEnter={handleHover}
@@ -162,16 +182,20 @@ const Navbar: React.FC<Navbar> = ({ openNotifications, setOpenNotifications, ope
               </div>
             </Link>
             {
-              <div className="hidden md:flex items-center gap-6 ml-8 overflow-hidden">
+              <div
+                ref={linksRef}
+                className="flex min-w-0 flex-1 items-center gap-4 2xl:gap-6 ml-4 xl:ml-8 overflow-hidden"
+              >
                 {links.map((link, index) => (<Link
                   to={link.path}
                   key={index}
-                  className="flex items-center gap-2 font-normal text-xs 2xl:text-lg cursor-pointer "
+                  title={link.name}
+                  className="flex shrink-0 items-center gap-2 font-normal text-xs 2xl:text-sm cursor-pointer "
                 >
                   <span className="text-[#625F7E] hover:text-gray-200 transition-all ">
                     {link.icon}
                   </span>
-                  <span className="text-white hover:text-gray-200 transition-all ">
+                  <span className="nav-label whitespace-nowrap text-white hover:text-gray-200 transition-all ">
                     {link.name}
                   </span>
                   {link.badge}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -98,7 +98,7 @@ const Header: React.FC<Header> = ({ onlineUsers, recentCaseOpenings, notificatio
 
 
   return (
-    <div className="flex flex-col p-4 w-screen justify-center ">
+    <div className="flex flex-col p-4 w-full justify-center ">
       <div className="flex pb-2 items-center">
         {items.map((item, index) => (
           <div

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Gegenstände in dieser Kiste",
     "leftArrow": "Pfeil links",
     "openCase": "Kiste öffnen -",
+    "openFree": "Gratis öffnen",
+    "openFreeCount": "Gratis öffnen x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "Pfeil rechts",
     "topArrow": "Pfeil oben"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Items in this case",
     "leftArrow": "left arrow",
     "openCase": "Open case -",
+    "openFree": "Open free",
+    "openFreeCount": "Open free x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "right arrow",
     "topArrow": "top arrow"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Objetos de esta caja",
     "leftArrow": "flecha izquierda",
     "openCase": "Abrir caja -",
+    "openFree": "Abrir gratis",
+    "openFreeCount": "Abrir gratis x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "flecha derecha",
     "topArrow": "flecha superior"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Objets de cette caisse",
     "leftArrow": "flèche de gauche",
     "openCase": "Ouvrir la caisse -",
+    "openFree": "Ouvrir gratuitement",
+    "openFreeCount": "Ouvrir gratuitement x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "flèche de droite",
     "topArrow": "flèche du haut"

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Items di kotak ini",
     "leftArrow": "panah kiri",
     "openCase": "Buka kotak -",
+    "openFree": "Buka gratis",
+    "openFreeCount": "Buka gratis x{{count}}",
     "provablyFair": "Gak ngechit, aman",
     "rightArrow": "panah kanan",
     "topArrow": "panah atas"

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Oggetti in questa cassa",
     "leftArrow": "freccia a sinistra",
     "openCase": "Apri cassa -",
+    "openFree": "Apri gratis",
+    "openFreeCount": "Apri gratis x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "freccia a destra",
     "topArrow": "freccia in alto"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "このケースの中身",
     "leftArrow": "左向き矢印",
     "openCase": "ケースを開ける -",
+    "openFree": "無料で開ける",
+    "openFreeCount": "無料で開ける x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "右向き矢印",
     "topArrow": "上向き矢印"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "이 케이스의 아이템",
     "leftArrow": "왼쪽 화살표",
     "openCase": "케이스 열기 -",
+    "openFree": "무료로 열기",
+    "openFreeCount": "무료로 열기 x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "오른쪽 화살표",
     "topArrow": "위 화살표"

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Itens desta caixa",
     "leftArrow": "seta esquerda",
     "openCase": "Abrir caixa -",
+    "openFree": "Abrir grátis",
+    "openFreeCount": "Abrir grátis x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "seta direita",
     "topArrow": "seta superior"

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "Vật phẩm trong hòm này",
     "leftArrow": "mũi tên trái",
     "openCase": "Mở hòm -",
+    "openFree": "Mở miễn phí",
+    "openFreeCount": "Mở miễn phí x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "mũi tên phải",
     "topArrow": "mũi tên trên"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -145,6 +145,8 @@
     "itemsInThisCase": "本箱内物品",
     "leftArrow": "左箭头",
     "openCase": "开箱 -",
+    "openFree": "免费开箱",
+    "openFreeCount": "免费开箱 x{{count}}",
     "provablyFair": "provably fair",
     "rightArrow": "右箭头",
     "topArrow": "上箭头"

--- a/src/index.css
+++ b/src/index.css
@@ -288,6 +288,13 @@ a:hover {
   color: #535bf2;
 }
 
+/* body is a flex container, so #root grows to its widest child: one 120vw reel used to
+   stretch the whole document sideways, and every w-full inside it with it */
+#root {
+  width: 100%;
+  min-width: 0;
+}
+
 body {
   margin: 0;
   display: flex;
@@ -478,4 +485,9 @@ button:focus-visible {
       var(--color2),
       var(--color1));
   background-size: 600% 100%;
+}
+
+/* the navbar drops its link labels when the row runs out of room for them */
+.nav-icons-only .nav-label {
+  display: none;
 }

--- a/src/pages/Battles/BattleRoom/BattleRoom.view.tsx
+++ b/src/pages/Battles/BattleRoom/BattleRoom.view.tsx
@@ -41,12 +41,12 @@ const BattleRoomView: React.FC<BattleRoomViewProps> = ({
   onLeave,
 }) => {
   if (loading)
-    return <div className="w-screen py-16 text-center">{i18n.t("battles.loadingBattle")}</div>;
+    return <div className="w-full py-16 text-center">{i18n.t("battles.loadingBattle")}</div>;
   if (notFound)
-    return <div className="w-screen py-16 text-center">{i18n.t("battles.battleNotFound")}</div>;
+    return <div className="w-full py-16 text-center">{i18n.t("battles.battleNotFound")}</div>;
 
   return (
-    <div className="w-screen flex flex-col items-center py-6 gap-5 px-4">
+    <div className="w-full flex flex-col items-center py-6 gap-5 px-4">
       <div className="w-full max-w-[1200px] flex items-center justify-between">
         <button
           onClick={onBack}

--- a/src/pages/Battles/Battles/Battles.view.tsx
+++ b/src/pages/Battles/Battles/Battles.view.tsx
@@ -28,7 +28,7 @@ const BattlesView: React.FC<BattlesViewProps> = ({
   openBattle,
   slotsFor,
 }) => (
-  <div className="w-screen flex flex-col items-center py-8 gap-8 px-4">
+  <div className="w-full flex flex-col items-center py-8 gap-8 px-4">
     <Title title={i18n.t("nav.caseBattles")} />
 
     <div className="flex flex-col gap-4 w-full max-w-[1100px] bg-[#212031] rounded-lg p-5">

--- a/src/pages/CasePage/CasePage.tsx
+++ b/src/pages/CasePage/CasePage.tsx
@@ -152,16 +152,16 @@ const CasePage = () => {
   };
 
   return (
-    <div className="flex flex-col items-center w-screen relative">
+    <div className="flex flex-col items-center w-full relative">
       {!loading && data && (
         <button
           onClick={() => navigate(`/battles?add=${id}`)}
-          className="absolute top-4 right-4 md:right-8 z-20 px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 font-semibold text-sm"
+          className="self-end mr-4 mt-4 md:absolute md:top-4 md:right-8 md:mr-0 md:mt-0 z-20 px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 font-semibold text-sm"
         >
           {i18n.t("casePage.addToBattle")}
         </button>
       )}
-      <div className="flex flex-col items-center overflow-hidden  md:max-w-[1920px]">
+      <div className="flex w-full flex-col items-center overflow-hidden md:max-w-[1920px]">
         <h1 className="text-2xl color-[#e1dde9] font-bold py-7">
           {loading ? <Skeleton width={200} height={30} /> : data && data.title}
         </h1>
@@ -185,7 +185,7 @@ const CasePage = () => {
                 text={userData == null ? i18n.t("upgrade.signInToPlay") : freeNow ? (
                   <div className="flex items-center justify-center gap-1 text-base">
                     <FaGift />
-                    <span>Open free{quantity > 1 ? ` x${quantity}` : ""}</span>
+                    <span>{quantity > 1 ? i18n.t("casePage.openFreeCount", { count: quantity }) : i18n.t("casePage.openFree")}</span>
                   </div>
                 ) : <div className="flex items-center justify-center text-base">
                 <span className="mr-1">{i18n.t("casePage.openCase")} </span>{<Monetary value={data.price * quantity}/>}
@@ -219,7 +219,7 @@ const CasePage = () => {
 
         <div className="flex flex-col md:p-8 gap-2 items-center ">
           <Title title={i18n.t("casePage.itemsInThisCase")} />
-          <div className="flex flex-wrap gap-6 px-8 justify-center w-screen max-w-[1920px]">
+          <div className="flex flex-wrap gap-6 px-8 justify-center w-full max-w-[1920px]">
             {loading
               ? { array: Array(12).fill(0) }.array.map((_, i) => (
                 <Skeleton

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -152,9 +152,9 @@ const CoinFlip = () => {
   }, [countDown]);
 
   return (
-    <div className="w-screen flex flex-col items-center justify-center gap-12">
-      <div className="flex bg-[#212031] rounded flex-col lg:flex-row">
-        <div className="lg:w-[340px] flex flex-col items-center gap-4 border-r border-gray-700 py-4 px-6">
+    <div className="w-full flex flex-col items-center justify-center gap-12">
+      <div className="flex w-full max-w-full bg-[#212031] rounded flex-col lg:w-auto lg:flex-row">
+        <div className="w-full min-w-0 lg:w-[340px] flex flex-col items-center gap-4 border-r border-gray-700 py-4 px-6">
           <div className="w-full">
             <BetAmount
               value={bet === 0 ? "" : String(bet)}
@@ -216,7 +216,7 @@ const CoinFlip = () => {
           </div>
         </div>
         <div className="flex flex-col">
-          <div className="flex lg:w-[800px] border-b border-gray-700  p-4">
+          <div className="flex w-full lg:max-w-[800px] border-b border-gray-700 p-4">
             <div className="flex bg-[#19172D] rounded items-center justify-center w-full h-[340px] relative ">
               {
                 gameEnded && <div className="absolute top-0 left-0 p-2">
@@ -228,7 +228,7 @@ const CoinFlip = () => {
               <Coin spinning={spinning} result={result} />
             </div>
           </div>
-          <div className="flex w-screen lg:w-[800px] p-4 flex-col">
+          <div className="flex w-full lg:max-w-[800px] p-4 flex-col">
             <h3 className="mb-2 text-lg font-semibold">{i18n.t("coin.gameHistory")}</h3>
             <div className="flex items-center gap-2 justify-end w-full  overflow-hidden h-[24px]">
               {history.map((e, i) => (

--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -244,8 +244,8 @@ const CrashGame = () => {
   }, [countDown]);
 
   return (
-    <div className="w-screen flex flex-col items-center justify-center gap-12">
-      <div className="flex bg-[#212031] rounded flex-col lg:flex-row">
+    <div className="w-full flex flex-col items-center justify-center gap-12">
+      <div className="flex w-full max-w-full bg-[#212031] rounded flex-col lg:w-auto lg:flex-row">
         <SideMenu bet={bet} setBet={setBet} cashoutAt={cashoutAt} setCashoutAt={setCashoutAt} queued={queued}
          multiplier={multiplier} gameStarted={gameStarted} handleBet={handleBet} handleCashout={handleCashout}
          isLogged={isLogged} userGambled={userGambled} userCashedOut={userCashedOut} userData={userData} userMultiplier={userMultiplier} disableButton={disableButton}/>

--- a/src/pages/Crash/GameContainer.tsx
+++ b/src/pages/Crash/GameContainer.tsx
@@ -21,7 +21,7 @@ const BETTING_COUNTDOWN_S = 10.7;
 const GameContainer: React.FC<GameHistory> = ({ crashPoint, multiplier, gameStarted, gameEnded, countDown, up, idle, falling, history }) => {
     return (
         <div className="flex flex-col">
-            <div className="flex flex-col gap-2 lg:w-[800px] border-b border-gray-700  p-4">
+            <div className="flex flex-col gap-2 w-full lg:max-w-[800px] border-b border-gray-700 p-4">
                 <div className="flex rounded items-center flex-col justify-center w-full h-[340px] relative overflow-hidden bg-surface-nav">
                     <CrashGraph
                         gameStarted={gameStarted}
@@ -69,7 +69,7 @@ const GameContainer: React.FC<GameHistory> = ({ crashPoint, multiplier, gameStar
                     />
                 </div>
             </div>
-            <div className="flex w-screen lg:w-[800px] p-4 flex-col">
+            <div className="flex w-full lg:max-w-[800px] p-4 flex-col">
                 <h3 className="mb-2 text-lg font-semibold">{i18n.t("coin.gameHistory")}</h3>
                 <div className="flex items-center gap-2 justify-end w-full overflow-hidden h-[24px]">
                     {history.map((e: { crashPoint: number | null }, i: Key) => (

--- a/src/pages/Crash/LiveBets.tsx
+++ b/src/pages/Crash/LiveBets.tsx
@@ -39,7 +39,7 @@ const LiveBets: React.FC<GameHistory> = ({ gameState }) => {
     };
 
     return (
-        <div className="flex flex-col px-8 py-4 bg-[#212031] rounded file:h-min lg:w-[1140px] w-full">
+        <div className="flex flex-col px-8 py-4 bg-[#212031] rounded file:h-min w-full lg:max-w-[1140px]">
 
             <div className="flex flex-col">
                 <div className="flex items-center justify-between py-4">

--- a/src/pages/Home/Banner.tsx
+++ b/src/pages/Home/Banner.tsx
@@ -7,7 +7,7 @@ import i18n from "../../i18n";
 const Banner: React.FC<BannerProps> = ({ left, right }) => {
   return (
     <div
-      className={`w-screen  max-w-[1920px] h-[460px]  bg-no-repeat hidden md:flex bg-cover bg-center`}
+      className={`w-full max-w-[1920px] h-[460px]  bg-no-repeat hidden md:flex bg-cover bg-center`}
       style={{ backgroundImage: `url(${left.image})` }}
     >
       <div className="flex items-center justify-center w-full ">

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -148,7 +148,7 @@ const Home = () => {
   ];
 
   return (
-    <div className="w-screen flex justify-center">
+    <div className="w-full flex justify-center">
       <div className=" flex-col w-full max-w-[1920px] ">
         <Carousel
           autoPlay={true}

--- a/src/pages/Home/Leaderboard.tsx
+++ b/src/pages/Home/Leaderboard.tsx
@@ -35,7 +35,7 @@ const Leaderboard = ({ aside }: { aside?: React.ReactNode }) => {
 
             {/* the podium reads three entries, so two ranked players used to crash the page */}
             {!loading && users.length >= 3 ? (
-                <div className="flex gap-14 my-16 ">
+                <div className="flex gap-4 md:gap-6 xl:gap-14 my-16">
                     <TopPlayer key={users[1]._id} user={users[1]} rank={2} />
                     <TopPlayer key={users[0]._id} user={users[0]} rank={1} />
                     <TopPlayer key={users[2]._id} user={users[2]} rank={3} />

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -160,7 +160,7 @@ const Profile = () => {
   ];
 
   return (
-    <div className="flex flex-col items-center w-screen">
+    <div className="flex flex-col items-center w-full">
       <div className="flex flex-col max-w-[1312px] py-4 w-full">
         {loading ? (
           <div className="flex items-center justify-start pb-7">

--- a/src/pages/ProvablyFair/ProvablyFair.view.tsx
+++ b/src/pages/ProvablyFair/ProvablyFair.view.tsx
@@ -29,7 +29,7 @@ const ProvablyFairView: React.FC<ProvablyFairViewProps> = ({
   verifying,
   doVerify,
 }) => (
-  <div className="w-screen flex flex-col items-center py-8 gap-6 px-4">
+  <div className="w-full flex flex-col items-center py-8 gap-6 px-4">
     <Title title={i18n.t("footer.provablyFair")} />
 
     <p className="text-[#84819a] text-sm max-w-[640px] text-center">

--- a/src/pages/Slot/Game.tsx
+++ b/src/pages/Slot/Game.tsx
@@ -29,7 +29,7 @@ const Game: React.FC<SlotMachineProps> = ({ grid, isSpinning, data, winningLines
         return (
             // aspect-ratio reserves the bar's height before it loads, so the machine below
             // it does not jump down when the image arrives
-            <img src={bottomBar} alt={i18n.t("slot.bottomBar")} className={`w-screen md:w-[416px] aspect-[539/7] z-10 ${index == 0 ? "scale-y-[-1]" : ""} `}
+            <img src={bottomBar} alt={i18n.t("slot.bottomBar")} className={`w-full md:w-[416px] aspect-[539/7] z-10 ${index == 0 ? "scale-y-[-1]" : ""} `}
                 onLoad={() => setLoadedImages(loadedImages + 1)}
             />
         )

--- a/src/pages/Upgrade/ClockPointer.tsx
+++ b/src/pages/Upgrade/ClockPointer.tsx
@@ -17,7 +17,7 @@ const ClockPointer: React.FC<ClockPointerProps> = ({ successRate, spinning, succ
     const strokeLength = circumference * successRate;
 
     return (
-        <div className="relative w-[380px] h-[380px]" style={{
+        <div className="relative w-[380px] h-[380px] max-w-[88vw] max-h-[88vw]" style={{
             backgroundImage: `url(/images/clock.webp)`,
             backgroundSize: 'cover',
             backgroundPosition: 'center',

--- a/src/pages/Upgrade/Upgrade.tsx
+++ b/src/pages/Upgrade/Upgrade.tsx
@@ -25,9 +25,9 @@ const Upgrade: React.FC = () => {
     const [spinning, setSpinning] = useState(false);
 
     return (
-        <div className="w-screen flex justify-center z-10">
+        <div className="w-full flex justify-center z-10">
             <div className=" flex-col w-full max-w-[1920px]">
-                <div className="w-full flex justify-center ml-1">
+                <div className="w-full flex justify-center">
                     <Tooltip id="my-tooltip" style={{
                         width: "300px",
                         zIndex: 30,


### PR DESCRIPTION
The navbar switched to its desktop form at 768px, but the eight links, the logo and the wallet strip need well over a thousand pixels. Between 768px and 1230px the whole page scrolled sideways, and around 1330px the last link was cut through the middle of a word.

**Change**

The desktop nav hands over to the sidebar below `xl`, and the link labels drop to icons whenever the row runs out of room. That threshold cannot be a breakpoint: the labelled row needs 1430px in Chinese and 1890px in Portuguese, so it measures itself. The `2xl` type jump went from 12px→18px to 12px→14px, since widening the window should never be what loses the labels.

The case page had the battle button pinned to the corner at every width, so on a phone it sat on top of the case name. It now sits above the title until there is room beside it.

Underneath both: `body` is a flex container, so `#root` grew to its widest child. One 120vw reel stretched the document and every `w-full` inside it, and the `overflow-hidden` meant to contain it had nothing to bite on. `#root` is pinned to 100%, and the in-flow `w-screen` elements are `w-full`, since 100vw ignores the scrollbar.

Also fixed: three podium cards at a fixed 256px did not fit a tablet, the crash and coinflip panels took a fixed width from `lg` upward that was wider than an `lg` screen, the upgrade dial was 380px on a 360px phone, and the free-openings button was still in English.

**Tests**

Measured every page at 360, 768, 1024, 1280 and 1440, and the navbar and case page at fourteen widths from 360 to 1920 across the languages with the longest and shortest labels. No horizontal page overflow anywhere, no clipped links, and the battle button no longer overlaps the title.