### PR TITLE
fix(avatar): stop the avatar linking to a profile that does not exist

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -125,7 +125,7 @@ const Avatar: React.FC<Avatar> = ({ image, loading, id, size, level, showLevel =
                     highlightColor="#161427"
                     baseColor="#1c1a31"
                 />
-            ) : noLink ? (
+            ) : noLink || !id ? (
                 content
             ) : (
                 <Link to={`/profile/${id}`}>

--- a/src/pages/Battles/BattleRoom/BattleRoom.view.tsx
+++ b/src/pages/Battles/BattleRoom/BattleRoom.view.tsx
@@ -198,7 +198,7 @@ const BattleRoomView: React.FC<BattleRoomViewProps> = ({
                 <div className="flex items-center gap-2 min-w-0">
                   <Avatar
                     image={col.player.profilePicture}
-                    id={col.player.userId || col.player.username}
+                    id={col.player.userId || ""}
                     size="small"
                     level={0}
                   />

--- a/src/pages/Battles/Battles/Battles.view.tsx
+++ b/src/pages/Battles/Battles/Battles.view.tsx
@@ -202,9 +202,10 @@ const BattlesView: React.FC<BattlesViewProps> = ({
                   <Avatar
                     key={p.slot}
                     image={p.profilePicture}
-                    id={p.userId || p.username}
+                    id={p.userId || ""}
                     size="small"
                     level={0}
+                    noLink
                   />
                 ))}
               </div>

--- a/src/pages/Coin/LiveBets.tsx
+++ b/src/pages/Coin/LiveBets.tsx
@@ -71,7 +71,7 @@ const LiveBets: React.FC<GameHistory> = ({ gameState, type }) => {
                                 onMouseEnter={() => handleMouseEnter(playerId)}
                                 onMouseLeave={handleMouseLeave}>
                                 <div className="flex items-center gap-2">
-                                    <Avatar image={player.profilePicture} id={playerId} size="small" level={player.level} />
+                                    <Avatar image={player.profilePicture} id={playerId} size="small" level={player.level} noLink />
                                     <span className="font-bold text-sm">{player.username}</span>
                                 </div>
                             </a>

--- a/src/pages/Crash/LiveBets.tsx
+++ b/src/pages/Crash/LiveBets.tsx
@@ -71,7 +71,7 @@ const LiveBets: React.FC<GameHistory> = ({ gameState }) => {
 
                             <a href={`/profile/${playerId}`} target="_blank" rel="noreferrer" className="text-white transition-all">
                                 <div className="flex items-center gap-2">
-                                    <Avatar image={player.profilePicture} id={playerId} size="small" level={player.level} />
+                                    <Avatar image={player.profilePicture} id={playerId} size="small" level={player.level} noLink />
                                     <span className="font-bold text-sm">{player.username}</span>
                                 </div>
                             </a>

--- a/src/pages/Profile/UserInfo.tsx
+++ b/src/pages/Profile/UserInfo.tsx
@@ -50,7 +50,7 @@ const UserInfo: React.FC<UserProps> = ({
     <div className="flex flex-col lg:flex-row items-center justify-between w-full">
       <div className="flex flex-col lg:flex-row items-center gap-7">
         <div className="relative group">
-          <Avatar image={profilePicture} loading={false} id={id} size={'extra-large'} level={level} showLevel={true} />
+          <Avatar image={profilePicture} loading={false} id={id} size={'extra-large'} level={level} showLevel={true} noLink={true} />
 
           {isSameUser && (
             <button


### PR DESCRIPTION
## Problem

Clicking another player's picture on their profile navigated to `/profile/undefined` and left a blank page. `GET /users/:id` returns the raw document, which has `_id` and no `id`, but the profile header passed `id` to `Avatar`. On your own profile the "change avatar" overlay covers the link, so it only showed up on other people's profiles.

The same broken link existed in four other places:

- Battle list rows are clickable divs that open the battle, and the avatars inside them carried links that stole the click. Bots have a null `userId`, so those fell back to the username and pointed at `/profile/SomeBotName`.
- The battle room used the same username fallback for bots.
- Coin and Crash live bets already wrap the row in an `<a>` to the profile, so the avatar was rendering a nested anchor.

## Change

`Avatar` now skips the link when it has no id, so a missing id can no longer produce a dead route anywhere. The five call sites above pass `noLink` or an empty id fallback as appropriate.

## Tests

`npm run test:unit` (112 pass), `npx tsc --noEmit`, `npm run lint` unchanged from baseline.
