### PR TITLE
fix(api): move to the new host, and let non-browser callers in

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Measure latency from a non-Sydney vantage
         env:
-          URL: https://kanicasino.cfhxo.com/health
+          URL: https://kanicasino.fabrixhosting.com.au/health
           THRESHOLD: '3'
           SAMPLES: '5'
           DISCORD_WEBHOOK: ${{ secrets.MONITOR_DISCORD_WEBHOOK }}
@@ -56,7 +56,7 @@ jobs:
             body=$(jq -n --arg r "uptime probe from ${ray:-?}: ${bad}/${SAMPLES} bad" '{reason:$r}')
             out=$(curl -s -m 30 -o /dev/null -w '%{http_code}' -X POST \
               -H 'Content-Type: application/json' -H "x-maint-token: ${MAINT_TOKEN}" \
-              -d "$body" https://kanicasino.cfhxo.com/internal/tunnel-restart || echo 000)
+              -d "$body" https://kanicasino.fabrixhosting.com.au/internal/tunnel-restart || echo 000)
             case "$out" in
               202) action="restarted cloudflared" ;;
               429) action="restart skipped, still within the 15 min cooldown" ;;

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm run dev
 Create a `.env` in the project root with:
 
 ```
-VITE_BASE_URL=https://kanicasino.cfhxo.com
+VITE_BASE_URL=https://kanicasino.fabrixhosting.com.au
 ```
 
 ### Run the full stack

--- a/backend/__tests__/unit/cors.test.js
+++ b/backend/__tests__/unit/cors.test.js
@@ -1,0 +1,35 @@
+const { parseOrigins, originAllowed } = require("../../utils/cors");
+
+describe("allowed origins", () => {
+  it("splits, trims and drops blanks", () => {
+    expect(parseOrigins("https://a.com, https://b.com ,")).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("falls back to the production domain when unset", () => {
+    expect(parseOrigins("")).toEqual(["https://kanicasino.com"]);
+    expect(parseOrigins(undefined)).toEqual(["https://kanicasino.com"]);
+  });
+});
+
+describe("who gets through the cors gate", () => {
+  const prod = { isDevelopment: false, allowedOrigins: ["https://kanicasino.com"] };
+
+  it("lets a listed browser origin through", () => {
+    expect(originAllowed("https://kanicasino.com", prod)).toBe(true);
+  });
+
+  it("refuses an origin that is not listed", () => {
+    expect(originAllowed("https://evil.example", prod)).toBe(false);
+  });
+
+  // the regression this file exists for: curl, server-to-server, the uptime probe and the
+  // mail provider posting the one-click unsubscribe all send no Origin at all
+  it("lets a request with no Origin through", () => {
+    expect(originAllowed(undefined, prod)).toBe(true);
+    expect(originAllowed("", prod)).toBe(true);
+  });
+
+  it("lets everything through in development", () => {
+    expect(originAllowed("https://evil.example", { isDevelopment: true, allowedOrigins: [] })).toBe(true);
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -25,12 +25,10 @@ const isDevelopment = process.env.NODE_ENV === "development";
 
 // allowed origins are configurable via ALLOWED_ORIGINS (comma-separated); falls
 // back to the production domain so behaviour is unchanged when it isn't set
-const allowedOrigins = (process.env.ALLOWED_ORIGINS || "https://kanicasino.com")
-  .split(",")
-  .map((o) => o.trim())
-  .filter(Boolean);
+const { parseOrigins, originAllowed } = require("./utils/cors");
+const allowedOrigins = parseOrigins(process.env.ALLOWED_ORIGINS);
 
-const isOriginAllowed = (origin) => isDevelopment || allowedOrigins.includes(origin);
+const isOriginAllowed = (origin) => originAllowed(origin, { isDevelopment, allowedOrigins });
 
 const corsOrigin = (origin, callback) => {
   if (isOriginAllowed(origin)) {
@@ -49,7 +47,7 @@ const corsOptions = {
 app.use((req, res, next) => {
   const origin = req.headers.origin;
 
-  if (isDevelopment || allowedOrigins.includes(origin)) {
+  if (isOriginAllowed(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin || "*");
     res.setHeader("Access-Control-Allow-Credentials", "true");
   } else {

--- a/backend/utils/cors.js
+++ b/backend/utils/cors.js
@@ -1,0 +1,17 @@
+// comma separated in the env, so a box can allow the apex and the www host at once
+function parseOrigins(value, fallback = "https://kanicasino.com") {
+  return String(value || fallback)
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+// a request with no Origin header is not a browser cross-origin call at all: curl, a
+// server-to-server hit, the uptime probe, or the mail provider POSTing the one-click
+// unsubscribe. cors does not apply to any of those, and refusing them would break every
+// non-browser caller the moment NODE_ENV stops being development.
+function originAllowed(origin, { isDevelopment = false, allowedOrigins = [] } = {}) {
+  return isDevelopment || !origin || allowedOrigins.includes(origin);
+}
+
+module.exports = { parseOrigins, originAllowed };

--- a/backend/utils/mailer.js
+++ b/backend/utils/mailer.js
@@ -5,7 +5,7 @@ const FROM = process.env.MAIL_FROM || "KaniCasino <no-reply@kanicasino.com>";
 // the from address can send but cannot receive, so replies need somewhere real to go
 const REPLY_TO = process.env.MAIL_REPLY_TO;
 const SITE = process.env.SITE_URL || "https://kanicasino.com";
-const API = process.env.API_URL || "https://kanicasino.cfhxo.com";
+const API = process.env.API_URL || "https://kanicasino.fabrixhosting.com.au";
 const REGION = process.env.AWS_REGION || "sa-east-1";
 
 // unset means email is off, so a misconfigured box stays silent instead of throwing


### PR DESCRIPTION
The API moves from `kanicasino.cfhxo.com` to `kanicasino.fabrixhosting.com.au`.

## The move

Swapped in `.github/workflows/uptime.yml` (probe + tunnel-restart POST), `backend/utils/mailer.js` (the `API_URL` fallback), and the README. Already done directly on the box: `API_URL`, `ALLOWED_ORIGINS`, `~/cf-watchdog-checkhost.sh`, `~/maintenance-kani.sh`, and the GitHub deploy webhook.

Verified before switching: same backend (identical `/health` uptime and data through both hostnames), API-key gate intact, and latency indistinguishable from the old host across São Paulo, US and EU over four interleaved check-host rounds.

## The CORS bug this uncovered

The gate is `allowedOrigins.includes(origin)`. A request with **no Origin header** gives `undefined`, which is never in the list, so it 403s. Nothing has noticed because the production box runs `NODE_ENV=development`, and development skips the check entirely — the two faults have been cancelling each other out.

Correcting `NODE_ENV` without this fix would 403 every non-browser caller:

- the uptime workflow's `POST /internal/tunnel-restart`
- socket.io handshakes from non-browser clients
- `POST /email/unsubscribe` from the mail provider, which is an RFC 8058 obligation and fails silently

`/health` and `/deploy/github` are mounted above the gate and were never affected.

A missing Origin is not a cross-origin browser call, so CORS does not apply to it. The predicate moved to `backend/utils/cors.js` so it can be tested — it previously sat inline in a file that starts servers on require, so it had no coverage at all.

## Tests

Six new unit tests covering the origin parser and the gate, including the no-Origin case this fixes. Backend 627 passing.

## After this merges

`NODE_ENV=production` on the box, which then also re-arms the replica-set guard at `index.js:109` that currently lets the API boot with non-atomic money writes.