### PR TITLE
Crash and coin flip stages take their width from their contents

### DIFF
--- a/e2e/gameStage.spec.ts
+++ b/e2e/gameStage.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, Page } from "@playwright/test";
+
+// the crash and coin flip stages had their width taken from whatever happened to be
+// inside them, so an empty game history collapsed the canvas to 130px and forty results
+// stretched it back out to 768px. these tests assert the property that was broken rather
+// than a magic number: the stage states its own width, so it is the same on a laptop and
+// an ultrawide, and nothing inside it can move it.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("kani.onboardingSeen", "1"));
+});
+
+const stageWidth = (page: Page) =>
+  page.evaluate(() => {
+    // crash draws to a canvas; coin flip spins a div. whichever is present is the stage.
+    const el = document.querySelector("canvas") || document.querySelector(".coin");
+    if (!el) return null;
+    const box = el.closest("div.relative") || el.parentElement;
+    return box ? Math.round(box.getBoundingClientRect().width) : null;
+  });
+
+async function open(page: Page, route: string) {
+  await page.goto(route);
+  await page.waitForTimeout(1200);
+}
+
+// forty results is an ordinary evening. before the fix this is what pushed the panel out.
+async function fillHistory(page: Page) {
+  await page.evaluate(() => {
+    const row = [...document.querySelectorAll("div")].find(
+      (d) => d.className.includes("justify-end") && d.className.includes("h-[24px]")
+    );
+    if (!row) return;
+    for (let i = 0; i < 40; i++) {
+      const chip = document.createElement("div");
+      chip.className = "min-h-[24px] min-w-[24px] rounded-lg p-2 bg-green-500";
+      chip.innerHTML = "<span class='font-bold'>128.44x</span>";
+      row.appendChild(chip);
+    }
+  });
+  await page.waitForTimeout(400);
+}
+
+for (const route of ["/crash", "/coinflip"]) {
+  test(`${route} keeps its stage width when the game history grows`, async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await open(page, route);
+
+    const before = await stageWidth(page);
+    expect(before).not.toBeNull();
+    // a collapsed stage was 130px; anything near that is the bug coming back
+    expect(before).toBeGreaterThan(600);
+
+    await fillHistory(page);
+    expect(await stageWidth(page)).toBe(before);
+  });
+
+  test(`${route} states its own width instead of taking the viewport's`, async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await open(page, route);
+    const laptop = await stageWidth(page);
+
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.waitForTimeout(600);
+    const ultrawide = await stageWidth(page);
+
+    expect(laptop).toBeGreaterThan(600);
+    expect(ultrawide).toBe(laptop);
+  });
+
+  test(`${route} fills a phone without pushing the page sideways`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await open(page, route);
+
+    const width = await stageWidth(page);
+    expect(width).toBeGreaterThan(300);
+    expect(width).toBeLessThanOrEqual(390);
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth
+    );
+    expect(overflow).toBe(false);
+  });
+}

