### PR TITLE
fix(fandom): the preview fits, and contested means contested

### DIFF
--- a/backend/__tests__/integration/fandom.test.js
+++ b/backend/__tests__/integration/fandom.test.js
@@ -102,6 +102,34 @@ describe("fan boards", () => {
     expect(String(board.top.userId)).toBe(String(early._id));
   });
 
+  it("measures the chase by the leader's margin, not by how popular the character is", async () => {
+    const runaway = await makeItem("Yuuma");
+    const closeRace = await makeItem("Momiji");
+    const lonely = await makeItem("Sannyo");
+
+    // three fans but a 60-copy lead: popular, not contested
+    await makeUser({ pinned: runaway, inventory: copies(runaway, 63) });
+    await makeUser({ pinned: runaway, inventory: copies(runaway, 3) });
+    await makeUser({ pinned: runaway, inventory: copies(runaway, 1) });
+    // two fans, one copy between them
+    await makeUser({ pinned: closeRace, inventory: copies(closeRace, 5) });
+    await makeUser({ pinned: closeRace, inventory: copies(closeRace, 4) });
+    // one fan, nobody chasing
+    await makeUser({ pinned: lonely, inventory: copies(lonely, 2) });
+
+    await fandom.rebuild();
+
+    const board = async (name) => FanBoard.findOne({ name }).lean();
+    expect((await board("Yuuma")).gap).toBe(60);
+    expect((await board("Momiji")).gap).toBe(1);
+    expect((await board("Sannyo")).gap).toBe(999999);
+    expect((await board("Momiji")).secondCount).toBe(4);
+
+    // and the contested tab leads with the close race, not the popular one
+    const res = await request(app).get("/fandom");
+    expect(res.body.boards[0].name).toBe("Momiji");
+  });
+
   it("gives every character a board, so an unheld one can be claimed", async () => {
     await makeItem("Yuuma");
     await makeItem("Sannyo");

--- a/backend/models/FanBoard.js
+++ b/backend/models/FanBoard.js
@@ -26,6 +26,10 @@ const FanBoardSchema = new mongoose.Schema({
   fanCount: { type: Number, default: 0 },
   // the leader's count, kept flat so browse can sort and filter on it
   topCount: { type: Number, default: 0 },
+  // runner-up, and how far clear the leader is. a board nobody is chasing carries the
+  // sentinel so it sorts last on the contested tab instead of looking like a dead heat.
+  secondCount: { type: Number, default: 0 },
+  gap: { type: Number, default: 999999 },
   top: FanSchema,
   ranks: [FanSchema],
   updatedAt: { type: Date, default: Date.now },
@@ -34,5 +38,6 @@ const FanBoardSchema = new mongoose.Schema({
 // the browse page sorts by these
 FanBoardSchema.index({ fanCount: -1 });
 FanBoardSchema.index({ topCount: -1 });
+FanBoardSchema.index({ gap: 1 });
 
 module.exports = mongoose.model("FanBoard", FanBoardSchema);

--- a/backend/routes/fandomRoutes.js
+++ b/backend/routes/fandomRoutes.js
@@ -26,6 +26,8 @@ const publicBoard = (board) => ({
   caseId: board.caseId || null,
   fanCount: board.fanCount,
   topCount: board.topCount || 0,
+  secondCount: board.secondCount || 0,
+  gap: typeof board.gap === "number" ? board.gap : 999999,
   top: board.topCount > 0 ? publicFan(board.top) : null,
 });
 
@@ -45,7 +47,8 @@ router.get("/", async (req, res) => {
         ? { topCount: -1, fanCount: -1, name: 1 }
         : sort === "open"
         ? { name: 1 }
-        : { fanCount: -1, topCount: -1, name: 1 };
+        // closest race first, and a board with nobody chasing sorts behind every real one
+        : { gap: 1, fanCount: -1, name: 1 };
 
     const [boards, total] = await Promise.all([
       FanBoard.find(filter).sort(order).skip((page - 1) * PAGE_SIZE).limit(PAGE_SIZE).lean(),
@@ -101,7 +104,7 @@ router.get("/reach", isAuthenticated, async (req, res) => {
     if (!held.size) return res.json({ reach: [] });
 
     const boards = await FanBoard.find({ name: { $in: [...held.keys()] } })
-      .select("name image rarity caseId fanCount topCount top")
+      .select("name image rarity caseId fanCount topCount secondCount gap top")
       .lean();
 
     const pinnedName = user.fixedItem && user.fixedItem.name;

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -7,6 +7,8 @@ const CollectorBoard = require("../models/CollectorBoard");
 // how many chasers a board keeps. deep enough that anyone in touching distance sees
 // themselves, short enough that a board document stays small.
 const RANKS_KEPT = 50;
+// a board nobody is chasing is not contested; it sorts behind every real race
+const NO_CONTEST = 999999;
 const COLLECTORS_KEPT = 100;
 
 // the same character can appear in more than one case, as separate item rows sharing a
@@ -41,6 +43,13 @@ function countPinned(user, character) {
     if (entry.name === character.name || (entry._id && character.ids.has(String(entry._id)))) held += 1;
   }
   return held;
+}
+
+// how close the chase is: the leader's margin over the runner-up. a board with no leader
+// or nobody behind them is not a contest at all.
+function gapOf(rows) {
+  if (!rows.length || rows[0].count <= 0 || rows.length < 2) return NO_CONTEST;
+  return rows[0].count - rows[1].count;
 }
 
 // count desc, then whoever pinned it first, then account age. never random.
@@ -171,6 +180,8 @@ async function rebuild() {
               caseId: board.caseId,
               fanCount: board.fanCount,
               topCount: board.rows.length ? board.rows[0].count : 0,
+              secondCount: board.rows.length > 1 ? board.rows[1].count : 0,
+              gap: gapOf(board.rows),
               top: board.rows[0] || null,
               ranks: board.rows.slice(0, RANKS_KEPT),
               updatedAt: at,
@@ -269,6 +280,8 @@ async function refreshCharacters(names) {
             caseId: board.caseId,
             fanCount: board.fanCount,
             topCount: board.rows.length ? board.rows[0].count : 0,
+            secondCount: board.rows.length > 1 ? board.rows[1].count : 0,
+            gap: gapOf(board.rows),
             top: board.rows[0] || null,
             ranks: board.rows.slice(0, RANKS_KEPT),
             updatedAt: at,

--- a/src/components/PlayerPreview.tsx
+++ b/src/components/PlayerPreview.tsx
@@ -29,9 +29,12 @@ const PlayerPreview: React.FC<Player> = ({ player }) => {
         while (host && host.getBoundingClientRect().width === 0) host = host.parentElement;
         const box = host?.getBoundingClientRect();
         if (!box) return;
+        // clamp against the width the card will actually get, not its ideal one: on a
+        // phone the max-width shrinks it, and clamping on CARD_W pinned it off-screen left
+        const wide = Math.min(CARD_W, window.innerWidth - 16);
         const left = Math.min(
-            Math.max(8, box.left + box.width / 2 - CARD_W / 2),
-            window.innerWidth - CARD_W - 8
+            Math.max(8, box.left + box.width / 2 - wide / 2),
+            window.innerWidth - wide - 8
         );
         setAt(
             box.top < FLIP_AT
@@ -46,22 +49,22 @@ const PlayerPreview: React.FC<Player> = ({ player }) => {
     // uncoloured, so the rarity colour is an outer layer with the card 2px inside it
     const card = (
         <div
-            style={{ ...at, width: CARD_W, backgroundColor: player.fixedItem ? color : "#3A365A" }}
+            style={{ ...at, width: CARD_W, maxWidth: "calc(100vw - 16px)", backgroundColor: player.fixedItem ? color : "#3A365A" }}
             className="notched pointer-events-none fixed z-[140] p-[2px]"
         >
             <div className="notched flex items-stretch justify-between overflow-hidden bg-[#281D3F]">
-                <div className="flex items-center gap-2 p-6">
-                    <div className="min-w-[96px]">
+                <div className="flex min-w-0 flex-1 items-center gap-2 p-4 sm:p-6">
+                    <div className="w-24 shrink-0">
                         <Avatar image={player.profilePicture} id={player._id} size="large" level={player.level} noLink />
                     </div>
-                    <div className="flex flex-col items-start">
-                        <span className="flex items-center gap-1.5 font-bold text-lg max-w-[200px]">
+                    <div className="flex min-w-0 flex-col items-start">
+                        <span className="flex min-w-0 max-w-full items-center gap-1.5 font-bold text-lg">
                             <Badge badge={player.badge} linked={false} hoverCard={false} />
                             <span className="truncate text-white">{player.username}</span>
                         </span>
                         <span className="font-bold text-[#56528b] ">Level {player.level}</span>
                         {player.fanRank && (
-                            <span className="whitespace-nowrap text-xs text-[#84819A]">
+                            <span className="max-w-full truncate text-xs text-[#84819A]">
                                 {i18n.t("fandom.standingLine", {
                                     rank: player.fanRank.rank,
                                     name: player.fanRank.name,
@@ -72,7 +75,7 @@ const PlayerPreview: React.FC<Player> = ({ player }) => {
                     </div>
                 </div>
                 {player.fixedItem && (
-                    <div className="relative flex w-[160px] shrink-0 flex-col items-center justify-center px-2 py-4">
+                    <div className="relative flex w-[120px] shrink-0 flex-col items-center justify-center px-2 py-4 sm:w-[160px]">
                         <div
                             className="absolute left-1/2 top-1/2"
                             style={{ width: 1, height: 1, boxShadow: `0 0 60px 34px ${color}` }}
@@ -83,7 +86,7 @@ const PlayerPreview: React.FC<Player> = ({ player }) => {
                             className="relative z-10 h-24 w-24 object-contain"
                         />
                         <span
-                            className="relative z-10 w-full pt-2 text-center text-base font-semibold leading-tight"
+                            className="relative z-10 w-full break-words pt-2 text-center text-sm font-semibold leading-tight sm:text-base"
                             style={{ textShadow: '1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000' }}
                         >
                             {player.fixedItem.name}

--- a/src/pages/Fandom/Fandom/Fandom.services.ts
+++ b/src/pages/Fandom/Fandom/Fandom.services.ts
@@ -15,6 +15,9 @@ import { BoardCard, FandomTab, ReachCard } from "./Fandom.types";
 import i18n from "../../../i18n";
 
 const SEARCH_DEBOUNCE_MS = 350;
+// a board is contested when the runner-up is within reach of the leader, not when the
+// character happens to be popular
+const CONTESTED_GAP = 3;
 const TABS: FandomTab[] = ["contested", "biggest", "open", "reach", "collectors"];
 
 const isSort = (tab: FandomTab): tab is BoardSort =>
@@ -119,7 +122,7 @@ export const useFandomServices = () => {
         holderId: board.top && board.topCount > 0 ? board.top.userId : null,
         holderPicture: board.top ? board.top.profilePicture : "",
         count: board.topCount,
-        contested: board.fanCount >= 3,
+        contested: board.topCount > 0 && board.fanCount >= 2 && board.gap <= CONTESTED_GAP,
       })),
     [boards]
   );

--- a/src/services/fandom/FandomService.ts
+++ b/src/services/fandom/FandomService.ts
@@ -25,6 +25,9 @@ export interface FanBoardSummary {
   caseId: string | null;
   fanCount: number;
   topCount: number;
+  secondCount: number;
+  // how far clear the leader is; a board with nobody chasing carries a large sentinel
+  gap: number;
   top: Fan | null;
 }
 


### PR DESCRIPTION
Two things spotted on prod after #209.

## The player preview was cut off

`PlayerPreview` is a fixed-width card holding a fixed-width panel for the pinned item. A long username made the left column wider than the space left over, so the item panel hung past the card's right edge and `overflow-hidden` clipped the art and its name. Reproduced with a 27-character username: the panel sat 44px outside the card.

The left column is `flex-1 min-w-0` now, so it shrinks and the username truncates instead. The card is also capped at `calc(100vw - 16px)`, and the viewport clamp measures against the width the card will actually get rather than its ideal one, which had been pinning the card 88px off-screen left on a phone.

## "Contested" counted fans, not closeness

The tag was `fanCount >= 3`, so a board whose leader was 60 copies clear still wore it. The sweep now stores `secondCount` and `gap` (the leader's margin). The tag reads `gap <= 3`, and the "Most contested" tab sorts by `gap` ascending so the closest race leads. A board with no leader, or with nobody behind them, carries a sentinel and sorts behind every real race.

## Tests

A new fandom test builds three boards (a 60-copy runaway with three fans, a one-copy race with two, and a lone holder) and asserts the gaps and the tab order. Backend 615 passing; frontend lint, types, unit, e2e and build clean.

Measured after the fix at 1440px, 768px and 390px: the item panel sits inside the card at every width and the page never scrolls sideways.