### PR TITLE
feat(badges): the full badge list, and one per collection

### DIFF
--- a/backend/__tests__/integration/badges.test.js
+++ b/backend/__tests__/integration/badges.test.js
@@ -7,6 +7,8 @@ const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
 const User = require("../../models/User");
 const MissionState = require("../../models/MissionState");
 const Notification = require("../../models/Notification");
+const Item = require("../../models/Item");
+const Case = require("../../models/Case");
 const badges = require("../../utils/badges");
 
 let app;
@@ -184,6 +186,96 @@ describe("the backfill sweep", () => {
     // granting again changes nothing, so it says nothing
     await badges.grant(user._id, "contributor");
     expect(await Notification.countDocuments({ receiverId: user._id })).toBe(1);
+  });
+});
+
+describe("collection badges", () => {
+  // one category, two cases, four distinct items between them
+  async function makeCategory(category, titles) {
+    const items = [];
+    for (const title of titles) {
+      items.push(await Item.create({ name: title, image: "i.png", rarity: "2", baseValue: 10 }));
+    }
+    const half = Math.ceil(items.length / 2);
+    await Case.create({ title: `${category} A`, image: "c.png", price: 100, category, items: items.slice(0, half).map((i) => i._id) });
+    await Case.create({ title: `${category} B`, image: "c.png", price: 100, category, items: items.slice(half).map((i) => i._id) });
+    return items;
+  }
+
+  const own = (items) =>
+    items.map((it) => ({ _id: it._id, name: it.name, image: it.image, rarity: it.rarity }));
+
+  it("groups a category across all of its cases", async () => {
+    await makeCategory("Blue Archive", ["a", "b", "c", "d"]);
+    const sets = await badges.collectionSets();
+    expect(sets).toHaveLength(1);
+    expect(sets[0]).toMatchObject({ slug: "blue-archive", label: "Blue Archive" });
+    expect(sets[0].ids.size).toBe(4);
+  });
+
+  it("awards only a whole collection, and keeps it afterwards", async () => {
+    const items = await makeCategory("Touhou", ["a", "b", "c", "d"]);
+    const whole = await makeUser({ inventory: own(items) });
+    const nearly = await makeUser({ inventory: own(items.slice(0, 3)) });
+
+    expect(await badges.sweepCollections()).toBe(1);
+    expect(badges.heldBadges(await User.findById(whole._id).lean()).map((b) => b.key)).toEqual([
+      "collection:touhou",
+    ]);
+    expect(badges.heldBadges(await User.findById(nearly._id).lean())).toHaveLength(0);
+
+    // selling the set afterwards does not take the badge back
+    await User.updateOne({ _id: whole._id }, { $set: { inventory: [] } });
+    expect(badges.heldBadges(await User.findById(whole._id).lean()).map((b) => b.key)).toEqual([
+      "collection:touhou",
+    ]);
+    // and a second pass has nothing to do
+    expect(await badges.sweepCollections()).toBe(0);
+  });
+
+  it("carries the category name and tells the player", async () => {
+    const items = await makeCategory("Uma Musume", ["a", "b"]);
+    const user = await makeUser({ inventory: own(items) });
+
+    await badges.sweepCollections();
+    const held = badges.heldBadges(await User.findById(user._id).lean());
+    expect(held[0]).toMatchObject({ key: "collection:uma-musume", label: "Uma Musume" });
+
+    const notes = await Notification.find({ receiverId: user._id }).lean();
+    expect(notes).toHaveLength(1);
+    expect(notes[0].content).toContain("Uma Musume");
+  });
+
+  it("counts duplicates as one slot, not as progress", async () => {
+    const items = await makeCategory("Animals", ["a", "b", "c"]);
+    // three copies of one item is not three slots
+    const hoarder = await makeUser({ inventory: own([items[0], items[0], items[0]]) });
+    expect(await badges.sweepCollections()).toBe(0);
+    expect(badges.heldBadges(await User.findById(hoarder._id).lean())).toHaveLength(0);
+  });
+
+  it("lists every collection in the catalogue", async () => {
+    await makeCategory("Touhou", ["a", "b"]);
+    await makeCategory("Animals", ["c", "d", "e"]);
+    const list = await badges.catalog();
+    expect(list.map((b) => b.key)).toEqual(
+      expect.arrayContaining(["topFan", "contributor", "connected", "collection:touhou", "collection:animals"])
+    );
+    expect(list.find((b) => b.key === "collection:animals")).toMatchObject({ label: "Animals", size: 3 });
+
+    const res = await request(app).get("/users/badges/catalog");
+    expect(res.status).toBe(200);
+    expect(res.body.badges.length).toBe(list.length);
+  });
+
+  it("refuses to hand a collection badge out from the backoffice", async () => {
+    const admin = await makeUser({ isAdmin: true });
+    const target = await makeUser();
+    const res = await request(app)
+      .put(`/admin/users/${target._id}/badge`)
+      .set("Authorization", `Bearer ${tokenFor(admin)}`)
+      .send({ key: "collection:touhou" });
+    expect(res.status).toBe(400);
   });
 });
 

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -77,6 +77,9 @@ const UserSchema = new mongoose.Schema({
       key: { type: String, required: true },
       awardedAt: { type: Date, default: Date.now },
       note: String,
+      // the human name behind a keyed badge, so a collection one can be shown without
+      // looking its category up again
+      label: String,
     },
   ],
   // the one badge the player wears around the site. nothing shows until they pick one.

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -279,6 +279,17 @@ router.get("/me", authMiddleware.isAuthenticated, async (req, res) => {
   }
 });
 
+// what badges exist to be earned. two segments on purpose: a single-segment path here
+// would be swallowed by the GET /:id catch-all at the bottom of the file.
+router.get("/badges/catalog", async (req, res) => {
+  try {
+    res.json({ badges: await badges.catalog() });
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send("Server error");
+  }
+});
+
 // Fetch top players
 router.get('/topPlayers', async (req, res) => {
   try {

--- a/backend/tasks/cronJobs.js
+++ b/backend/tasks/cronJobs.js
@@ -54,6 +54,8 @@ module.exports = {
                 console.log(`Fan boards rebuilt: ${result.boards} boards, ${result.players} ranked.`);
                 const connected = await badges.sweepConnected(io);
                 if (connected) console.log(`Connected badge awarded to ${connected} players.`);
+                const collections = await badges.sweepCollections(io);
+                if (collections) console.log(`Collection badges awarded: ${collections}.`);
             } catch (error) {
                 console.error('Error rebuilding fan boards:', error);
             }

--- a/backend/utils/badges.js
+++ b/backend/utils/badges.js
@@ -1,6 +1,7 @@
 const User = require("../models/User");
 const MissionState = require("../models/MissionState");
 const Notification = require("../models/Notification");
+const Case = require("../models/Case");
 const { CATALOG } = require("./missionsCatalog");
 
 const TOP_FAN = "topFan";
@@ -11,6 +12,12 @@ const CONNECTED = "connected";
 // those over would let the backoffice fake a standing the sweep is about to overwrite.
 const GRANTABLE = [CONTRIBUTOR];
 const KEYS = [TOP_FAN, CONTRIBUTOR, CONNECTED];
+// one badge per case category, keyed off a slug of its name so a new category earns one
+// without a code change
+const COLLECTION = "collection:";
+const isCollection = (key) => typeof key === "string" && key.startsWith(COLLECTION);
+const slugify = (category) =>
+  String(category).toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 
 // stored notifications are english everywhere else in the codebase, so these are too
 const TITLES = { [CONTRIBUTOR]: "Contributor", [CONNECTED]: "Connected" };
@@ -36,8 +43,14 @@ function heldBadges(user) {
     });
   }
   for (const badge of user.badges || []) {
-    if (!KEYS.includes(badge.key) || badge.key === TOP_FAN) continue;
-    held.push({ key: badge.key, awardedAt: badge.awardedAt || null, note: badge.note || null });
+    if (badge.key === TOP_FAN) continue;
+    if (!KEYS.includes(badge.key) && !isCollection(badge.key)) continue;
+    held.push({
+      key: badge.key,
+      awardedAt: badge.awardedAt || null,
+      note: badge.note || null,
+      label: badge.label || null,
+    });
   }
   return held;
 }
