### PR TITLE
Marketing consent at signup

### DIFF
--- a/backend/__tests__/integration/marketingConsent.test.js
+++ b/backend/__tests__/integration/marketingConsent.test.js
@@ -1,0 +1,99 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+// the google login path verifies a real token; stand in for google so a fake token
+// resolves to whatever payload the test sets
+let mockGooglePayload = null;
+jest.mock("google-auth-library", () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn().mockImplementation(() => Promise.resolve({ getPayload: () => mockGooglePayload })),
+  })),
+}));
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+function signUp(body) {
+  const s = uniqueSuffix();
+  return request(app)
+    .post("/users/register")
+    .send({ email: `new-${s}@example.com`, username: `new-${s}`, password: "secret1", ...body })
+    .then((res) => ({ res, username: `new-${s}` }));
+}
+
+describe("register", () => {
+  it("keeps the ticked box", async () => {
+    const { res, username } = await signUp({ marketingOptIn: true });
+    expect(res.status).toBe(200);
+
+    const user = await User.findOne({ username });
+    expect(user.marketingOptIn).toBe(true);
+    expect(user.marketingOptInAt).toBeInstanceOf(Date);
+  });
+
+  it("defaults to off when the box is left alone", async () => {
+    const { username } = await signUp({});
+
+    const user = await User.findOne({ username });
+    expect(user.marketingOptIn).toBe(false);
+    expect(user.marketingOptInAt).toBeFalsy();
+  });
+
+  it("takes only a real true, so a stray truthy value cannot subscribe anyone", async () => {
+    const { username } = await signUp({ marketingOptIn: "yes" });
+
+    const user = await User.findOne({ username });
+    expect(user.marketingOptIn).toBe(false);
+  });
+});
+
+describe("google sign-up", () => {
+  const googleLogin = (body) => request(app).post("/users/googlelogin").send({ token: "fake", ...body });
+
+  it("keeps the ticked box on the sign-in that creates the account", async () => {
+    const s = uniqueSuffix();
+    mockGooglePayload = { email: `g-${s}@x.com`, name: `g-${s}`, picture: "p.png" };
+
+    const res = await googleLogin({ marketingOptIn: true });
+    expect(res.status).toBe(200);
+
+    const user = await User.findOne({ email: mockGooglePayload.email });
+    expect(user.marketingOptIn).toBe(true);
+    expect(user.marketingOptInAt).toBeInstanceOf(Date);
+  });
+
+  it("defaults to off without one", async () => {
+    const s = uniqueSuffix();
+    mockGooglePayload = { email: `g-${s}@x.com`, name: `g-${s}`, picture: "p.png" };
+
+    await googleLogin({});
+
+    const user = await User.findOne({ email: mockGooglePayload.email });
+    expect(user.marketingOptIn).toBe(false);
+  });
+
+  // consent belongs to the signup, so a later sign-in must not speak for the account
+  it("never rewrites the choice of someone who already has an account", async () => {
+    const s = uniqueSuffix();
+    mockGooglePayload = { email: `g-${s}@x.com`, name: `g-${s}`, picture: "p.png" };
+    await googleLogin({ marketingOptIn: true });
+
+    await googleLogin({ marketingOptIn: false });
+    expect((await User.findOne({ email: mockGooglePayload.email })).marketingOptIn).toBe(true);
+
+    await User.updateOne({ email: mockGooglePayload.email }, { $set: { marketingOptIn: false } });
+    await googleLogin({ marketingOptIn: true });
+    expect((await User.findOne({ email: mockGooglePayload.email })).marketingOptIn).toBe(false);
+  });
+});

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -42,7 +42,7 @@ router.post(
     }
 
 
