### PR TITLE
Keep disabled accounts off every public surface

### DIFF
--- a/backend/__tests__/integration/hideDisabled.test.js
+++ b/backend/__tests__/integration/hideDisabled.test.js
@@ -1,0 +1,190 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const FanBoard = require("../../models/FanBoard");
+const CollectorBoard = require("../../models/CollectorBoard");
+const fandom = require("../../utils/fandom");
+
+let app;
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(over = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `u-${s}`,
+    email: `u-${s}@e.com`,
+    password: "x",
+    walletBalance: 100,
+    ...over,
+  });
+}
+
+// a player pinned to a character, holding some copies of it
+async function fan(name, copies, over = {}) {
+  const item = await Item.create({ name, image: `${name}.png`, rarity: "4", baseValue: 100 });
+  const inventory = Array.from({ length: copies }, () => ({
+    _id: item._id,
+    uniqueId: `uq-${uniqueSuffix()}`,
+    name: item.name,
+    image: item.image,
+    rarity: item.rarity,
+  }));
+  return makeUser({
+    inventory,
+    fixedItem: { name: item.name, image: item.image, rarity: item.rarity, description: "" },
+    fixedAt: new Date(),
+    ...over,
+  });
+}
+
+describe("the leaderboard", () => {
+  it("leaves a disabled account out of the top players", async () => {
+    await makeUser({ username: `clean-${uniqueSuffix()}`, weeklyWinnings: 100 });
+    const banned = await makeUser({ username: `banned-${uniqueSuffix()}`, weeklyWinnings: 999999, disabled: true });
+
+    const res = await request(app).get("/users/topPlayers");
+    expect(res.status).toBe(200);
+    expect(res.body.map((u) => u.username)).not.toContain(banned.username);
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+
+  it("does not count a disabled account in somebody's rank", async () => {
+    // three accounts above the viewer, one of them disabled
+    await makeUser({ weeklyWinnings: 300 });
+    await makeUser({ weeklyWinnings: 200, disabled: true });
+    await makeUser({ weeklyWinnings: 150 });
+    const me = await makeUser({ weeklyWinnings: 10 });
+
+    const res = await request(app)
+      .get("/users/ranking")
+      .set("Authorization", `Bearer ${tokenFor(me)}`);
+
+    // two visible players are ahead, so third place, not fourth
+    expect(res.body.ranking).toBe(3);
+    expect(res.body.users.every((u) => !u.disabled)).toBe(true);
+  });
+});
+
+describe("the public profile", () => {
+  it("reads as no such player", async () => {
+    const banned = await makeUser({ disabled: true });
+    const res = await request(app).get(`/users/${banned._id}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it("still works for everybody else", async () => {
+    const user = await makeUser();
+    const res = await request(app).get(`/users/${user._id}`);
+    expect(res.body.username).toBe(user.username);
+  });
+
+  it("hides their inventory too", async () => {
+    const banned = await makeUser({ disabled: true });
+    const res = await request(app).get(`/users/inventory/${banned._id}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// the sweep rebuilds every board from every account on a ten minute cron, so without this
+// a disabled name is back on top fan within the hour however many times it is cleared
+describe("the fan boards", () => {
+  it("drops a disabled account on the next sweep", async () => {
+    const keeper = await fan("Reimu", 2);
+    const banned = await fan("Reimu", 50, { disabled: true });
+
+    await fandom.rebuild();
+
+    const board = await FanBoard.findOne({ name: "Reimu" });
+    expect(board).toBeTruthy();
+    const names = board.ranks.map((r) => r.username);
+    expect(names).not.toContain(banned.username);
+    expect(names).toContain(keeper.username);
+    // and the disabled account does not take the board with fifty copies
+    expect(board.top.username).toBe(keeper.username);
+    expect(board.fanCount).toBe(1);
+  });
+
+  it("keeps them off the collector board", async () => {
+    await fan("Marisa", 3);
+    const banned = await fan("Yukari", 40, { disabled: true });
+
+    await fandom.rebuild();
+
+    const board = await CollectorBoard.findOne({ key: "collection" });
+    expect(board.ranks.map((r) => r.username)).not.toContain(banned.username);
+  });
+
+  // fanRank is what puts the top fan badge on a player site-wide, so a disabled account
+  // must never come out of a sweep holding one. mongoose materialises the nested path as
+  // an empty object rather than leaving it undefined, so the check is on the contents.
+  it("does not hand them a fanRank to wear", async () => {
+    const keeper = await fan("Sakuya", 2);
+    const banned = await fan("Sakuya", 30, { disabled: true });
+    await fandom.rebuild();
+
+    const after = await User.findById(banned._id);
+    expect(after.fanRank && after.fanRank.name).toBeFalsy();
+    // and the sweep did run, so this is not just an empty rebuild
+    expect((await User.findById(keeper._id)).fanRank.name).toBe("Sakuya");
+  });
+
+  // pinning triggers a targeted rebuild of just that character's board
+  it("leaves them out of a single-character refresh too", async () => {
+    const keeper = await fan("Cirno", 1);
+    const banned = await fan("Cirno", 60, { disabled: true });
+
+    await fandom.refreshCharacters(["Cirno"]);
+
+    const board = await FanBoard.findOne({ name: "Cirno" });
+    expect(board.ranks.map((r) => r.username)).toEqual([keeper.username]);
+  });
+});
+
+describe("friends", () => {
+  it("drops a disabled friend from the list", async () => {
+    const banned = await makeUser({ disabled: true });
+    const keeper = await makeUser();
+    const me = await makeUser({ friends: [banned._id, keeper._id] });
+
+    const res = await request(app).get("/friends/me").set("Authorization", `Bearer ${tokenFor(me)}`);
+    expect(res.status).toBe(200);
+    // populate yields null where the match fails; those must not reach the client
+    expect(res.body.friends).toHaveLength(1);
+    expect(res.body.friends[0].username).toBe(keeper.username);
+  });
+
+  it("drops a disabled friend request", async () => {
+    const banned = await makeUser({ disabled: true });
+    const me = await makeUser({ friendRequests: [banned._id] });
+
+    const res = await request(app).get("/friends/me").set("Authorization", `Bearer ${tokenFor(me)}`);
+    expect(res.body.requests).toEqual([]);
+  });
+
+  it("hides a disabled account's own friends list", async () => {
+    const banned = await makeUser({ disabled: true });
+    const res = await request(app).get(`/friends/list/${banned._id}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// what a ban must never do: rewrite what already happened
+describe("what stays", () => {
+  it("keeps the account and everything on it", async () => {
+    const banned = await makeUser({ walletBalance: 2536, disabled: true });
+    const after = await User.findById(banned._id);
+    expect(after).toBeTruthy();
+    expect(after.walletBalance).toBe(2536);
+  });
+});

--- a/backend/routes/friendsRoutes.js
+++ b/backend/routes/friendsRoutes.js
@@ -6,6 +6,10 @@ const User = require("../models/User");
 const Notification = require("../models/Notification");
 
 const PUBLIC_FIELDS = "username profilePicture level fixedItem";
+const { VISIBLE, isVisible } = require("../utils/visibility");
+// populate yields null where the match fails, so those are dropped rather than rendered
+const PUBLIC_POPULATE = { select: PUBLIC_FIELDS, match: VISIBLE };
+const seen = (list) => (list || []).filter(Boolean);
 
 // reject malformed ids up front so they return 400 instead of a cast-error 500
 const validId = (req, res, next) => {
@@ -20,14 +24,14 @@ module.exports = (io) => {
   router.get("/me", isAuthenticated, async (req, res) => {
     try {
       const me = await User.findById(req.user._id)
-        .populate("friends", PUBLIC_FIELDS)
-        .populate("friendRequests", PUBLIC_FIELDS);
+        .populate({ path: "friends", ...PUBLIC_POPULATE })
+        .populate({ path: "friendRequests", ...PUBLIC_POPULATE });
 
       if (!me) {
         return res.status(404).json({ message: "User not found" });
       }
 
-      res.json({ friends: me.friends, requests: me.friendRequests });
+      res.json({ friends: seen(me.friends), requests: seen(me.friendRequests) });
     } catch (err) {
       console.error(err);
       res.status(500).json({ message: "Server error" });
@@ -37,11 +41,11 @@ module.exports = (io) => {
   // a user's public friends list
   router.get("/list/:id", validId, async (req, res) => {
     try {
-      const user = await User.findById(req.params.id).populate("friends", PUBLIC_FIELDS);
-      if (!user) {
+      const user = await User.findById(req.params.id).populate({ path: "friends", ...PUBLIC_POPULATE });
+      if (!isVisible(user)) {
         return res.status(404).json({ message: "User not found" });
       }
-      res.json({ friends: user.friends });
+      res.json({ friends: seen(user.friends) });
     } catch (err) {
       console.error(err);
       res.status(500).json({ message: "Server error" });

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -22,6 +22,7 @@ const { OAuth2Client } = require('google-auth-library');
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const { resolvePassword } = require("../utils/password");
 const nameFilter = require("../utils/nameFilter");
+const { visible, isVisible } = require("../utils/visibility");
 
 // Register user
 router.post(
@@ -318,7 +319,7 @@ router.get("/badges/catalog", async (req, res) => {
 // Fetch top players
 router.get('/topPlayers', async (req, res) => {
   try {
-    const topPlayers = await User.find({})
+    const topPlayers = await User.find(visible())
       .sort({ weeklyWinnings: -1 })
       .limit(10) // Top 10 players
       .select('username weeklyWinnings profilePicture level fixedItem fanRank selectedBadge badges');
@@ -349,9 +350,9 @@ router.get('/ranking', authMiddleware.isAuthenticated, async (req, res) => {
     };
 
     const [rankAbove, aboveAll, belowAll] = await Promise.all([
-      User.countDocuments(aboveFilter),
-      User.find(aboveFilter).sort({ weeklyWinnings: 1, _id: -1 }).limit(6).select('username weeklyWinnings'),
-      User.find(belowFilter).sort({ weeklyWinnings: -1, _id: 1 }).limit(6).select('username weeklyWinnings'),
+      User.countDocuments(visible(aboveFilter)),
+      User.find(visible(aboveFilter)).sort({ weeklyWinnings: 1, _id: -1 }).limit(6).select('username weeklyWinnings'),
+      User.find(visible(belowFilter)).sort({ weeklyWinnings: -1, _id: 1 }).limit(6).select('username weeklyWinnings'),
     ]);
 
     // pad the 7-row window toward the other side when near the top or bottom
@@ -732,9 +733,9 @@ router.get("/:id", async (req, res) => {
       return res.status(404).json({ message: "User not found" });
     }
     const user = await User.findById(req.params.id)
-      .select("username profilePicture xp level fixedItem fanRank collectionRank nextBonus weeklyWinnings selectedBadge badges")
+      .select("username profilePicture xp level fixedItem fanRank collectionRank nextBonus weeklyWinnings selectedBadge badges disabled")
       .lean();
-    if (!user) return res.json(null);
+    if (!isVisible(user)) return res.json(null);
     res.json({ ...user, badges: badges.heldBadges(user), badge: badges.wornBadge(user) });
   } catch (err) {
     console.error(err.message);
@@ -761,7 +762,7 @@ router.get("/inventory/:userId", async (req, res) => {
     }
 
     const user = await User.findById(userId);
-    if (!user) {
+    if (!isVisible(user)) {
       return res.status(404).json({ message: "User not found" });
     }
 

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -3,6 +3,7 @@ const User = require("../models/User");
 const Item = require("../models/Item");
 const FanBoard = require("../models/FanBoard");
 const CollectorBoard = require("../models/CollectorBoard");
+const { visible } = require("./visibility");
 
 // how many chasers a board keeps. deep enough that anyone in touching distance sees
 // themselves, short enough that a board document stays small.
@@ -76,7 +77,7 @@ async function sweep() {
   const pinned = new Map();
   const collectors = [];
 
-  const cursor = User.find({})
+  const cursor = User.find(visible())
     .select("username profilePicture level fixedItem fixedAt inventory")
     .lean()
     .cursor();
@@ -244,7 +245,7 @@ async function refreshCharacters(names) {
   for (const name of wanted) {
     const character = byName.get(name);
     if (!character) continue;
-    const users = await User.find({ "fixedItem.name": name })
+    const users = await User.find(visible({ "fixedItem.name": name }))
       .select("username profilePicture level fixedAt inventory")
       .lean();
     const rows = users

--- a/backend/utils/visibility.js
+++ b/backend/utils/visibility.js
@@ -1,0 +1,19 @@
+// a disabled account is frozen, not deleted. its rows stay put so the ledger, past battles
+// and market history all remain whole, and nothing that already happened is rewritten.
+//
+// but it must not appear anywhere a player browses. that is the whole point of the ban:
+// the account was disabled because its name is the problem, so leaving the name on a
+// leaderboard would defeat it.
+//
+// every public query composes this in. one constant rather than a filter written out at
+// each call site, so a surface that forgets it is visible in a grep rather than invisible.
+const VISIBLE = { disabled: { $ne: true } };
+
+// merge into an existing filter. `{ ...filter, ...VISIBLE }` is safe here because no
+// caller filters on `disabled` itself.
+const visible = (filter = {}) => ({ ...filter, ...VISIBLE });
+
+// for a single document already loaded
+const isVisible = (user) => !!user && user.disabled !== true;
+
+module.exports = { VISIBLE, visible, isVisible };


### PR DESCRIPTION
Disabling an account stopped it being used but not being seen, and the point of the ban was the name. Three banned slur usernames were still sitting on live Top Fan boards.

The fandom sweep is why. It rebuilds every board from every account on a `*/10` cron, so clearing a name by hand does nothing — it is back within the hour. Both the full sweep and the single-character refresh filter now.

`utils/visibility.js` holds the rule once and every public query composes it in, so a surface that forgets it shows up in a grep rather than in production. Covered: top players, ranking including the `countDocuments` that produces a player's own position, the public profile, the public inventory, the fan and collector boards, and friend lists. Populated friends need `match` plus a `.filter(Boolean)`, since mongoose yields `null` where the match fails rather than dropping the entry.

The backoffice is deliberately left alone: it is the one place that has to see a banned account. Nothing historical is rewritten either — the ledger, past battles and market sale history are meant to be immutable, and tearing holes in them is not undoable.

Tests: 13 integration, including one that runs the real sweep with a disabled account holding 50 copies of a character and asserts it neither appears on the board nor takes it. Full backend suite green at 777.
