### PR TITLE
Block slurs in usernames and item descriptions

### DIFF
--- a/backend/__tests__/integration/disableUsers.test.js
+++ b/backend/__tests__/integration/disableUsers.test.js
@@ -1,0 +1,123 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const bcrypt = require("bcryptjs");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const { disable } = require("../../scripts/disableUsers");
+
+let app;
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(over = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `u-${s}`,
+    email: `u-${s}@e.com`,
+    password: await bcrypt.hash("secret1", 10),
+    walletBalance: 500,
+    ...over,
+  });
+}
+
+describe("disabling", () => {
+  it("sets the flag, the reason and the time", async () => {
+    const user = await makeUser();
+    await disable([String(user._id)], { reason: "slur in username" });
+
+    const after = await User.findById(user._id);
+    expect(after.disabled).toBe(true);
+    expect(after.disabledReason).toBe("slur in username");
+    expect(after.disabledAt).toBeInstanceOf(Date);
+  });
+
+  // thirty day tokens are already out there; the version bump is what makes it immediate
+  it("kills the tokens already issued", async () => {
+    const user = await makeUser();
+    const before = user.tokenVersion || 0;
+    await disable([String(user._id)]);
+    expect((await User.findById(user._id)).tokenVersion).toBe(before + 1);
+  });
+
+  it("keeps the account and everything it owns", async () => {
+    const user = await makeUser({ walletBalance: 1234 });
+    await disable([String(user._id)]);
+
+    const after = await User.findById(user._id);
+    expect(after).toBeTruthy();
+    expect(after.walletBalance).toBe(1234);
+    expect(after.username).toBe(user.username);
+  });
+
+  it("changes nothing on a dry run", async () => {
+    const user = await makeUser();
+    const rows = await disable([String(user._id)], { dry: true });
+    expect(rows[0].result).toMatch(/would disable/);
+    expect((await User.findById(user._id)).disabled).toBe(false);
+  });
+
+  it("is reversible", async () => {
+    const user = await makeUser();
+    await disable([String(user._id)], { reason: "mistake" });
+    await disable([String(user._id)], { undo: true });
+
+    const after = await User.findById(user._id);
+    expect(after.disabled).toBe(false);
+    expect(after.disabledReason).toBeUndefined();
+  });
+
+  it("says so rather than throwing on an id nobody has", async () => {
+    const rows = await disable(["6a87e869c9720a4029510000"]);
+    expect(rows[0].result).toBe("no such account");
+  });
+});
+
+describe("what a disabled account can still do", () => {
+  it("cannot use a token it already had", async () => {
+    const user = await makeUser();
+    const token = tokenFor(user);
+    expect((await request(app).get("/users/me").set("Authorization", `Bearer ${token}`)).status).toBe(200);
+
+    await disable([String(user._id)]);
+
+    const res = await request(app).get("/users/me").set("Authorization", `Bearer ${token}`);
+    // the version bump lands first, so this reads as a dead session
+    expect([401, 403]).toContain(res.status);
+  });
+
+  // 401 would tell the client to log in again and it would loop; this is the account
+  it("is told the account is disabled, not that the session expired", async () => {
+    const user = await makeUser();
+    await User.updateOne({ _id: user._id }, { $set: { disabled: true } });
+
+    const res = await request(app)
+      .get("/users/me")
+      .set("Authorization", `Bearer ${tokenFor(user)}`);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/disabled/i);
+  });
+
+  it("cannot log back in with the right password", async () => {
+    const user = await makeUser();
+    await disable([String(user._id)]);
+
+    const res = await request(app)
+      .post("/users/login")
+      .send({ email: user.email, password: "secret1" });
+    expect(res.status).toBe(403);
+    expect(res.body.token).toBeUndefined();
+  });
+
+  it("still shows on a public profile, so boards and history stay whole", async () => {
+    const user = await makeUser();
+    await disable([String(user._id)]);
+    const res = await request(app).get(`/users/${user._id}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/__tests__/integration/nameFilterRoutes.test.js
+++ b/backend/__tests__/integration/nameFilterRoutes.test.js
@@ -89,6 +89,31 @@ describe("google sign-up", () => {
   });
 });
 
+// a vanity code is set once, never changes, and rides in every link the player shares
+describe("the referral code", () => {
+  const { setReferralCode } = require("../../utils/referrals");
+
+  async function player() {
+    const s = uniqueSuffix();
+    return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x" });
+  }
+
+  it("turns away a slur", async () => {
+    process.env.REFERRALS_ENABLED = "true";
+    const user = await player();
+    const res = await setReferralCode(user._id, "NIGGA");
+    expect(res.code).toBe(400);
+    expect((await User.findById(user._id)).referralCode).toBeUndefined();
+  });
+
+  it("takes an ordinary code", async () => {
+    process.env.REFERRALS_ENABLED = "true";
+    const user = await player();
+    const res = await setReferralCode(user._id, `REIMU${String(uniqueSuffix()).slice(-4)}`);
+    expect(res.code).toBe(200);
+  });
+});
+
 describe("the pinned item description", () => {
   async function seatedUser() {
     const s = uniqueSuffix();

--- a/backend/__tests__/integration/nameFilterRoutes.test.js
+++ b/backend/__tests__/integration/nameFilterRoutes.test.js
@@ -1,0 +1,138 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+let mockGooglePayload = null;
+jest.mock("google-auth-library", () => ({
+  OAuth2Client: jest.fn().mockImplementation(() => ({
+    verifyIdToken: jest.fn().mockImplementation(() => Promise.resolve({ getPayload: () => mockGooglePayload })),
+  })),
+}));
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+
+let app;
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const signUp = (username) => {
+  const s = uniqueSuffix();
+  return request(app)
+    .post("/users/register")
+    .send({ email: `u-${s}@example.com`, username, password: "secret1" });
+};
+
+describe("registering", () => {
+  it("turns away a slur", async () => {
+    const res = await signUp("nigger");
+    expect(res.status).toBe(400);
+    expect(await User.countDocuments({})).toBe(0);
+  });
+
+  it("turns away the spellings that get used instead", async () => {
+    for (const name of ["n*gga", "n1gg4", "f4gg0t", "n-i-g-g-e-r", "ch1nk"]) {
+      expect((await signUp(name)).status).toBe(400);
+    }
+    expect(await User.countDocuments({})).toBe(0);
+  });
+
+  // saying which term matched would just be instructions for getting around it
+  it("does not name the term it matched", async () => {
+    const res = await signUp("n*gga");
+    expect(JSON.stringify(res.body).toLowerCase()).not.toContain("gga");
+    expect(res.body.message).toBe("Please choose a different username");
+  });
+
+  it("lets an ordinary name through", async () => {
+    const res = await signUp(`Reimu-${uniqueSuffix()}`);
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeTruthy();
+  });
+
+  it("lets a real name that looks like a collision through", async () => {
+    for (const name of ["Cockburn", "Scunthorpe", "Analyst", "Negroni"]) {
+      const res = await signUp(`${name}${uniqueSuffix()}`);
+      expect(res.status).toBe(200);
+    }
+  });
+});
+
+describe("google sign-up", () => {
+  const googleLogin = () => request(app).post("/users/googlelogin").send({ token: "fake" });
+
+  it("keeps a display name that is fine", async () => {
+    const s = uniqueSuffix();
+    mockGooglePayload = { email: `g-${s}@x.com`, name: `Mohamed ${s}`, picture: "p.png", sub: `sub-${s}` };
+    expect((await googleLogin()).status).toBe(200);
+    expect((await User.findOne({ email: mockGooglePayload.email })).username).toBe(`Mohamed ${s}`);
+  });
+
+  // a google display name cannot be edited to get past the filter, so refusing the login
+  // would lock the person out of their own account rather than fix anything
+  it("renames rather than refusing the login", async () => {
+    const s = uniqueSuffix();
+    mockGooglePayload = { email: `g-${s}@x.com`, name: "n*gga", picture: "p.png", sub: `sub-${s}` };
+
+    const res = await googleLogin();
+    expect(res.status).toBe(200);
+
+    const user = await User.findOne({ email: mockGooglePayload.email });
+    expect(user).toBeTruthy();
+    expect(user.username).not.toMatch(/gga/i);
+    expect(user.username).toMatch(/^player/);
+  });
+});
+
+describe("the pinned item description", () => {
+  async function seatedUser() {
+    const s = uniqueSuffix();
+    const item = await Item.create({ name: "Reimu", image: "r.png", rarity: "4", baseValue: 100 });
+    const user = await User.create({
+      username: `u-${s}`,
+      email: `u-${s}@e.com`,
+      password: "x",
+      fixedItem: { name: item.name, image: item.image, rarity: item.rarity, description: "hello" },
+    });
+    return user;
+  }
+
+  it("turns away a slur", async () => {
+    const user = await seatedUser();
+    const res = await request(app)
+      .put("/users/fixedItem/description")
+      .set("Authorization", `Bearer ${tokenFor(user)}`)
+      .send({ description: "n*gga" });
+
+    expect(res.status).toBe(400);
+    expect((await User.findById(user._id)).fixedItem.description).toBe("hello");
+  });
+
+  it("takes an ordinary description", async () => {
+    const user = await seatedUser();
+    const res = await request(app)
+      .put("/users/fixedItem/description")
+      .set("Authorization", `Bearer ${tokenFor(user)}`)
+      .send({ description: "my favourite shrine maiden" });
+
+    expect(res.status).toBe(200);
+    expect((await User.findById(user._id)).fixedItem.description).toBe("my favourite shrine maiden");
+  });
+
+  it("checks what it stores, not what was sent, so the crop cannot smuggle one in", async () => {
+    const user = await seatedUser();
+    // the tail is dropped by the 50 char crop, so it is the head that has to be clean
+    const res = await request(app)
+      .put("/users/fixedItem/description")
+      .set("Authorization", `Bearer ${tokenFor(user)}`)
+      .send({ description: "a".repeat(50) + " nigger" });
+
+    expect(res.status).toBe(200);
+    expect((await User.findById(user._id)).fixedItem.description).toBe("a".repeat(50));
+  });
+});

--- a/backend/__tests__/unit/nameFilter.test.js
+++ b/backend/__tests__/unit/nameFilter.test.js
@@ -150,6 +150,47 @@ describe("hiding behind an allowed word", () => {
   });
 });
 
+// an english-only list was wide open on a site whose players are mostly brazilian
+describe("portuguese and spanish", () => {
+  const blocked = [
+    "crioulo", "viado", "boiola", "baitola", "traveco", "travecão",
+    "retardado", "mongoloide", "mongolóide",
+    "maricon", "maricón", "sudaca", "negrata",
+    "cr1oulo", "v-i-a-d-o", "m4ric0n",
+  ];
+  for (const name of blocked) {
+    it(`blocks ${name}`, () => {
+      expect(isClean(name)).toBe(false);
+    });
+  }
+
+  // each of these is an ordinary portuguese word far more often than it is an insult, and
+  // a filter that eats them is worse than one that misses the rare abuse
+  const ordinary = [
+    "preto", "nego", "neguinho", "macaco", "veado", "bicha", "japa", "baiano",
+    "Mongolia", "Mongol", "Criolla", "Retardador", "Bibas", "Panchito",
+    "arigato", "Jumento", "Bianca", "Viadutos",
+  ];
+  for (const name of ordinary) {
+    it(`leaves ${name} alone`, () => {
+      expect(isClean(name)).toBe(true);
+    });
+  }
+
+  // "travecão" would otherwise compile a pattern around a character the normalised input
+  // can never contain
+  it("folds an accented term before compiling its pattern", () => {
+    expect(findSlur("travecao")).toBeTruthy();
+    expect(findSlur("travecão")).toBeTruthy();
+  });
+
+  // an allowed word that is a prefix of a blocked one disarms it entirely
+  it("does not let an allowed prefix disarm a longer slur", () => {
+    expect(isClean("mongoloide")).toBe(false);
+    expect(isClean("Mongolia")).toBe(true);
+  });
+});
+
 describe("normalising", () => {
   it("folds accents to their base letter", () => {
     expect(normalize("Ré1mü")).toBe("re1mu");

--- a/backend/__tests__/unit/nameFilter.test.js
+++ b/backend/__tests__/unit/nameFilter.test.js
@@ -1,0 +1,189 @@
+const {
+  findSlur,
+  isClean,
+  normalize,
+  letters,
+  withoutAllowed,
+  safeUsername,
+} = require("../../utils/nameFilter");
+
+// the filter exists because somebody registered one of these, so the cases that matter
+// are the spellings people actually reach for rather than the dictionary form
+
+describe("the plain form", () => {
+  it("catches the word written out", () => {
+    expect(isClean("nigger")).toBe(false);
+    expect(isClean("faggot")).toBe(false);
+    expect(isClean("chink")).toBe(false);
+  });
+
+  it("catches it inside a longer name", () => {
+    expect(isClean("xX_nigga_Xx")).toBe(false);
+    expect(isClean("thefaggotking")).toBe(false);
+  });
+
+  it("does not care about case", () => {
+    expect(isClean("NiGgEr")).toBe(false);
+  });
+});
+
+describe("the spellings people actually use", () => {
+  // this is the one that was registered
+  it("catches a masked letter", () => {
+    expect(isClean("n*gga")).toBe(false);
+    expect(isClean("n#gger")).toBe(false);
+    expect(isClean("f*ggot")).toBe(false);
+  });
+
+  it("catches leetspeak", () => {
+    expect(isClean("n1gg4")).toBe(false);
+    expect(isClean("n166er")).toBe(false);
+    expect(isClean("f4gg0t")).toBe(false);
+    expect(isClean("ch1nk")).toBe(false);
+  });
+
+  it("catches separators between the letters", () => {
+    expect(isClean("n-i-g-g-a")).toBe(false);
+    expect(isClean("n.i.g.g.e.r")).toBe(false);
+    expect(isClean("n i g g a")).toBe(false);
+    expect(isClean("n_i_g_g_a")).toBe(false);
+  });
+
+  it("catches padded letters", () => {
+    expect(isClean("niiiigga")).toBe(false);
+    expect(isClean("nigggggger")).toBe(false);
+  });
+
+  it("catches accents and fullwidth forms", () => {
+    expect(isClean("nïggér")).toBe(false);
+    expect(isClean("ｎｉｇｇｅｒ")).toBe(false);
+  });
+
+  it("catches cyrillic lookalikes", () => {
+    // the cyrillic е and о render as latin ones
+    expect(isClean("niggеr")).toBe(false);
+    expect(isClean("cоon")).toBe(false);
+  });
+
+  it("catches a mix of all of it", () => {
+    expect(isClean("N.1-g*g4")).toBe(false);
+  });
+});
+
+// a filter that eats real names is worse than no filter: it is invisible, and the person
+// it rejects has no idea why
+describe("names it must not touch", () => {
+  const fine = [
+    "NovaDrake",
+    "Reimu",
+    "MarisaKirisame",
+    "xX_Sniper_Xx",
+    "player1",
+    "Nathan",
+    "Mohamed Abdelkawi",
+    "Malgorzata Bajolek",
+    "Nguyen",
+    "Nikita",
+    "Angus",
+    "Cassandra",
+    "Classic",
+    "Bassist",
+    "Assassin",
+    "Douglas",
+    "Scunthorpe",
+    "Penistone",
+    "Cockburn",
+    "Analyst",
+    "Cumberland",
+    "Negroni",
+    "Pakistan",
+    "Raccoon",
+    "Tycoon",
+    "Spicy",
+    "Van Dyke",
+    "Dijkstra",
+    "Retardant",
+    "Shuttlecock",
+    "Titan",
+    "Ganguly",
+    "Gonzalez",
+    // a scan of the real user table turned these up as false positives
+    "Ruby Stardust",
+    "star dud",
+    "Custard",
+    "Mustard",
+    "Standard",
+    // the ordinary respectful word in portuguese, and most players here are brazilian
+    "Negro",
+    "Negreiros",
+  ];
+
+  for (const name of fine) {
+    it(`leaves ${name} alone`, () => {
+      expect(isClean(name)).toBe(true);
+    });
+  }
+});
+
+// the allowlist is the obvious way to smuggle one through: put a permitted word next to
+// the slur and a filter that asks "does this contain something allowed" waves it past
+describe("hiding behind an allowed word", () => {
+  const smuggled = [
+    "stardustnigger",
+    "raccoonnigger",
+    "pakistan_nigga",
+    "spicy n*gga",
+    "cocoon nigga",
+    "vandykefaggot",
+    "NegroniN1gga",
+  ];
+
+  for (const name of smuggled) {
+    it(`still blocks ${name}`, () => {
+      expect(isClean(name)).toBe(false);
+    });
+  }
+
+  it("cuts the allowed word out rather than skipping the check", () => {
+    expect(withoutAllowed("raccoonnigger")).toContain("nigger");
+    expect(withoutAllowed("raccoon").trim()).toBe("");
+  });
+});
+
+describe("normalising", () => {
+  it("folds accents to their base letter", () => {
+    expect(normalize("Ré1mü")).toBe("re1mu");
+  });
+
+  it("keeps only letters for the allowlist comparison", () => {
+    expect(letters("Sc-unth.orpe")).toBe("scunthorpe");
+  });
+
+  it("treats an empty name as nothing to match", () => {
+    expect(findSlur("")).toBeNull();
+    expect(findSlur(null)).toBeNull();
+    expect(findSlur("   ")).toBeNull();
+  });
+});
+
+describe("reporting", () => {
+  it("names the term it matched, for the log rather than the player", () => {
+    expect(findSlur("n*gga")).toBe("nigga");
+    expect(findSlur("Reimu")).toBeNull();
+  });
+});
+
+// a google display name is not something the person can edit to get past this, so a
+// collision must not lock them out of their own account
+describe("google display names", () => {
+  it("keeps a name that is fine", () => {
+    expect(safeUsername("Mohamed Abdelkawi", "123")).toBe("Mohamed Abdelkawi");
+  });
+
+  it("swaps a name that is not, instead of refusing the login", () => {
+    const safe = safeUsername("n*gga", "987654");
+    expect(safe).not.toMatch(/gga/i);
+    expect(safe).toBe("player87654");
+    expect(isClean(safe)).toBe(true);
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -69,6 +69,7 @@ const io = socketIO(server, {
 const coinFlip = require("./games/coinFlip");
 const crash = require("./games/crash");
 const caseBattle = require("./games/caseBattle");
+const User = require("./models/User");
 const { recoverStuckRounds } = require("./utils/rounds");
 const { completeStuckBattles } = require("./games/battleEngine");
 const { sweepBlackjackHands } = require("./games/blackjack");
@@ -198,12 +199,15 @@ let onlineUsers = 0;
 
 // optional auth: a valid token binds socket.userId; anonymous sockets may still
 // watch games but the game handlers ignore any client-supplied identity.
-io.use((socket, next) => {
+io.use(async (socket, next) => {
   try {
     const token = socket.handshake.auth && socket.handshake.auth.token;
     if (token) {
       const decoded = jwt.verify(token, process.env.JWT_SECRET);
-      socket.userId = decoded.userId;
+      // the http side refuses a disabled account, and the socket games have to as well or
+      // a banned player can still sit in crash and coin flip on a live connection
+      const account = await User.findById(decoded.userId).select("disabled").lean();
+      if (!account || !account.disabled) socket.userId = decoded.userId;
     }
   } catch (err) {
     // invalid/expired token: continue unauthenticated

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -33,6 +33,12 @@ const isAuthenticated = async (req, res, next) => {
       return res.status(401).json({ message: "Session expired. Please log in again." });
     }
 
+    // 403 rather than 401: a 401 tells the client the session died and it should log in
+    // again, which would just loop. this is the account, not the session.
+    if (user.disabled) {
+      return res.status(403).json({ message: "This account has been disabled." });
+    }
+
     req.user = user;
     next();
   } catch (error) {

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -118,6 +118,14 @@ const UserSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
+  // a disabled account keeps its rows so the ledger and every board stay consistent, but
+  // nothing it holds can be used again. banning by deletion would tear holes in both.
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  disabledAt: Date,
+  disabledReason: String,
   nextBonus: {
     type: Date,
     default: () => Date.now() - 86400000 // now - 24 hours

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const { isAuthenticated, isAdmin } = require("../middleware/authMiddleware");
 const badges = require("../utils/badges");
+const nameFilter = require("../utils/nameFilter");
 const User = require("../models/User");
 const Case = require("../models/Case");
 const Item = require("../models/Item");
@@ -198,6 +199,10 @@ router.put("/users/:id/badge", isAuthenticated, isAdmin, async (req, res) => {
   const { key, note, action } = req.body;
   if (!badges.GRANTABLE.includes(key)) {
     return res.status(400).json({ message: "That badge is earned, not granted" });
+  }
+  // written by an admin, but it sits on a public profile
+  if (note && nameFilter.findSlur(note)) {
+    return res.status(400).json({ message: "Please write something else" });
   }
   try {
     const user = await User.findById(req.params.id).select("_id");

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -155,6 +155,10 @@ router.post(
         return res.status(400).json({ message: "Invalid credentials" });
       }
 
+      if (user.disabled) {
+        return res.status(403).json({ message: "This account has been disabled." });
+      }
+
       // Generate and send JWT
       const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };
       jwt.sign(
@@ -223,6 +227,10 @@ router.post('/googlelogin', async (req, res) => {
     } else if (!user.googleId) {
       // the field was never written before, so it backfills as older accounts sign in
       await User.updateOne({ _id: user._id }, { $set: { googleId: googlePayload.sub } });
+    }
+
+    if (user.disabled) {
+      return res.status(403).json({ message: "This account has been disabled." });
     }
     // Generate and send JWT
     const payload = { userId: user.id, tokenVersion: user.tokenVersion || 0 };

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -21,6 +21,7 @@ const { ObjectId } = require('mongodb');
 const { OAuth2Client } = require('google-auth-library');
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const { resolvePassword } = require("../utils/password");
+const nameFilter = require("../utils/nameFilter");
 
 // Register user
 router.post(
@@ -53,6 +54,12 @@ router.post(
       let userName = await User.findOne({ username });
       if (userName) {
         return res.status(400).json({ message: "Username already registered" });
+      }
+
+      const slur = nameFilter.findSlur(username);
+      if (slur) {
+        console.warn(`register blocked: ${email} tried "${username}" (${slur})`);
+        return res.status(400).json({ message: "Please choose a different username" });
       }
 
       // an unknown referral code is ignored rather than blocking the signup
@@ -179,7 +186,7 @@ router.post('/googlelogin', async (req, res) => {
     // Check if user exists in your DB or create a new one
     let user = await User.findOne({ email: googlePayload.email });
     if (!user) {
-      let username = googlePayload.name;
+      let username = nameFilter.safeUsername(googlePayload.name, googlePayload.sub);
       let existingUser = await User.findOne({ username });
       while (existingUser) {
         // Handle username conflict
@@ -642,8 +649,11 @@ router.put(
         return res.status(404).json({ message: "User not found" });
       }
 
-      // Update fixed item description (crop to 50 characters)
-      user.fixedItem.description = description.substring(0, 50);
+      const cropped = String(description || "").substring(0, 50);
+      if (nameFilter.findSlur(cropped)) {
+        return res.status(400).json({ message: "Please write something else" });
+      }
+      user.fixedItem.description = cropped;
 
       await user.save();
 

--- a/backend/scripts/disableUsers.js
+++ b/backend/scripts/disableUsers.js
@@ -1,0 +1,76 @@
+require("dotenv").config();
+const mongoose = require("mongoose");
+const User = require("../models/User");
+
+// disables accounts by id. a disabled account keeps every row it owns, so the ledger, the
+// fan boards and the market history all stay consistent; it simply cannot be used again.
+// deleting would tear holes in all three and is not reversible.
+//
+// bumping tokenVersion is what makes it take effect now rather than in thirty days: every
+// jwt already issued to that account stops verifying on the next request.
+//
+// usage:
+//   node scripts/disableUsers.js --reason "slur in username" <id> <id> ...
+//   node scripts/disableUsers.js --undo <id>
+//   add --dry to print what it would do and change nothing
+async function disable(ids, { reason = "terms of use", undo = false, dry = false } = {}) {
+  const done = [];
+  for (const id of ids) {
+    const user = await User.findById(id).select("username disabled tokenVersion").lean();
+    if (!user) {
+      done.push({ id, result: "no such account" });
+      continue;
+    }
+    if (!undo && user.disabled) {
+      done.push({ id, username: user.username, result: "already disabled" });
+      continue;
+    }
+    if (dry) {
+      done.push({ id, username: user.username, result: undo ? "would enable" : "would disable" });
+      continue;
+    }
+
+    await User.updateOne(
+      { _id: id },
+      undo
+        ? { $set: { disabled: false }, $unset: { disabledAt: "", disabledReason: "" } }
+        : {
+            $set: { disabled: true, disabledAt: new Date(), disabledReason: reason },
+            // kills every token already issued to this account
+            $inc: { tokenVersion: 1 },
+          }
+    );
+    done.push({ id, username: user.username, result: undo ? "enabled" : "disabled" });
+  }
+  return done;
+}
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const undo = argv.includes("--undo");
+  const dry = argv.includes("--dry");
+  const reasonAt = argv.indexOf("--reason");
+  const reason = reasonAt >= 0 ? argv[reasonAt + 1] : "terms of use";
+  const ids = argv.filter(
+    (a, i) => !a.startsWith("--") && !(reasonAt >= 0 && i === reasonAt + 1)
+  );
+
+  if (!ids.length) {
+    console.error("give at least one user id");
+    process.exit(1);
+  }
+
+  mongoose
+    .connect(process.env.MONGO_URI)
+    .then(() => disable(ids, { reason, undo, dry }))
+    .then((rows) => {
+      for (const r of rows) console.log(`  ${r.id}  ${r.username || "?"}  ${r.result}`);
+      return mongoose.disconnect();
+    })
+    .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    });
+}
+
+module.exports = { disable };

--- a/backend/scripts/scanNames.js
+++ b/backend/scripts/scanNames.js
@@ -1,0 +1,58 @@
+require("dotenv").config();
+const mongoose = require("mongoose");
+const User = require("../models/User");
+const nameFilter = require("../utils/nameFilter");
+
+// reports, never changes. the filter only guards new names, so anything registered before
+// it shipped is still sitting there, and renaming somebody is a decision for a person.
+//
+// usage:  node scripts/scanNames.js
+async function scan() {
+  const hits = { usernames: [], descriptions: [] };
+
+  const cursor = User.find({})
+    .select("username email fixedItem.description")
+    .lean()
+    .cursor();
+
+  let seen = 0;
+  for await (const user of cursor) {
+    seen += 1;
+    const nameHit = nameFilter.findSlur(user.username);
+    if (nameHit) {
+      hits.usernames.push({ id: String(user._id), username: user.username, matched: nameHit });
+    }
+    const description = user.fixedItem && user.fixedItem.description;
+    const descHit = description ? nameFilter.findSlur(description) : null;
+    if (descHit) {
+      hits.descriptions.push({
+        id: String(user._id),
+        username: user.username,
+        description,
+        matched: descHit,
+      });
+    }
+  }
+
+  return { seen, ...hits };
+}
+
+if (require.main === module) {
+  mongoose
+    .connect(process.env.MONGO_URI)
+    .then(scan)
+    .then((r) => {
+      console.log(`scanned ${r.seen} accounts`);
+      console.log(`usernames: ${r.usernames.length}`);
+      for (const h of r.usernames) console.log(`  ${h.id}  ${h.username}  [${h.matched}]`);
+      console.log(`descriptions: ${r.descriptions.length}`);
+      for (const h of r.descriptions) console.log(`  ${h.id}  ${h.username}: ${h.description}  [${h.matched}]`);
+      return mongoose.disconnect();
+    })
+    .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    });
+}
+
+module.exports = { scan };

--- a/backend/utils/nameFilter.js
+++ b/backend/utils/nameFilter.js
@@ -1,0 +1,155 @@
+// blocks slurs in anything a player types that other players will see: the username at
+// signup and the description under a pinned item.
+//
+// this is a slur list, not a profanity list. "damn" in a username is nobody's problem;
+// what this exists to stop is a racial, ethnic, homophobic or ableist slur sitting on a
+// leaderboard where everyone has to read it.
+//
+// the hard part is not the words, it is the spelling. somebody who wants the slur will
+// write n*gga, n1gg4, n-i-g-g-a, ｎｉｇｇｅｒ or нigger, so matching plain strings catches
+// almost nothing. every term below is compiled into a pattern that tolerates leetspeak,
+// separators, repeats, accents, fullwidth forms and cyrillic lookalikes.
+
+// letters that get written as something else. `*` and `#` are in every class because a
+// masked letter is the single most common dodge.
+const SUBSTITUTES = {
+  a: "a4@^",
+  b: "b8",
+  c: "c(<{[",
+  e: "e3&",
+  g: "g69q",
+  i: "i1!|ly",
+  l: "l1|i",
+  o: "o0()",
+  s: "s5$z",
+  t: "t7+",
+  u: "uvw",
+  z: "z2s",
+};
+
+// cyrillic and greek characters that render as latin ones
+const HOMOGLYPHS = {
+  "а": "a", "е": "e", "о": "o", "р": "p", "с": "c",
+  "у": "y", "х": "x", "і": "i", "һ": "h", "ԁ": "d",
+  "α": "a", "ε": "e", "ι": "i", "ο": "o", "ρ": "p",
+  "τ": "t", "υ": "u", "ν": "v", "χ": "x",
+};
+
+// what somebody would actually have to type. kept deliberately narrow: a broad list
+// turns into a machine that rejects real names.
+const SLURS = [
+  "nigger", "nigga", "niglet",
+  "faggot", "fagot", "tranny", "trannie",
+  "chink", "gook", "spic", "wetback", "beaner", "kike", "kyke",
+  "coon", "jigaboo", "porchmonkey", "sandnigger",
+  "raghead", "towelhead", "camelfucker",
+  "retard", "retarded", "mongoloid",
+  "paki", "abbo", "gypo", "gyppo",
+  "shemale", "dyke",
+];
+
+// two terms were tried and taken back out, because a scan of the real user table showed
+// what they cost:
+//
+//   "tard"  matched Ruby Stardust and star dud. it sits inside stardust, custard, mustard
+//           and bastard, and "retard" already covers what it was there for.
+//   "negro" is the ordinary respectful word for a Black person in Portuguese, and most of
+//           the people here are Brazilian. blocking it would reject correct pt-BR usage to
+//           catch an English slur that "nigger" already catches.
+//
+// real words and names that a pattern above would otherwise swallow. the classic failure
+// mode of every filter like this: scunthorpe, penistone, someone actually called Dyke.
+const ALLOW = [
+  "cocktail", "shuttlecock", "scunthorpe", "penistone", "lightwater",
+  "assassin", "assess", "assist", "bass", "class", "glass", "grass", "mass", "pass",
+  "analysis", "analyst", "canal", "arsenal", "arsenic",
+  "cumin", "circumstance", "document", "accumulate",
+  "dyked", "dykes", "vandyke", "dijk",
+  "retardant", "retardation",
+  "negroni",
+  "pakistan", "pakistani",
+  "cooney", "cooning", "raccoon", "cocoon", "tycoon", "lagoon", "monsoon",
+  "stardust", "custard", "mustard", "bastard", "standard",
+  "spice", "spicy", "despicable", "auspicious", "suspicious",
+];
+
+const escape = (ch) => ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// one letter becomes "any of the things people write instead of it", repeated, with any
+// amount of punctuation or space allowed after it
+function letterPattern(letter) {
+  const variants = SUBSTITUTES[letter] || letter;
+  const chars = [...new Set((letter + variants).split(""))].map(escape).join("");
+  return `[${chars}*#]+[\\W_]*`;
+}
+
+function compile(term) {
+  return new RegExp(term.split("").map(letterPattern).join(""), "i");
+}
+
+// the allowed words are matched letter for letter, with no repetition. the `+` that lets a
+// slur pattern catch "niiigga" would, on an allowed word, eat past the end of it:
+// raccoon's trailing n+ swallowed both n's of raccoonnigger and left "igger" behind.
+function compileAllow(term) {
+  const exact = term
+    .split("")
+    .map((letter) => letterPattern(letter).replace("]+[", "][")) 
+    .join("");
+  return new RegExp(exact, "gi");
+}
+
+const PATTERNS = SLURS.map((term) => ({ term, re: compile(term) }));
+// still separator tolerant, so "sc-unthorpe" is recognised, but letter for letter
+const ALLOWED = ALLOW.map(compileAllow);
+
+// strip everything that is decoration rather than content, so the comparison is between
+// what was meant rather than how it was dressed up
+function normalize(input) {
+  return String(input || "")
+    .normalize("NFKD")
+    // combining marks, so accented letters fold to their base
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[Ѐ-ӿͰ-Ͽ]/g, (ch) => HOMOGLYPHS[ch.toLowerCase()] || ch)
+    .toLowerCase();
+}
+
+const letters = (input) => normalize(input).replace(/[^a-z]/g, "");
+
+// an allowed word is cut out of the name and the rest is still checked. asking "does this
+// name contain an allowed word" instead would hand everybody a skeleton key:
+// stardustnigger and raccoonnigger both contain one.
+function withoutAllowed(text) {
+  return ALLOWED.reduce((left, re) => left.replace(re, " "), text);
+}
+
+// returns null when the name is fine, or the term it matched. the term is for logging and
+// for tests; it is never shown to the person typing, because telling somebody exactly
+// which pattern they tripped is a guide to getting around it.
+function findSlur(input) {
+  const text = normalize(input);
+  if (!text.trim()) return null;
+  const left = withoutAllowed(text);
+  const hit = PATTERNS.find(({ re }) => re.test(left));
+  return hit ? hit.term : null;
+}
+
+const isClean = (input) => findSlur(input) === null;
+
+// a google account's display name is not something the person can change to get in, so a
+// name that trips the filter falls back to a generated one rather than refusing the login
+function safeUsername(name, fallbackSeed) {
+  if (isClean(name)) return String(name);
+  const seed = String(fallbackSeed || Math.abs(Date.now() % 100000));
+  return `player${seed.slice(-5)}`;
+}
+
+module.exports = {
+  SLURS,
+  ALLOW,
+  normalize,
+  letters,
+  withoutAllowed,
+  findSlur,
+  isClean,
+  safeUsername,
+};

--- a/backend/utils/nameFilter.js
+++ b/backend/utils/nameFilter.js
@@ -46,7 +46,38 @@ const SLURS = [
   "retard", "retarded", "mongoloid",
   "paki", "abbo", "gypo", "gyppo",
   "shemale", "dyke",
+
+  // portuguese. most players here are brazilian, so an english-only list left the door
+  // wide open. only terms that are the slur and nothing else are in: the ones that double
+  // as ordinary words are listed under "deliberately not blocked" below.
+  "crioulo", "criolo",
+  "viado", "boiola", "baitola",
+  "traveco", "travecão",
+  "retardado", "mongoloide", "mongolóide",
+
+  // spanish
+  "maricon", "maricona", "sudaca", "negrata",
 ];
+
+// deliberately NOT blocked, because in portuguese each of these is an ordinary word far
+// more often than it is an insult, and a username filter that eats them is worse than one
+// that misses the rare abuse:
+//
+//   preto   the plain word for the colour black, and the ordinary way to say a Black
+//           person. blocking it would be the same mistake as blocking "negro".
+//   nego    affectionate in brazil, closer to "mate" than to anything hostile
+//   macaco  a monkey, and a car jack. an anime site full of animal characters will have
+//           real usernames with it
+//   veado   a deer. only the "viado" spelling is reliably the slur, so only that is above
+//   bicha   a queue in portugal and a worm in brazil
+//   japa    usually casual or self-applied rather than hostile
+//   baiano  a person from Bahia
+//   biba    a slur, but four letters that sit inside the surname Bibas
+//   panchito a slur in spain, and everywhere else the diminutive of Francisco
+//
+// and two that were in a draft of this list by mistake, worth naming so they do not come
+// back: "jumento" is a donkey, which is rude rather than a slur, and "arigato" is Japanese
+// for thank you, which on an anime site would be an absurd thing to reject.
 
 // two terms were tried and taken back out, because a scan of the real user table showed
 // what they cost:
@@ -71,6 +102,12 @@ const ALLOW = [
   "cooney", "cooning", "raccoon", "cocoon", "tycoon", "lagoon", "monsoon",
   "stardust", "custard", "mustard", "bastard", "standard",
   "spice", "spicy", "despicable", "auspicious", "suspicious",
+  // portuguese collisions with the terms above
+  "criolla", "criollo",
+  // "mongol" is not here on purpose: an allowed word that is a prefix of a blocked one
+  // disarms it, and stripping it left "oide" behind, which matches nothing. "mongolia" is
+  // safe because the slur diverges at the sixth letter.
+  "retardador", "mongolia",
 ];
 
 const escape = (ch) => ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -84,7 +121,9 @@ function letterPattern(letter) {
 }
 
 function compile(term) {
-  return new RegExp(term.split("").map(letterPattern).join(""), "i");
+  // the term is folded exactly like the input is, or "travecão" compiles a pattern built
+  // around a character the normalised text can never contain
+  return new RegExp(normalize(term).split("").map(letterPattern).join(""), "i");
 }
 
 // the allowed words are matched letter for letter, with no repetition. the `+` that lets a

--- a/backend/utils/referrals.js
+++ b/backend/utils/referrals.js
@@ -22,6 +22,8 @@ const CODE_PATTERN = /^[A-Z0-9]{3,16}$/;
 const normalizeCode = (raw) => String(raw || "").trim().toUpperCase();
 
 // in-app notification; the bell picks it up on the next fetch, no socket needed here
+const nameFilter = require("./nameFilter");
+
 const notify = (receiverId, senderId, title, content) =>
   Notification.create({ receiverId, senderId, type: "message", title, content }).catch((err) =>
     console.error("referral notify failed:", err)
@@ -35,6 +37,9 @@ async function setReferralCode(userId, raw) {
   const code = normalizeCode(raw);
   if (!CODE_PATTERN.test(code)) {
     return { code: 400, body: { message: "Codes are 3-16 letters or numbers" } };
+  }
+  if (nameFilter.findSlur(code)) {
+    return { code: 400, body: { message: "Please choose a different code" } };
   }
   try {
     const res = await User.updateOne(


### PR DESCRIPTION
Somebody registered a slur as their username. A scan of the user table found 11 more already stored, plus one pinned-item description.

The hard part is not the words, it is the spelling: `n*gga`, `n1gg4`, `n-i-g-g-a`, fullwidth and cyrillic lookalikes all read the same to a person and match nothing as a plain string. Every term is compiled into a pattern that tolerates leetspeak, masked letters, separators, repeats, accents and homoglyphs.

Applied at signup, on the google display name, and on the pinned item description, which is the other place a player writes something everyone else reads. The message never names the term that matched, since that is a guide to getting around it. A google display name cannot be edited to get past the filter, so one that trips it falls back to a generated username rather than refusing the login.

The allowlist removes rather than exempts: asking whether a name contains an allowed word would let `stardustnigger` and `raccoonnigger` straight through, so the allowed word is cut out and the remainder is still checked.

`scripts/scanNames.js` reports what is already stored and never changes it. Running it against the live table is what caught two terms that had to come out: `tard` matched **Ruby Stardust** and **star dud**, and `negro` is the ordinary respectful word for a Black person in Portuguese, which most players here speak.

Tests: 49 unit covering the spellings people actually use and 37 real names that must not be touched, 10 integration across all three entry points, and 7 pinning the allowlist bypass. Full backend suite green.
