### PR TITLE
Centre the Discord button label when it wraps

### DIFF
--- a/src/pages/Home/DiscordWidget.tsx
+++ b/src/pages/Home/DiscordWidget.tsx
@@ -106,7 +106,7 @@ const DiscordWidget = () => {
             href={invite}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-auto flex items-center justify-center gap-2 rounded-lg bg-[#5865F2] px-4 py-3 font-bold text-white transition-all hover:bg-[#4752C4]"
+            className="mt-auto flex items-center text-center justify-center gap-2 rounded-lg bg-[#5865F2] px-4 py-3 font-bold text-white transition-all hover:bg-[#4752C4]"
           >
             <FaDiscord className="text-xl" />
             {i18n.t("home.joinTheKanicasinoServer")}


### PR DESCRIPTION
The join button is a centred flex row, so the icon and the label are centred as a pair, but the label's own lines stay ragged once it wraps. It wraps in every language whose string is longer than English, which is most of them.

One class. The change has been sitting uncommitted in a working tree since before #205.