--- a/src/pages/Coin/CoinFlip.tsx
+++ b/src/pages/Coin/CoinFlip.tsx
@@ -153,8 +153,8 @@ const CoinFlip = () => {
 
   return (
     <div className="w-full flex flex-col items-center justify-center gap-12">
-      <div className="flex w-full max-w-full bg-[#212031] rounded flex-col lg:w-auto lg:flex-row">
-        <div className="w-full min-w-0 lg:w-[340px] flex flex-col items-center gap-4 border-r border-gray-700 py-4 px-6">
+      <div className="flex w-full max-w-[800px] bg-[#212031] rounded flex-col xl:w-[1140px] xl:max-w-none xl:flex-row">
+        <div className="w-full min-w-0 xl:w-[340px] xl:shrink-0 flex flex-col items-center gap-4 border-b xl:border-b-0 xl:border-r border-gray-700 py-4 px-6">
           <div className="w-full">
             <BetAmount
               value={bet === 0 ? "" : String(bet)}
@@ -215,8 +215,8 @@ const CoinFlip = () => {
             )}
           </div>
         </div>
-        <div className="flex flex-col">
-          <div className="flex w-full lg:max-w-[800px] border-b border-gray-700 p-4">
+        <div className="flex w-full min-w-0 flex-col xl:w-[800px] xl:shrink-0">
+          <div className="flex w-full border-b border-gray-700 p-4">
             <div className="flex bg-[#19172D] rounded items-center justify-center w-full h-[340px] relative ">
               {
                 gameEnded && <div className="absolute top-0 left-0 p-2">
@@ -228,7 +228,7 @@ const CoinFlip = () => {
               <Coin spinning={spinning} result={result} />
             </div>
           </div>
-          <div className="flex w-full lg:max-w-[800px] p-4 flex-col">
+          <div className="flex w-full p-4 flex-col">
             <h3 className="mb-2 text-lg font-semibold">{i18n.t("coin.gameHistory")}</h3>
             <div className="flex items-center gap-2 justify-end w-full  overflow-hidden h-[24px]">
               {history.map((e, i) => (

--- a/src/pages/Crash/Crash.tsx
+++ b/src/pages/Crash/Crash.tsx
@@ -245,7 +245,7 @@ const CrashGame = () => {
 
   return (
     <div className="w-full flex flex-col items-center justify-center gap-12">
-      <div className="flex w-full max-w-full bg-[#212031] rounded flex-col lg:w-auto lg:flex-row">
+      <div className="flex w-full max-w-[800px] bg-[#212031] rounded flex-col xl:w-[1140px] xl:max-w-none xl:flex-row">
         <SideMenu bet={bet} setBet={setBet} cashoutAt={cashoutAt} setCashoutAt={setCashoutAt} queued={queued}
          multiplier={multiplier} gameStarted={gameStarted} handleBet={handleBet} handleCashout={handleCashout}
          isLogged={isLogged} userGambled={userGambled} userCashedOut={userCashedOut} userData={userData} userMultiplier={userMultiplier} disableButton={disableButton}/>

--- a/src/pages/Crash/GameContainer.tsx
+++ b/src/pages/Crash/GameContainer.tsx
@@ -20,8 +20,8 @@ const BETTING_COUNTDOWN_S = 10.7;
 
 const GameContainer: React.FC<GameHistory> = ({ crashPoint, multiplier, gameStarted, gameEnded, countDown, up, idle, falling, history }) => {
     return (
-        <div className="flex flex-col">
-            <div className="flex flex-col gap-2 w-full lg:max-w-[800px] border-b border-gray-700 p-4">
+        <div className="flex w-full min-w-0 flex-col xl:w-[800px] xl:shrink-0">
+            <div className="flex flex-col gap-2 w-full border-b border-gray-700 p-4">
                 <div className="flex rounded items-center flex-col justify-center w-full h-[340px] relative overflow-hidden bg-surface-nav">
                     <CrashGraph
                         gameStarted={gameStarted}
@@ -69,7 +69,7 @@ const GameContainer: React.FC<GameHistory> = ({ crashPoint, multiplier, gameStar
                     />
                 </div>
             </div>
-            <div className="flex w-full lg:max-w-[800px] p-4 flex-col">
+            <div className="flex w-full p-4 flex-col">
                 <h3 className="mb-2 text-lg font-semibold">{i18n.t("coin.gameHistory")}</h3>
                 <div className="flex items-center gap-2 justify-end w-full overflow-hidden h-[24px]">
                     {history.map((e: { crashPoint: number | null }, i: Key) => (

--- a/src/pages/Crash/SideMenu.tsx
+++ b/src/pages/Crash/SideMenu.tsx
@@ -78,7 +78,7 @@ const SideMenu: React.FC<SideMenuProps> = ({ bet, setBet, cashoutAt, setCashoutA
         (isLogged && (userGambled ? !gameStarted || userCashedOut : invalidBet));
 
     return (
-      <div className="lg:w-[340px] flex flex-col gap-2 border-r border-gray-700 py-4 px-6">
+      <div className="w-full min-w-0 xl:w-[340px] xl:shrink-0 flex flex-col gap-2 border-b xl:border-b-0 xl:border-r border-gray-700 py-4 px-6">
         <BetAmount
           value={bet === null ? "" : String(bet)}
           onChange={(value) => setBet(value === "" ? null : Math.min(MAX_BET, Number(value)))}


### PR DESCRIPTION
The outer row carried `lg:w-auto`, so it sized to its content, and the `w-full` on the stage inside it was asking for 100% of something being measured from that same child. The panel ended up as wide as whatever happened to be in it, which was the game history row: an empty history gave a 130px canvas and forty results gave 768px.

The stage now states its own width instead of inheriting one. Side by side it is exactly 340 + 800; stacked it is the panel, capped at the same 800. That total needs `xl` rather than `lg`, because 1140 is wider than a 1024 screen, which is what #207 was fixing when it reached for `w-auto`. The rail's divider moves under it when stacked instead of running down the right of the page.

The canvas is now 768px at every viewport from 900px upward, and nothing inside it can move it.

Tests: `e2e/gameStage.spec.ts` asserts the property rather than the number, across both games. The stage is the same width on a 1280 laptop and a 1920 ultrawide, forty history chips do not move it, and on a phone it fills the width without pushing the page sideways. Reverting the fix fails four of those six and leaves the two phone cases green, which is the right shape since the bug never applied below `lg`.