-    const { email, password, username, referralCode } = req.body;
+    const { email, password, username, referralCode, marketingOptIn } = req.body;
 
     try {
       // Check if user already exists
@@ -62,7 +62,17 @@ router.post(
       // compatibility, decrypt a legacy AES-wrapped value if detected.
       const originalPassword = resolvePassword(password);
       const placeholder = getRandomPlaceholderImage();
-      user = new User({ email, username, profilePicture: placeholder, basePicture: placeholder, isAdmin: false });
+      // strictly true, so a stray truthy value cannot sign somebody up to the mailing list
+      const consented = marketingOptIn === true;
+      user = new User({
+        email,
+        username,
+        profilePicture: placeholder,
+        basePicture: placeholder,
+        isAdmin: false,
+        marketingOptIn: consented,
+        marketingOptInAt: consented ? new Date() : undefined,
+      });
       if (referrer) user.referredBy = referrer._id;
 
       // Hash password
@@ -158,7 +168,7 @@ router.post(
 
 // Google login
 router.post('/googlelogin', async (req, res) => {
-  const { token, referralCode } = req.body;
+  const { token, referralCode, marketingOptIn } = req.body;
   try {
     const ticket = await client.verifyIdToken({
       idToken: token,
@@ -178,12 +188,17 @@ router.post('/googlelogin', async (req, res) => {
       }
       // a referral only counts at account creation, never on a later login
       const referrer = referralCode ? await findReferrer(referralCode) : null;
+      // consent is taken at signup only: a returning player's choice lives in their email
+      // settings, and a later sign-in must never overwrite it
+      const consented = marketingOptIn === true;
       user = new User({
         googleId: googlePayload.sub,
         email: googlePayload.email,
         username: username,
         profilePicture: googlePayload.picture,
         basePicture: googlePayload.picture,
+        marketingOptIn: consented,
+        marketingOptInAt: consented ? new Date() : undefined,
       });
       if (referrer) user.referredBy = referrer._id;
       await user.save();

--- a/src/components/header/userFlow/SignUp.tsx
+++ b/src/components/header/userFlow/SignUp.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from "react";
-// Import Google Login component (optional)
-// import GoogleLogin from "react-google-login";
-import { register } from "../../../services/auth/auth";
+import { GoogleLogin } from "@react-oauth/google";
+import { register, googleLogin } from "../../../services/auth/auth";
 import MainButton from "../../MainButton";
 import { saveTokens } from "../../../services/auth/authUtils";
 import UserContext from "../../../UserContext";
@@ -13,6 +12,7 @@ const SignUpPage: React.FC = () => {
   const [password, setPassword] = useState("");
   const [nickname, setNickname] = useState("");
   const [referralCode, setReferralCode] = useState(getPendingReferralCode());
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -22,7 +22,7 @@ const SignUpPage: React.FC = () => {
     setLoading(true);
     e.preventDefault();
     try {
-      await register(email, password, nickname, referralCode.trim() || undefined)
+      await register(email, password, nickname, referralCode.trim() || undefined, marketingOptIn)
         .then((response) => {
           saveTokens(response.token, "");
           clearPendingReferralCode();
@@ -46,15 +46,22 @@ const SignUpPage: React.FC = () => {
 
 
 
-  // const handleGoogleSuccess = (response: any) => {
-  //   // Handle Google sign-up logic here
-  // };
-
-  // const handleGoogleFailure = (error: any) => {
-  //   // Handle Google sign-up failure here
-  // };
-
-
+  // the same endpoint as the login button, but reached from the create-account side, so the
+  // consent ticked above rides along and is kept only if this is what makes the account
+  const handleGoogleSignUp = async (credentialResponse: any) => {
+    try {
+      const code = referralCode.trim() || getPendingReferralCode() || undefined;
+      const data = await googleLogin(credentialResponse.credential, code, marketingOptIn);
+      if (data.token) {
+        saveTokens(data.token, "");
+        clearPendingReferralCode();
+        toggleLogin();
+      }
+    } catch (error) {
+      console.log(error);
+      setError(i18n.t("nav.invalidFormatPleaseTry"));
+    }
+  };
 
   return (
     <div className="flex flex-col justify-center ">
@@ -132,7 +139,19 @@ const SignUpPage: React.FC = () => {
                   ))}
 
                 </div>
-                <div className="flex flex-col ">
+                <div className="flex flex-col gap-3 pt-3">
+                  <label className="flex cursor-pointer items-start gap-2 text-sm text-gray-600">
+                    <input
+                      type="checkbox"
+                      checked={marketingOptIn}
+                      onChange={(e) => setMarketingOptIn(e.target.checked)}
+                      className="mt-0.5 h-4 w-4 accent-indigo-500"
+                    />
+                    <span>
+                      {i18n.t("auth.marketingOptIn")}
+                      <span className="block text-xs text-gray-400">{i18n.t("auth.marketingOptInHint")}</span>
+                    </span>
+                  </label>
                   <MainButton
                     text={i18n.t("auth.signUp")}
                     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -143,15 +162,13 @@ const SignUpPage: React.FC = () => {
                   />
 
                   {error && <p className="text-red-500 text-sm">{error}</p>}
-                  {/* Uncomment to enable Google Login */}
-                  {/* <GoogleLogin
-                      clientId="<YOUR_GOOGLE_CLIENT_ID>"
-                      buttonText={i18n.t("nav.signUpWithGoogle")}
-                      onSuccess={handleGoogleSuccess}
-                      onFailure={handleGoogleFailure}
-                      cookiePolicy={"single_host_origin"}
-                      className="w-full text-white bg-red-500 px-6 py-2 rounded-lg hover:bg-red-400"
-                      /> */}
+                  <div className="flex justify-center">
+                    <GoogleLogin
+                      onSuccess={handleGoogleSignUp}
+                      onError={() => setError(i18n.t("nav.invalidFormatPleaseTry"))}
+                      theme="outline"
+                    />
+                  </div>
                 </div>
               </div>
             </form>

--- a/src/components/header/userFlow/index.tsx
+++ b/src/components/header/userFlow/index.tsx
@@ -32,7 +32,7 @@ const UserFlow: React.FC = () => {
         <Modal open={true} setOpen={toogleUserFlow} width={"400px"}>
           <div className="flex items-center justify-center p-8" >
             <div
-              className={`flex flex-col justify-center transition-all ${isLogin ? "h-[340px]" : "h-[460px]"
+              className={`flex flex-col justify-center transition-all ${isLogin ? "h-[340px]" : "h-[520px]"
                 }`}
             >
               {isLogin ? <Login /> : <SignUp />}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -40,6 +40,8 @@
     "email": "E-Mail-Adresse",
     "emailShort": "E-Mail",
     "forgotTip": "Pech gehabt 🙁",
+    "marketingOptIn": "E-Mails über neue Kisten, Events und Gewinnspiele erhalten",
+    "marketingOptInHint": "Kein Spam. Jederzeit abbestellbar.",
     "nickname": "Nickname",
     "orLogin": "Oder anmelden",
     "password": "Passwort",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -40,6 +40,8 @@
     "email": "Email address",
     "emailShort": "Email",
     "forgotTip": "Too bad for you 🙁",
+    "marketingOptIn": "Email me about new cases, events and giveaways",
+    "marketingOptInHint": "No spam. Unsubscribe any time.",
     "nickname": "Nickname",
     "orLogin": "Or Login",
     "password": "Password",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -40,6 +40,8 @@
     "email": "Correo electrónico",
     "emailShort": "Correo",
     "forgotTip": "Qué lástima 🙁",
+    "marketingOptIn": "Quiero recibir correos sobre nuevas cajas, eventos y sorteos",
+    "marketingOptInHint": "Sin spam. Cancela cuando quieras.",
     "nickname": "Apodo",
     "orLogin": "O inicia sesión",
     "password": "Contraseña",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -40,6 +40,8 @@
     "email": "Adresse e-mail",
     "emailShort": "E-mail",
     "forgotTip": "Dommage pour vous 🙁",
+    "marketingOptIn": "Recevoir des e-mails sur les nouvelles caisses, événements et cadeaux",
+    "marketingOptInHint": "Pas de spam. Désinscription à tout moment.",
     "nickname": "Pseudo",
     "orLogin": "Ou connectez-vous",
     "password": "Mot de passe",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -40,6 +40,8 @@
     "email": "Alamat email",
     "emailShort": "Email",
     "forgotTip": "Buruk buat kamu🙁",
+    "marketingOptIn": "Kirimi saya email tentang case baru, event, dan giveaway",
+    "marketingOptInHint": "Tanpa spam. Berhenti berlangganan kapan saja.",
     "nickname": "Nama singkat",
     "orLogin": "Atau masuk",
     "password": "Kata sandi (Pw)",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -40,6 +40,8 @@
     "email": "Indirizzo e-mail",
     "emailShort": "E-mail",
     "forgotTip": "Peccato per te 🙁",
+    "marketingOptIn": "Inviami email su nuove casse, eventi e giveaway",
+    "marketingOptInHint": "Niente spam. Disiscriviti quando vuoi.",
     "nickname": "Nickname",
     "orLogin": "Oppure accedi",
     "password": "Password",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -40,6 +40,8 @@
     "email": "メールアドレス",
     "emailShort": "メール",
     "forgotTip": "残念でした 🙁",
+    "marketingOptIn": "新しいケースやイベントのお知らせを受け取る",
+    "marketingOptInHint": "スパムはありません。いつでも配信停止できます。",
     "nickname": "ニックネーム",
     "orLogin": "またはログイン",
     "password": "パスワード",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -40,6 +40,8 @@
     "email": "이메일 주소",
     "emailShort": "이메일",
     "forgotTip": "아쉽네요 🙁",
+    "marketingOptIn": "새 케이스, 이벤트, 경품 소식을 이메일로 받기",
+    "marketingOptInHint": "스팸은 없습니다. 언제든 수신을 해지할 수 있습니다.",
     "nickname": "닉네임",
     "orLogin": "또는 로그인",
     "password": "비밀번호",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -40,6 +40,8 @@
     "email": "Endereço de e-mail",
     "emailShort": "E-mail",
     "forgotTip": "Que pena 🙁",
+    "marketingOptIn": "Quero receber e-mails sobre novas caixas, eventos e sorteios",
+    "marketingOptInHint": "Sem spam. Cancele quando quiser.",
     "nickname": "Apelido",
     "orLogin": "Ou entre",
     "password": "Senha",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -40,6 +40,8 @@
     "email": "Địa chỉ email",
     "emailShort": "Email",
     "forgotTip": "Tiếc quá 🙁",
+    "marketingOptIn": "Nhận email về hộp mới, sự kiện và quà tặng",
+    "marketingOptInHint": "Không spam. Hủy đăng ký bất cứ lúc nào.",
     "nickname": "Biệt danh",
     "orLogin": "Hoặc đăng nhập",
     "password": "Mật khẩu",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -40,6 +40,8 @@
     "email": "电子邮箱地址",
     "emailShort": "邮箱",
     "forgotTip": "太可惜了 🙁",
+    "marketingOptIn": "接收新箱子、活动和赠品的邮件通知",
+    "marketingOptInHint": "没有垃圾邮件，随时可退订。",
     "nickname": "昵称",
     "orLogin": "或登录",
     "password": "密码",

--- a/src/services/auth/auth.ts
+++ b/src/services/auth/auth.ts
@@ -5,14 +5,15 @@ export async function login(email: string, password: string) {
     return response.data;
 }
 
-export async function googleLogin(token: string, referralCode?: string) {
-    const response = await api.post('/users/googlelogin', { token, referralCode });
+// marketingOptIn only lands if this sign-in is what creates the account
+export async function googleLogin(token: string, referralCode?: string, marketingOptIn?: boolean) {
+    const response = await api.post('/users/googlelogin', { token, referralCode, marketingOptIn });
     return response.data;
 }
 
-export async function register(email: string, password: string, username: string, referralCode?: string) {
+export async function register(email: string, password: string, username: string, referralCode?: string, marketingOptIn?: boolean) {
     const response = await api.post('/users/register', {
-        email, password, username, referralCode
+        email, password, username, referralCode, marketingOptIn
     });
     return response.data;
 }


### PR DESCRIPTION
`marketingOptIn` existed on the user and in the profile email settings, but neither `register` nor `googlelogin` ever collected it, so every account sat at `false` and the mailing list had no way to grow.

Adds an unchecked box to the signup form, and a google button beside it so both paths from create-account carry the answer. Both endpoints compare with `=== true` and stamp `marketingOptInAt`. `googlelogin` reads it only on the sign-in that creates the account, the same rule `referralCode` follows, so a returning player's choice is never overwritten.

The box is unchecked because a pre-ticked one is not valid consent under LGPD.

Tests: 6 integration tests covering both endpoints and the returning-player case. Full backend, unit, e2e, build and lint pass.