@@ -51,8 +64,9 @@ function wornBadge(user) {
 
 // a badge lands silently otherwise: it sits on the profile with nothing telling the
 // player it arrived. the socket emit is optional, the stored row is not.
-async function notifyBadge(userId, key, io) {
-  const content = `You earned the ${TITLES[key] || key} badge. Pick it on your profile to wear it.`;
+async function notifyBadge(userId, key, io, label) {
+  const name = label || TITLES[key] || key;
+  const content = `You earned the ${name} badge. Pick it on your profile to wear it.`;
   await Notification.create({
     senderId: userId,
     receiverId: userId,
@@ -65,15 +79,16 @@ async function notifyBadge(userId, key, io) {
 
 // the filter is the mutex: a badge already held is not pushed twice, and only a real
 // award notifies
-async function award(userId, key, io, note) {
+async function award(userId, key, io, note, label) {
   const badge = { key, awardedAt: new Date() };
   if (note) badge.note = String(note).slice(0, 120);
+  if (label) badge.label = String(label).slice(0, 60);
   const res = await User.updateOne(
     { _id: userId, "badges.key": { $ne: key } },
     { $push: { badges: badge } }
   );
   if (res.modifiedCount !== 1) return false;
-  await notifyBadge(userId, key, io);
+  await notifyBadge(userId, key, io, label);
   return true;
 }
 
@@ -101,6 +116,64 @@ async function sweepConnected(io) {
   return awarded;
 }
 
+// every case category and the item ids that make it whole. a category is complete only
+// when the player owns one of every distinct item across all of its cases.
+async function collectionSets() {
+  const cases = await Case.find({}, { category: 1, items: 1 }).lean();
+  const byCategory = new Map();
+  for (const one of cases) {
+    const label = (one.category || "").trim();
+    if (!label) continue;
+    const slug = slugify(label);
+    if (!slug) continue;
+    if (!byCategory.has(slug)) byCategory.set(slug, { slug, label, ids: new Set() });
+    for (const id of one.items || []) byCategory.get(slug).ids.add(String(id));
+  }
+  return [...byCategory.values()].filter((c) => c.ids.size > 0);
+}
+
+// completing a collection is kept for good: selling something afterwards does not take it
+// back, so nobody has to be afraid to trade once they have it.
+async function sweepCollections(io) {
+  const sets = await collectionSets();
+  if (!sets.length) return 0;
+  const smallest = Math.min(...sets.map((c) => c.ids.size));
+
+  // an inventory shorter than the smallest collection cannot complete anything, which
+  // skips most accounts before their items are ever read
+  const cursor = User.find({ $expr: { $gte: [{ $size: { $ifNull: ["$inventory", []] } }, smallest] } })
+    .select("inventory badges")
+    .lean()
+    .cursor();
+
+  let awarded = 0;
+  for await (const user of cursor) {
+    const owned = new Set();
+    for (const entry of user.inventory || []) if (entry && entry._id) owned.add(String(entry._id));
+    const has = new Set((user.badges || []).map((b) => b.key));
+    for (const set of sets) {
+      const key = COLLECTION + set.slug;
+      if (has.has(key) || owned.size < set.ids.size) continue;
+      let whole = true;
+      for (const id of set.ids) {
+        if (!owned.has(id)) { whole = false; break; }
+      }
+      if (whole && (await award(user._id, key, io, null, set.label))) awarded += 1;
+    }
+  }
+  return awarded;
+}
+
+// what exists to be earned, for the "all badges" list. the collection ones come from the
+// live categories rather than a hardcoded set.
+async function catalog() {
+  const sets = await collectionSets();
+  return [
+    ...KEYS.map((key) => ({ key, label: null })),
+    ...sets.map((set) => ({ key: COLLECTION + set.slug, label: set.label, size: set.ids.size })),
+  ];
+}
+
 async function grant(userId, key, note, io) {
   if (!GRANTABLE.includes(key)) return { ok: false, message: "That badge is earned, not granted" };
   return { ok: true, changed: await award(userId, key, io, note) };
@@ -121,6 +194,12 @@ module.exports = {
   CONNECTED,
   KEYS,
   GRANTABLE,
+  COLLECTION,
+  isCollection,
+  slugify,
+  collectionSets,
+  sweepCollections,
+  catalog,
   SOCIAL_KEYS,
   heldBadges,
   wornBadge,

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,8 +1,8 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
-import { BsBroadcast, BsHammer } from "react-icons/bs";
-import { Badge as BadgeData, BadgeKey } from "../services/badges/BadgeService";
+import { BsBroadcast, BsHammer, BsBoxSeam } from "react-icons/bs";
+import { Badge as BadgeData, BadgeKey, isCollectionBadge } from "../services/badges/BadgeService";
 import { rarityColor, rarityName } from "../utils/rarity";
 import i18n from "../i18n";
 
@@ -23,7 +23,23 @@ const CARD_W = 240;
 // in the hover card, because a 18px picture of anything is unreadable in a table row.
 export const BADGE_KEYS: BadgeKey[] = ["topFan", "contributor", "connected"];
 
-const FACE: Record<BadgeKey, { from: string; to: string; ink: string; icon: JSX.Element }> = {
+interface Face {
+  from: string;
+  to: string;
+  ink: string;
+  icon: JSX.Element;
+}
+
+// every collection badge wears the same face; the category is what tells them apart, and
+// it is in the name rather than the mark
+const COLLECTION_FACE: Face = {
+  from: "#3FCF8E",
+  to: "#1E8E5A",
+  ink: "#062B1B",
+  icon: <BsBoxSeam size="62%" />,
+};
+
+const FACE: Record<string, Face> = {
   topFan: {
     from: "#FFCC00",
     to: "#E0A213",
@@ -48,12 +64,25 @@ const FACE: Record<BadgeKey, { from: string; to: string; ink: string; icon: JSX.
   },
 };
 
+// a collection badge has no entry of its own: they all share one face
+export const faceFor = (key: string): Face | null =>
+  FACE[key] || (isCollectionBadge(key) ? COLLECTION_FACE : null);
+
+// the flavour name for a collection comes from i18n where one exists, and falls back to
+// the category itself so a new category needs no translation to be readable
+export const badgeName = (key: string, label?: string | null): string => {
+  if (!isCollectionBadge(key)) return i18n.t(`badge.${key}`);
+  const flavour = `badge.collection.${key.slice("collection:".length)}`;
+  if (i18n.exists(flavour)) return i18n.t(flavour);
+  return i18n.t("badge.collectionGeneric", { category: label || key });
+};
+
 export const BadgeFace: React.FC<{
   badgeKey: BadgeKey;
   size?: keyof typeof MARK;
   muted?: boolean;
 }> = ({ badgeKey, size = "inline", muted = false }) => {
-  const face = FACE[badgeKey];
+  const face = faceFor(badgeKey);
   if (!face) return null;
   return (
     <span
@@ -84,10 +113,10 @@ const Badge: React.FC<BadgeProps> = ({ badge, size = "inline", linked = true, ho
     setAt({ top: box.bottom + CARD_GAP, left });
   }, [hovered]);
 
-  if (!badge || !FACE[badge.key]) return null;
+  const face = badge ? faceFor(badge.key) : null;
+  if (!badge || !face) return null;
 
-  const face = FACE[badge.key];
-  const name = i18n.t(`badge.${badge.key}`);
+  const name = badgeName(badge.key, badge.label);
   const fandom = badge.fandom;
   const label = fandom ? i18n.t("fandom.badgeTitle", { name: fandom.name, count: fandom.count }) : name;
   const rivals = fandom ? Math.max(0, fandom.fans - 1) : 0;
@@ -153,7 +182,9 @@ const Badge: React.FC<BadgeProps> = ({ badge, size = "inline", linked = true, ho
         ) : (
           <>
             <p className="mt-2 text-[12px] leading-relaxed text-[#C9C6DE]">
-              {i18n.t(`badge.${badge.key}Hint`)}
+              {isCollectionBadge(badge.key)
+                ? i18n.t("badge.collectionHint", { category: badge.label || "" })
+                : i18n.t(`badge.${badge.key}Hint`)}
             </p>
             {badge.note && <p className="mt-2 text-[11px] italic text-[#84819A]">{badge.note}</p>}
             {badge.awardedAt && (

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -15,12 +15,14 @@ interface BadgeProps {
   hoverCard?: boolean;
 }
 
-const MARK = { inline: "h-[18px] w-[18px]", large: "h-6 w-6" };
+const MARK = { inline: "h-[18px] w-[18px]", large: "h-6 w-6", xl: "h-10 w-10" };
 const CARD_GAP = 10;
 const CARD_W = 240;
 
 // one mark per badge, all the same size and shape. the detail that tells them apart lives
 // in the hover card, because a 18px picture of anything is unreadable in a table row.
+export const BADGE_KEYS: BadgeKey[] = ["topFan", "contributor", "connected"];
+
 const FACE: Record<BadgeKey, { from: string; to: string; ink: string; icon: JSX.Element }> = {
   topFan: {
     from: "#FFCC00",
@@ -44,6 +46,27 @@ const FACE: Record<BadgeKey, { from: string; to: string; ink: string; icon: JSX.
     ink: "#ffffff",
     icon: <BsBroadcast size="68%" />,
   },
+};
+
+export const BadgeFace: React.FC<{
+  badgeKey: BadgeKey;
+  size?: keyof typeof MARK;
+  muted?: boolean;
+}> = ({ badgeKey, size = "inline", muted = false }) => {
+  const face = FACE[badgeKey];
+  if (!face) return null;
+  return (
+    <span
+      style={
+        muted
+          ? { backgroundImage: "linear-gradient(to bottom, #3A365A, #2A2840)", color: "#625F7E" }
+          : { backgroundImage: `linear-gradient(to bottom, ${face.from}, ${face.to})`, color: face.ink }
+      }
+      className={`notched-xs inline-flex shrink-0 items-center justify-center ${MARK[size]}`}
+    >
+      {face.icon}
+    </span>
+  );
 };
 
 const Badge: React.FC<BadgeProps> = ({ badge, size = "inline", linked = true, hoverCard = true }) => {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -54,6 +54,16 @@
     "awarded": "Verliehen am {{date}}",
     "chooseHint": "Wähle eines, das du auf der Seite trägst.",
     "clearHint": "Klicke auf das getragene, um es abzulegen.",
+    "collection": {
+      "animals": "Zoowärter",
+      "blue-archive": "Kivotos-Experte",
+      "counter-strike": "Waffenhändler",
+      "touhou": "Gensokyo-Experte",
+      "uma-musume": "Legendärer Trainer"
+    },
+    "collectionGeneric": "{{category}}-Experte",
+    "collectionHint": "Besitzt jeden Gegenstand der {{category}}-Sammlung.",
+    "collectionHow": "Sammle alle {{count}} Gegenstände aus sämtlichen {{category}}-Kisten. Einmal erhalten, bleibt es.",
     "connected": "Verbunden",
     "connectedHint": "Ist dem Discord beigetreten und folgt auf X.",
     "connectedHow": "Hole dir beide sozialen Missionen im Missionen-Tab: dem Discord beitreten und auf X folgen.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -49,20 +49,30 @@
     "signUp": "Registrieren"
   },
   "badge": {
+    "allCount": "Du hast {{held}} von {{total}}",
+    "allTitle": "Alle Abzeichen",
     "awarded": "Verliehen am {{date}}",
     "chooseHint": "Wähle eines, das du auf der Seite trägst.",
     "clearHint": "Klicke auf das getragene, um es abzulegen.",
     "connected": "Verbunden",
     "connectedHint": "Ist dem Discord beigetreten und folgt auf X.",
+    "connectedHow": "Hole dir beide sozialen Missionen im Missionen-Tab: dem Discord beitreten und auf X folgen.",
     "contributor": "Mitwirkender",
     "contributorHint": "Hat beim Aufbau von KaniCasino geholfen.",
+    "contributorHow": "Von Hand verliehen für Hilfe beim Aufbau von KaniCasino: Kunst, Übersetzungen, Code, Ideen.",
     "couldNotSave": "Diese Wahl konnte nicht gespeichert werden",
     "grant": "Abzeichen verleihen",
+    "locked": "NICHT ERHALTEN",
+    "noneTheirs": "Noch keine Abzeichen.",
+    "noneYours": "Du hast noch keine Abzeichen.",
     "note": "Was hat die Person getan?",
     "revoke": "Entziehen",
+    "seeAll": "Alle Abzeichen ansehen",
     "shelfTitle": "Abzeichen",
     "topFan": "Top-Fan",
-    "topFanHint": "Besitzt mehr Exemplare eines Charakters als alle anderen."
+    "topFanHint": "Besitzt mehr Exemplare eines Charakters als alle anderen.",
+    "topFanHow": "Hefte einen Charakter an dein Profil und besitze mehr Exemplare davon als alle anderen.",
+    "wearing": "GETRAGEN"
   },
   "balance": {
     "admin_adjust": "Admin-Korrektur",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -54,6 +54,16 @@
     "awarded": "Awarded {{date}}",
     "chooseHint": "Pick one to wear around the site.",
     "clearHint": "Click the one you are wearing to take it off.",
+    "collection": {
+      "animals": "Zookeeper",
+      "blue-archive": "Kivotos Expert",
+      "counter-strike": "Arms Dealer",
+      "touhou": "Gensokyo Expert",
+      "uma-musume": "Trainer Legend"
+    },
+    "collectionGeneric": "{{category}} Expert",
+    "collectionHint": "Owns every item in the {{category}} collection.",
+    "collectionHow": "Collect all {{count}} items across every {{category}} case. Kept for good once earned.",
     "connected": "Connected",
     "connectedHint": "Joined the Discord and follows on X.",
     "connectedHow": "Claim both social missions on your Missions tab: join the Discord and follow on X.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -49,20 +49,30 @@
     "signUp": "Sign up"
   },
   "badge": {
+    "allCount": "You have {{held}} of {{total}}",
+    "allTitle": "All badges",
     "awarded": "Awarded {{date}}",
     "chooseHint": "Pick one to wear around the site.",
     "clearHint": "Click the one you are wearing to take it off.",
     "connected": "Connected",
     "connectedHint": "Joined the Discord and follows on X.",
+    "connectedHow": "Claim both social missions on your Missions tab: join the Discord and follow on X.",
     "contributor": "Contributor",
     "contributorHint": "Helped build KaniCasino.",
+    "contributorHow": "Given by hand for helping build KaniCasino: art, translations, code, ideas.",
     "couldNotSave": "Could not save that choice",
     "grant": "Grant badge",
+    "locked": "NOT EARNED",
+    "noneTheirs": "No badges yet.",
+    "noneYours": "You have no badges yet.",
     "note": "What did they do?",
     "revoke": "Revoke",
+    "seeAll": "See all badges",
     "shelfTitle": "Badges",
     "topFan": "Top Fan",
-    "topFanHint": "Holds more of one character than anybody else."
+    "topFanHint": "Holds more of one character than anybody else.",
+    "topFanHow": "Pin a character to your profile and hold more copies of them than anyone else.",
+    "wearing": "WEARING"
   },
   "balance": {
     "admin_adjust": "Admin adjustment",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -49,20 +49,30 @@
     "signUp": "Registrarse"
   },
   "badge": {
+    "allCount": "Tienes {{held}} de {{total}}",
+    "allTitle": "Todas las insignias",
     "awarded": "Concedida el {{date}}",
     "chooseHint": "Elige una para llevar por el sitio.",
     "clearHint": "Haz clic en la que llevas para quitártela.",
     "connected": "Conectado",
     "connectedHint": "Se unió al Discord y sigue en X.",
+    "connectedHow": "Reclama las dos misiones sociales en tu pestaña Misiones: unirte al Discord y seguir en X.",
     "contributor": "Colaborador",
     "contributorHint": "Ayudó a construir KaniCasino.",
+    "contributorHow": "Concedida a mano por ayudar a construir KaniCasino: arte, traducciones, código, ideas.",
     "couldNotSave": "No se pudo guardar esa elección",
     "grant": "Conceder insignia",
+    "locked": "NO CONSEGUIDA",
+    "noneTheirs": "Aún sin insignias.",
+    "noneYours": "Aún no tienes insignias.",
     "note": "¿Qué hizo?",
     "revoke": "Retirar",
+    "seeAll": "Ver todas las insignias",
     "shelfTitle": "Insignias",
     "topFan": "Top Fan",
-    "topFanHint": "Tiene más copias de un personaje que nadie."
+    "topFanHint": "Tiene más copias de un personaje que nadie.",
+    "topFanHow": "Fija un personaje en tu perfil y ten más copias suyas que nadie.",
+    "wearing": "EN USO"
   },
   "balance": {
     "admin_adjust": "Ajuste administrativo",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -54,6 +54,16 @@
     "awarded": "Concedida el {{date}}",
     "chooseHint": "Elige una para llevar por el sitio.",
     "clearHint": "Haz clic en la que llevas para quitártela.",
+    "collection": {
+      "animals": "Cuidador del Zoo",
+      "blue-archive": "Experto de Kivotos",
+      "counter-strike": "Traficante de Armas",
+      "touhou": "Experto de Gensokyo",
+      "uma-musume": "Entrenador Legendario"
+    },
+    "collectionGeneric": "Experto de {{category}}",
+    "collectionHint": "Tiene todos los objetos de la colección {{category}}.",
+    "collectionHow": "Reúne los {{count}} objetos de todas las cajas de {{category}}. Una vez conseguida, es para siempre.",
     "connected": "Conectado",
     "connectedHint": "Se unió al Discord y sigue en X.",
     "connectedHow": "Reclama las dos misiones sociales en tu pestaña Misiones: unirte al Discord y seguir en X.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -49,20 +49,30 @@
     "signUp": "S'inscrire"
   },
   "badge": {
+    "allCount": "Vous en avez {{held}} sur {{total}}",
+    "allTitle": "Tous les badges",
     "awarded": "Attribué le {{date}}",
     "chooseHint": "Choisissez-en un à porter sur le site.",
     "clearHint": "Cliquez sur celui que vous portez pour l'enlever.",
     "connected": "Connecté",
     "connectedHint": "A rejoint le Discord et suit sur X.",
+    "connectedHow": "Réclamez les deux missions sociales dans l'onglet Missions : rejoindre le Discord et suivre sur X.",
     "contributor": "Contributeur",
     "contributorHint": "A participé à la construction de KaniCasino.",
+    "contributorHow": "Attribué à la main pour avoir aidé à construire KaniCasino : art, traductions, code, idées.",
     "couldNotSave": "Impossible d'enregistrer ce choix",
     "grant": "Attribuer un badge",
+    "locked": "NON OBTENU",
+    "noneTheirs": "Pas encore de badge.",
+    "noneYours": "Vous n'avez pas encore de badge.",
     "note": "Qu'a-t-il fait ?",
     "revoke": "Retirer",
+    "seeAll": "Voir tous les badges",
     "shelfTitle": "Badges",
     "topFan": "Top Fan",
-    "topFanHint": "Possède plus d'exemplaires d'un personnage que quiconque."
+    "topFanHint": "Possède plus d'exemplaires d'un personnage que quiconque.",
+    "topFanHow": "Épinglez un personnage sur votre profil et possédez-en plus d'exemplaires que quiconque.",
+    "wearing": "PORTÉ"
   },
   "balance": {
     "admin_adjust": "Ajustement administrateur",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -54,6 +54,16 @@
     "awarded": "Attribué le {{date}}",
     "chooseHint": "Choisissez-en un à porter sur le site.",
     "clearHint": "Cliquez sur celui que vous portez pour l'enlever.",
+    "collection": {
+      "animals": "Gardien du Zoo",
+      "blue-archive": "Expert de Kivotos",
+      "counter-strike": "Marchand d'Armes",
+      "touhou": "Expert de Gensokyo",
+      "uma-musume": "Entraîneur Légendaire"
+    },
+    "collectionGeneric": "Expert de {{category}}",
+    "collectionHint": "Possède tous les objets de la collection {{category}}.",
+    "collectionHow": "Réunissez les {{count}} objets de toutes les caisses {{category}}. Acquis une fois, gardé pour toujours.",
     "connected": "Connecté",
     "connectedHint": "A rejoint le Discord et suit sur X.",
     "connectedHow": "Réclamez les deux missions sociales dans l'onglet Missions : rejoindre le Discord et suivre sur X.",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -54,6 +54,16 @@
     "awarded": "Diberikan {{date}}",
     "chooseHint": "Pilih satu untuk dipakai di seluruh situs.",
     "clearHint": "Klik lencana yang dipakai untuk melepasnya.",
+    "collection": {
+      "animals": "Penjaga Kebun Binatang",
+      "blue-archive": "Ahli Kivotos",
+      "counter-strike": "Pedagang Senjata",
+      "touhou": "Ahli Gensokyo",
+      "uma-musume": "Pelatih Legendaris"
+    },
+    "collectionGeneric": "Ahli {{category}}",
+    "collectionHint": "Punya semua item di koleksi {{category}}.",
+    "collectionHow": "Kumpulkan semua {{count}} item dari setiap case {{category}}. Sekali didapat, disimpan selamanya.",
     "connected": "Terhubung",
     "connectedHint": "Sudah gabung Discord dan mengikuti di X.",
     "connectedHow": "Klaim kedua misi sosial di tab Misi: gabung Discord dan ikuti di X.",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -49,20 +49,30 @@
     "signUp": "Daftar (member baru)"
   },
   "badge": {
+    "allCount": "Kamu punya {{held}} dari {{total}}",
+    "allTitle": "Semua lencana",
     "awarded": "Diberikan {{date}}",
     "chooseHint": "Pilih satu untuk dipakai di seluruh situs.",
     "clearHint": "Klik lencana yang dipakai untuk melepasnya.",
     "connected": "Terhubung",
     "connectedHint": "Sudah gabung Discord dan mengikuti di X.",
+    "connectedHow": "Klaim kedua misi sosial di tab Misi: gabung Discord dan ikuti di X.",
     "contributor": "Kontributor",
     "contributorHint": "Ikut membangun KaniCasino.",
+    "contributorHow": "Diberikan langsung karena ikut membangun KaniCasino: gambar, terjemahan, kode, ide.",
     "couldNotSave": "Tidak bisa menyimpan pilihan itu",
     "grant": "Beri lencana",
+    "locked": "BELUM DIDAPAT",
+    "noneTheirs": "Belum ada lencana.",
+    "noneYours": "Kamu belum punya lencana.",
     "note": "Apa yang dia lakukan?",
     "revoke": "Cabut",
+    "seeAll": "Lihat semua lencana",
     "shelfTitle": "Lencana",
     "topFan": "Top Fan",
-    "topFanHint": "Punya lebih banyak salinan satu karakter daripada siapa pun."
+    "topFanHint": "Punya lebih banyak salinan satu karakter daripada siapa pun.",
+    "topFanHow": "Sematkan satu karakter di profilmu dan kumpulkan lebih banyak daripada siapa pun.",
+    "wearing": "DIPAKAI"
   },
   "balance": {
     "admin_adjust": "Penyesuaian admin",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -49,20 +49,30 @@
     "signUp": "Registrati"
   },
   "badge": {
+    "allCount": "Ne hai {{held}} su {{total}}",
+    "allTitle": "Tutti i distintivi",
     "awarded": "Assegnato il {{date}}",
     "chooseHint": "Scegline uno da portare per il sito.",
     "clearHint": "Clicca su quello che porti per toglierlo.",
     "connected": "Connesso",
     "connectedHint": "È entrato nel Discord e segue su X.",
+    "connectedHow": "Riscuoti entrambe le missioni social nella scheda Missioni: entra nel Discord e segui su X.",
     "contributor": "Collaboratore",
     "contributorHint": "Ha aiutato a costruire KaniCasino.",
+    "contributorHow": "Assegnato a mano per aver aiutato a costruire KaniCasino: arte, traduzioni, codice, idee.",
     "couldNotSave": "Impossibile salvare questa scelta",
     "grant": "Assegna distintivo",
+    "locked": "NON OTTENUTO",
+    "noneTheirs": "Ancora nessun distintivo.",
+    "noneYours": "Non hai ancora distintivi.",
     "note": "Che cosa ha fatto?",
     "revoke": "Rimuovi",
+    "seeAll": "Vedi tutti i distintivi",
     "shelfTitle": "Distintivi",
     "topFan": "Top Fan",
-    "topFanHint": "Possiede più copie di un personaggio di chiunque altro."
+    "topFanHint": "Possiede più copie di un personaggio di chiunque altro.",
+    "topFanHow": "Fissa un personaggio sul tuo profilo e possiedine più copie di chiunque altro.",
+    "wearing": "INDOSSATO"
   },
   "balance": {
     "admin_adjust": "Rettifica amministrativa",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -54,6 +54,16 @@
     "awarded": "Assegnato il {{date}}",
     "chooseHint": "Scegline uno da portare per il sito.",
     "clearHint": "Clicca su quello che porti per toglierlo.",
+    "collection": {
+      "animals": "Guardiano dello Zoo",
+      "blue-archive": "Esperto di Kivotos",
+      "counter-strike": "Trafficante d'Armi",
+      "touhou": "Esperto di Gensokyo",
+      "uma-musume": "Allenatore Leggendario"
+    },
+    "collectionGeneric": "Esperto di {{category}}",
+    "collectionHint": "Possiede ogni oggetto della collezione {{category}}.",
+    "collectionHow": "Raccogli tutti i {{count}} oggetti di ogni cassa {{category}}. Una volta ottenuto, resta per sempre.",
     "connected": "Connesso",
     "connectedHint": "È entrato nel Discord e segue su X.",
     "connectedHow": "Riscuoti entrambe le missioni social nella scheda Missioni: entra nel Discord e segui su X.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -49,20 +49,30 @@
     "signUp": "新規登録"
   },
   "badge": {
+    "allCount": "{{total}} 中 {{held}} 個取得済み",
+    "allTitle": "すべてのバッジ",
     "awarded": "{{date}} に付与",
     "chooseHint": "サイト内で付けるバッジを選んでください。",
     "clearHint": "付けているバッジをクリックすると外せます。",
     "connected": "連携済み",
     "connectedHint": "Discord に参加し、X をフォロー済み。",
+    "connectedHow": "ミッションタブでソーシャルミッションを両方受け取ってください：Discord 参加と X のフォロー。",
     "contributor": "貢献者",
     "contributorHint": "KaniCasino の制作を手伝いました。",
+    "contributorHow": "KaniCasino の制作への協力（アート、翻訳、コード、アイデア）に対して手動で付与されます。",
     "couldNotSave": "この選択を保存できませんでした",
     "grant": "バッジを付与",
+    "locked": "未取得",
+    "noneTheirs": "まだバッジはありません。",
+    "noneYours": "まだバッジがありません。",
     "note": "何をした人ですか？",
     "revoke": "取り消し",
+    "seeAll": "すべてのバッジを見る",
     "shelfTitle": "バッジ",
     "topFan": "トップファン",
-    "topFanHint": "あるキャラクターを誰よりも多く持っています。"
+    "topFanHint": "あるキャラクターを誰よりも多く持っています。",
+    "topFanHow": "キャラクターをプロフィールに固定し、誰よりも多く集めましょう。",
+    "wearing": "付けています"
   },
   "balance": {
     "admin_adjust": "管理者による調整",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -54,6 +54,16 @@
     "awarded": "{{date}} に付与",
     "chooseHint": "サイト内で付けるバッジを選んでください。",
     "clearHint": "付けているバッジをクリックすると外せます。",
+    "collection": {
+      "animals": "動物園長",
+      "blue-archive": "キヴォトスマスター",
+      "counter-strike": "武器商",
+      "touhou": "幻想郷マスター",
+      "uma-musume": "伝説のトレーナー"
+    },
+    "collectionGeneric": "{{category}} マスター",
+    "collectionHint": "{{category}} コレクションの全アイテムを所持。",
+    "collectionHow": "{{category}} の全ケースから {{count}} 種を集めましょう。一度取ればずっと残ります。",
     "connected": "連携済み",
     "connectedHint": "Discord に参加し、X をフォロー済み。",
     "connectedHow": "ミッションタブでソーシャルミッションを両方受け取ってください：Discord 参加と X のフォロー。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -54,6 +54,16 @@
     "awarded": "{{date}} 수여",
     "chooseHint": "사이트에서 달고 다닐 뱃지를 고르세요.",
     "clearHint": "달고 있는 뱃지를 누르면 벗습니다.",
+    "collection": {
+      "animals": "동물원장",
+      "blue-archive": "키보토스 달인",
+      "counter-strike": "무기상",
+      "touhou": "환상향 달인",
+      "uma-musume": "전설의 트레이너"
+    },
+    "collectionGeneric": "{{category}} 달인",
+    "collectionHint": "{{category}} 컴렉션의 모든 아이템을 보유.",
+    "collectionHow": "모든 {{category}} 케이스의 {{count}}개 아이템을 모으세요. 한 번 받으면 영원합니다.",
     "connected": "연결됨",
     "connectedHint": "Discord에 참여하고 X를 팔로우합니다.",
     "connectedHow": "미션 탭에서 소셜 미션 두 개를 모두 수령하세요: Discord 참여와 X 팔로우.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -49,20 +49,30 @@
     "signUp": "회원가입"
   },
   "badge": {
+    "allCount": "{{total}}개 중 {{held}}개 보유",
+    "allTitle": "모든 뱃지",
     "awarded": "{{date}} 수여",
     "chooseHint": "사이트에서 달고 다닐 뱃지를 고르세요.",
     "clearHint": "달고 있는 뱃지를 누르면 벗습니다.",
     "connected": "연결됨",
     "connectedHint": "Discord에 참여하고 X를 팔로우합니다.",
+    "connectedHow": "미션 탭에서 소셜 미션 두 개를 모두 수령하세요: Discord 참여와 X 팔로우.",
     "contributor": "기여자",
     "contributorHint": "KaniCasino 제작을 도았습니다.",
+    "contributorHow": "KaniCasino 제작을 도운 분께 직접 수여합니다: 그림, 번역, 코드, 아이디어.",
     "couldNotSave": "선택을 저장하지 못했습니다",
     "grant": "뱃지 수여",
+    "locked": "미획득",
+    "noneTheirs": "아직 뱃지가 없습니다.",
+    "noneYours": "아직 뱃지가 없습니다.",
     "note": "무엇을 했나요?",
     "revoke": "회수",
+    "seeAll": "모든 뱃지 보기",
     "shelfTitle": "뱃지",
     "topFan": "최고의 팬",
-    "topFanHint": "한 캐릭터를 누구보다 많이 가지고 있습니다."
+    "topFanHint": "한 캐릭터를 누구보다 많이 가지고 있습니다.",
+    "topFanHow": "프로필에 캐릭터를 고정하고 누구보다 많이 모으세요.",
+    "wearing": "착용 중"
   },
   "balance": {
     "admin_adjust": "관리자 조정",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -54,6 +54,16 @@
     "awarded": "Concedido em {{date}}",
     "chooseHint": "Escolha um para usar pelo site.",
     "clearHint": "Clique no que você está usando para tirá-lo.",
+    "collection": {
+      "animals": "Zelador do Zoológico",
+      "blue-archive": "Especialista de Kivotos",
+      "counter-strike": "Traficante de Armas",
+      "touhou": "Especialista de Gensokyo",
+      "uma-musume": "Treinador Lendário"
+    },
+    "collectionGeneric": "Especialista de {{category}}",
+    "collectionHint": "Tem todos os itens da coleção {{category}}.",
+    "collectionHow": "Colecione os {{count}} itens de todas as caixas de {{category}}. Depois de conquistado, é para sempre.",
     "connected": "Conectado",
     "connectedHint": "Entrou no Discord e segue no X.",
     "connectedHow": "Resgate as duas missões sociais na aba Missões: entrar no Discord e seguir no X.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -49,20 +49,30 @@
     "signUp": "Cadastrar"
   },
   "badge": {
+    "allCount": "Você tem {{held}} de {{total}}",
+    "allTitle": "Todos os distintivos",
     "awarded": "Concedido em {{date}}",
     "chooseHint": "Escolha um para usar pelo site.",
     "clearHint": "Clique no que você está usando para tirá-lo.",
     "connected": "Conectado",
     "connectedHint": "Entrou no Discord e segue no X.",
+    "connectedHow": "Resgate as duas missões sociais na aba Missões: entrar no Discord e seguir no X.",
     "contributor": "Colaborador",
     "contributorHint": "Ajudou a construir o KaniCasino.",
+    "contributorHow": "Concedido à mão por ajudar a construir o KaniCasino: arte, traduções, código, ideias.",
     "couldNotSave": "Não foi possível salvar essa escolha",
     "grant": "Conceder distintivo",
+    "locked": "NÃO CONQUISTADO",
+    "noneTheirs": "Ainda sem distintivos.",
+    "noneYours": "Você ainda não tem distintivos.",
     "note": "O que essa pessoa fez?",
     "revoke": "Remover",
+    "seeAll": "Ver todos os distintivos",
     "shelfTitle": "Distintivos",
     "topFan": "Top Fã",
-    "topFanHint": "Tem mais cópias de um personagem do que qualquer outro."
+    "topFanHint": "Tem mais cópias de um personagem do que qualquer outro.",
+    "topFanHow": "Fixe um personagem no seu perfil e tenha mais cópias dele do que qualquer outro.",
+    "wearing": "EM USO"
   },
   "balance": {
     "admin_adjust": "Ajuste administrativo",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -54,6 +54,16 @@
     "awarded": "Trao ngày {{date}}",
     "chooseHint": "Chọn một cái để đeo khắp trang web.",
     "clearHint": "Nhấn vào cái đang đeo để gỡ ra.",
+    "collection": {
+      "animals": "Chủ Sở Thú",
+      "blue-archive": "Cao Thủ Kivotos",
+      "counter-strike": "Trùm Buôn Súng",
+      "touhou": "Cao Thủ Gensokyo",
+      "uma-musume": "Huấn Luyện Viên Huyền Thoại"
+    },
+    "collectionGeneric": "Cao Thủ {{category}}",
+    "collectionHint": "Sở hữu mọi vật phẩm trong bộ {{category}}.",
+    "collectionHow": "Thu thập đủ {{count}} vật phẩm từ mọi rương {{category}}. Đã đạt là giữ mãi.",
     "connected": "Đã kết nối",
     "connectedHint": "Đã vào Discord và theo dõi trên X.",
     "connectedHow": "Nhận cả hai nhiệm vụ xã hội ở tab Nhiệm vụ: vào Discord và theo dõi trên X.",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -49,20 +49,30 @@
     "signUp": "Đăng ký"
   },
   "badge": {
+    "allCount": "Bạn có {{held}} trên {{total}}",
+    "allTitle": "Tất cả huy hiệu",
     "awarded": "Trao ngày {{date}}",
     "chooseHint": "Chọn một cái để đeo khắp trang web.",
     "clearHint": "Nhấn vào cái đang đeo để gỡ ra.",
     "connected": "Đã kết nối",
     "connectedHint": "Đã vào Discord và theo dõi trên X.",
+    "connectedHow": "Nhận cả hai nhiệm vụ xã hội ở tab Nhiệm vụ: vào Discord và theo dõi trên X.",
     "contributor": "Người đóng góp",
     "contributorHint": "Đã góp sức xây dựng KaniCasino.",
+    "contributorHow": "Trao tay cho người góp sức xây dựng KaniCasino: tranh, bản dịch, mã, ý tưởng.",
     "couldNotSave": "Không thể lưu lựa chọn này",
     "grant": "Trao huy hiệu",
+    "locked": "CHƯA ĐẠT",
+    "noneTheirs": "Chưa có huy hiệu nào.",
+    "noneYours": "Bạn chưa có huy hiệu nào.",
     "note": "Họ đã làm gì?",
     "revoke": "Thu hồi",
+    "seeAll": "Xem tất cả huy hiệu",
     "shelfTitle": "Huy hiệu",
     "topFan": "Fan Số Một",
-    "topFanHint": "Giữ nhiều bản của một nhân vật hơn bất kỳ ai."
+    "topFanHint": "Giữ nhiều bản của một nhân vật hơn bất kỳ ai.",
+    "topFanHow": "Ghim một nhân vật vào hồ sơ và giữ nhiều bản hơn bất kỳ ai.",
+    "wearing": "ĐANG ĐEO"
   },
   "balance": {
     "admin_adjust": "Điều chỉnh của quản trị viên",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -49,20 +49,30 @@
     "signUp": "注册"
   },
   "badge": {
+    "allCount": "你已拥有 {{total}} 中的 {{held}} 个",
+    "allTitle": "全部徽章",
     "awarded": "授予于 {{date}}",
     "chooseHint": "选一个在全站佩戴。",
     "clearHint": "点击正在佩戴的徽章即可取下。",
     "connected": "已连接",
     "connectedHint": "已加入 Discord 并在 X 上关注。",
+    "connectedHow": "在任务页领取两个社交任务：加入 Discord 并在 X 上关注。",
     "contributor": "贡献者",
     "contributorHint": "参与了 KaniCasino 的建设。",
+    "contributorHow": "手动授予，感谢参与 KaniCasino 的建设：美术、翻译、代码、点子。",
     "couldNotSave": "无法保存该选择",
     "grant": "授予徽章",
+    "locked": "尚未获得",
+    "noneTheirs": "还没有徽章。",
+    "noneYours": "你还没有徽章。",
     "note": "他做了什么？",
     "revoke": "收回",
+    "seeAll": "查看全部徽章",
     "shelfTitle": "徽章",
     "topFan": "头号粉丝",
-    "topFanHint": "拥有某个角色的数量超过所有人。"
+    "topFanHint": "拥有某个角色的数量超过所有人。",
+    "topFanHow": "将一个角色固定到个人资料，并拥有比任何人都多的该角色。",
+    "wearing": "佩戴中"
   },
   "balance": {
     "admin_adjust": "管理员调整",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -54,6 +54,16 @@
     "awarded": "授予于 {{date}}",
     "chooseHint": "选一个在全站佩戴。",
     "clearHint": "点击正在佩戴的徽章即可取下。",
+    "collection": {
+      "animals": "动物园园长",
+      "blue-archive": "基维托斯达人",
+      "counter-strike": "军火商",
+      "touhou": "幻想乡达人",
+      "uma-musume": "传奇训练员"
+    },
+    "collectionGeneric": "{{category}} 达人",
+    "collectionHint": "拥有 {{category}} 系列的全部物品。",
+    "collectionHow": "集齐所有 {{category}} 箱子中的 {{count}} 件物品。一旦获得就永久保留。",
     "connected": "已连接",
     "connectedHint": "已加入 Discord 并在 X 上关注。",
     "connectedHow": "在任务页领取两个社交任务：加入 Discord 并在 X 上关注。",

--- a/src/pages/Profile/BadgeCatalog.tsx
+++ b/src/pages/Profile/BadgeCatalog.tsx
@@ -1,6 +1,13 @@
+import { useEffect, useState } from "react";
 import Modal from "../../components/Modal";
-import { BadgeFace, BADGE_KEYS } from "../../components/Badge";
-import { Badge as BadgeData, BadgeKey } from "../../services/badges/BadgeService";
+import { BadgeFace, badgeName } from "../../components/Badge";
+import {
+  Badge as BadgeData,
+  BadgeKey,
+  CatalogBadge,
+  getBadgeCatalog,
+  isCollectionBadge,
+} from "../../services/badges/BadgeService";
 import i18n from "../../i18n";
 
 interface BadgeCatalogProps {
@@ -13,7 +20,16 @@ interface BadgeCatalogProps {
 // every badge that exists, so a player can see what is out there rather than only what
 // they happen to hold. a locked one says what it would take.
 const BadgeCatalog: React.FC<BadgeCatalogProps> = ({ badges, worn, open, setOpen }) => {
+  const [all, setAll] = useState<CatalogBadge[]>([]);
   const held = new Map(badges.map((badge) => [badge.key, badge]));
+
+  // the collection badges come from the live categories, so the list cannot be a constant
+  useEffect(() => {
+    if (!open || all.length) return;
+    getBadgeCatalog()
+      .then(setAll)
+      .catch(() => setAll([]));
+  }, [open, all.length]);
 
   return (
     <Modal open={open} setOpen={setOpen} width="min(520px, 95vw)">
@@ -21,12 +37,12 @@ const BadgeCatalog: React.FC<BadgeCatalogProps> = ({ badges, worn, open, setOpen
         <div>
           <h2 className="text-lg font-bold">{i18n.t("badge.allTitle")}</h2>
           <p className="mt-1 text-xs text-[#84819A]">
-            {i18n.t("badge.allCount", { held: held.size, total: BADGE_KEYS.length })}
+            {i18n.t("badge.allCount", { held: held.size, total: all.length })}
           </p>
         </div>
 
         <div className="flex flex-col gap-2">
-          {BADGE_KEYS.map((key) => {
+          {all.map(({ key, label, size }) => {
             const owned = held.get(key);
             return (
               <div
@@ -39,7 +55,7 @@ const BadgeCatalog: React.FC<BadgeCatalogProps> = ({ badges, worn, open, setOpen
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className={`text-sm font-bold ${owned ? "text-white" : "text-[#625F7E]"}`}>
-                      {i18n.t(`badge.${key}`)}
+                      {badgeName(key, label)}
                     </span>
                     {worn === key && (
                       <span className="notched-xs bg-[#4F46E5] px-2 py-0.5 text-[9px] font-extrabold tracking-widest text-white">
@@ -53,10 +69,14 @@ const BadgeCatalog: React.FC<BadgeCatalogProps> = ({ badges, worn, open, setOpen
                     )}
                   </div>
                   <p className={`mt-1 text-xs leading-relaxed ${owned ? "text-[#C9C6DE]" : "text-[#84819A]"}`}>
-                    {i18n.t(`badge.${key}Hint`)}
+                    {isCollectionBadge(key)
+                      ? i18n.t("badge.collectionHint", { category: label || "" })
+                      : i18n.t(`badge.${key}Hint`)}
                   </p>
                   <p className="mt-1.5 text-[11px] leading-relaxed text-[#625F7E]">
-                    {i18n.t(`badge.${key}How`)}
+                    {isCollectionBadge(key)
+                      ? i18n.t("badge.collectionHow", { category: label || "", count: size || 0 })
+                      : i18n.t(`badge.${key}How`)}
                   </p>
                   {owned && owned.note && (
                     <p className="mt-1.5 text-[11px] italic text-[#84819A]">{owned.note}</p>

--- a/src/pages/Profile/BadgeCatalog.tsx
+++ b/src/pages/Profile/BadgeCatalog.tsx
@@ -1,0 +1,81 @@
+import Modal from "../../components/Modal";
+import { BadgeFace, BADGE_KEYS } from "../../components/Badge";
+import { Badge as BadgeData, BadgeKey } from "../../services/badges/BadgeService";
+import i18n from "../../i18n";
+
+interface BadgeCatalogProps {
+  badges: BadgeData[];
+  worn: BadgeKey | null;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// every badge that exists, so a player can see what is out there rather than only what
+// they happen to hold. a locked one says what it would take.
+const BadgeCatalog: React.FC<BadgeCatalogProps> = ({ badges, worn, open, setOpen }) => {
+  const held = new Map(badges.map((badge) => [badge.key, badge]));
+
+  return (
+    <Modal open={open} setOpen={setOpen} width="min(520px, 95vw)">
+      <div className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-lg font-bold">{i18n.t("badge.allTitle")}</h2>
+          <p className="mt-1 text-xs text-[#84819A]">
+            {i18n.t("badge.allCount", { held: held.size, total: BADGE_KEYS.length })}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {BADGE_KEYS.map((key) => {
+            const owned = held.get(key);
+            return (
+              <div
+                key={key}
+                className={`notched-sm flex items-start gap-3 p-3 ${
+                  owned ? "bg-[#212031]" : "bg-[#19172d]"
+                }`}
+              >
+                <BadgeFace badgeKey={key} size="xl" muted={!owned} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={`text-sm font-bold ${owned ? "text-white" : "text-[#625F7E]"}`}>
+                      {i18n.t(`badge.${key}`)}
+                    </span>
+                    {worn === key && (
+                      <span className="notched-xs bg-[#4F46E5] px-2 py-0.5 text-[9px] font-extrabold tracking-widest text-white">
+                        {i18n.t("badge.wearing")}
+                      </span>
+                    )}
+                    {!owned && (
+                      <span className="text-[9px] font-extrabold tracking-widest text-[#625F7E]">
+                        {i18n.t("badge.locked")}
+                      </span>
+                    )}
+                  </div>
+                  <p className={`mt-1 text-xs leading-relaxed ${owned ? "text-[#C9C6DE]" : "text-[#84819A]"}`}>
+                    {i18n.t(`badge.${key}Hint`)}
+                  </p>
+                  <p className="mt-1.5 text-[11px] leading-relaxed text-[#625F7E]">
+                    {i18n.t(`badge.${key}How`)}
+                  </p>
+                  {owned && owned.note && (
+                    <p className="mt-1.5 text-[11px] italic text-[#84819A]">{owned.note}</p>
+                  )}
+                  {owned && owned.awardedAt && (
+                    <p className="mt-1 text-[11px] text-[#625F7E]">
+                      {i18n.t("badge.awarded", {
+                        date: new Date(owned.awardedAt).toLocaleDateString(),
+                      })}
+                    </p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default BadgeCatalog;

--- a/src/pages/Profile/BadgeShelf.tsx
+++ b/src/pages/Profile/BadgeShelf.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 import { toast } from "react-toastify";
 import UserContext from "../../UserContext";
-import Badge from "../../components/Badge";
+import Badge, { badgeName } from "../../components/Badge";
 import BadgeCatalog from "./BadgeCatalog";
 import { Badge as BadgeData, BadgeKey, setWornBadge } from "../../services/badges/BadgeService";
 import i18n from "../../i18n";
@@ -70,7 +70,7 @@ const BadgeShelf: React.FC<BadgeShelfProps> = ({ badges, selectedBadge, isSameUs
                 } ${isSameUser ? "hover:text-white" : "cursor-default"}`}
               >
                 <Badge badge={badge} linked={false} />
-                {i18n.t(`badge.${badge.key}`)}
+                {badgeName(badge.key, badge.label)}
               </button>
             ))}
           </div>

--- a/src/pages/Profile/BadgeShelf.tsx
+++ b/src/pages/Profile/BadgeShelf.tsx
@@ -2,6 +2,7 @@ import { useContext, useState } from "react";
 import { toast } from "react-toastify";
 import UserContext from "../../UserContext";
 import Badge from "../../components/Badge";
+import BadgeCatalog from "./BadgeCatalog";
 import { Badge as BadgeData, BadgeKey, setWornBadge } from "../../services/badges/BadgeService";
 import i18n from "../../i18n";
 
@@ -18,8 +19,9 @@ const BadgeShelf: React.FC<BadgeShelfProps> = ({ badges, selectedBadge, isSameUs
   const { userData, toogleUserData } = useContext(UserContext);
   const [worn, setWorn] = useState<BadgeKey | null>(selectedBadge || null);
   const [saving, setSaving] = useState(false);
+  const [showAll, setShowAll] = useState(false);
 
-  if (!badges || badges.length === 0) return null;
+  const held = badges || [];
 
   const choose = async (key: BadgeKey) => {
     if (!isSameUser || saving) return;
@@ -39,29 +41,48 @@ const BadgeShelf: React.FC<BadgeShelfProps> = ({ badges, selectedBadge, isSameUs
 
   return (
     <div className="mt-5 flex flex-col gap-2">
-      <p className="text-[10px] font-extrabold tracking-[0.16em] text-[#625F7E]">
-        {i18n.t("badge.shelfTitle").toUpperCase()}
-      </p>
-      <div className="flex flex-wrap items-center gap-2">
-        {badges.map((badge) => (
-          <button
-            key={badge.key}
-            onClick={() => choose(badge.key)}
-            disabled={!isSameUser || saving}
-            className={`notched-sm flex items-center gap-2 border-0 px-3 py-2 text-xs font-semibold outline-none transition-all ${
-              worn === badge.key ? "bg-[#4F46E5] text-white" : "bg-[#212031] text-[#C9C6DE]"
-            } ${isSameUser ? "hover:text-white" : "cursor-default"}`}
-          >
-            <Badge badge={badge} linked={false} />
-            {i18n.t(`badge.${badge.key}`)}
-          </button>
-        ))}
-      </div>
-      {isSameUser && (
-        <p className="text-[11px] text-[#625F7E]">
-          {worn ? i18n.t("badge.clearHint") : i18n.t("badge.chooseHint")}
+      <div className="flex items-center gap-3">
+        <p className="text-[10px] font-extrabold tracking-[0.16em] text-[#625F7E]">
+          {i18n.t("badge.shelfTitle").toUpperCase()}
         </p>
+        <button
+          onClick={() => setShowAll(true)}
+          className="border-0 bg-transparent p-0 text-[11px] font-semibold text-[#84819A] underline outline-none transition-all hover:text-white"
+        >
+          {i18n.t("badge.seeAll")}
+        </button>
+      </div>
+
+      {held.length === 0 ? (
+        <p className="text-[11px] text-[#625F7E]">
+          {isSameUser ? i18n.t("badge.noneYours") : i18n.t("badge.noneTheirs")}
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            {held.map((badge) => (
+              <button
+                key={badge.key}
+                onClick={() => choose(badge.key)}
+                disabled={!isSameUser || saving}
+                className={`notched-sm flex items-center gap-2 border-0 px-3 py-2 text-xs font-semibold outline-none transition-all ${
+                  worn === badge.key ? "bg-[#4F46E5] text-white" : "bg-[#212031] text-[#C9C6DE]"
+                } ${isSameUser ? "hover:text-white" : "cursor-default"}`}
+              >
+                <Badge badge={badge} linked={false} />
+                {i18n.t(`badge.${badge.key}`)}
+              </button>
+            ))}
+          </div>
+          {isSameUser && (
+            <p className="text-[11px] text-[#625F7E]">
+              {worn ? i18n.t("badge.clearHint") : i18n.t("badge.chooseHint")}
+            </p>
+          )}
+        </>
       )}
+
+      <BadgeCatalog badges={held} worn={worn} open={showAll} setOpen={setShowAll} />
     </div>
   );
 };

--- a/src/services/badges/BadgeService.ts
+++ b/src/services/badges/BadgeService.ts
@@ -1,6 +1,10 @@
 import api from "../api";
 
-export type BadgeKey = "topFan" | "contributor" | "connected";
+// a collection badge is keyed off its category slug, so the set is open-ended
+export type BadgeKey = "topFan" | "contributor" | "connected" | `collection:${string}`;
+
+export const COLLECTION_PREFIX = "collection:";
+export const isCollectionBadge = (key: string) => key.startsWith(COLLECTION_PREFIX);
 
 export interface BadgeFandom {
   name: string;
@@ -14,7 +18,20 @@ export interface Badge {
   key: BadgeKey;
   awardedAt: string | null;
   note?: string | null;
+  // the category name behind a collection badge
+  label?: string | null;
   fandom?: BadgeFandom;
+}
+
+export interface CatalogBadge {
+  key: BadgeKey;
+  label: string | null;
+  size?: number;
+}
+
+export async function getBadgeCatalog(): Promise<CatalogBadge[]> {
+  const res = await api.get("/users/badges/catalog");
+  return res.data.badges || [];
 }
 
 export interface BadgeChoice {


### PR DESCRIPTION
Two things: a way to see badges you have not earned, and a new family of badges for completing a collection.

## See all badges

The profile listed only what a player already held, so there was no way to find out what else exists.

- A **See all badges** button opens the full set. Earned ones in colour with their note and date, the rest greyed out and marked not earned.
- Every row says what the badge means and what it would take to earn it.
- The shelf renders for a player holding nothing, which is the person most likely to want the list.

The requirement text is inline rather than on hover: it reads the same on a phone, and it does not hide the one thing the modal exists to show.

## Collection badges

Completing every item in a case category earns a badge for it. All five categories, with flavour names: Gensokyo Expert (Touhou, 134 items), Kivotos Expert (Blue Archive, 137), Trainer Legend (Uma Musume, 83), Zookeeper (Animals, 69), and Arms Dealer (Counter-Strike, 46 cases) which will stay rare for a very long time.

- Keyed `collection:<slug>` off the live `Case.category` values, so adding a category mints a badge with no code change. The category name rides on the badge row as `label`.
- The display name is an i18n flavour override with a plain `<category> Expert` fallback, so a new category reads properly before anybody translates it.
- **Earned once and kept.** The sweep never revokes, so selling the set afterwards leaves the badge and nobody is afraid to trade.
- Runs on the same ten-minute cron as the other sweeps, and skips any account whose inventory is shorter than the smallest collection before reading a single item.
- `GET /users/badges/catalog` serves the full list. Two segments on purpose: a single-segment path would be swallowed by the `GET /:id` catch-all.

## Tests

Ten new badge tests: category grouping across cases, whole-collection-only awarding, keeping it after the set is sold, duplicates not counting as progress, the catalogue contents and route, and the backoffice refusing to hand one out. Backend 620 passing; frontend lint, types, unit, e2e and build clean.

Verified in the sandbox end to end: seeded a completable category, watched the sweep award it, and checked the shelf and the modal.