### PR TITLE
chore(predictions): open markets from a reviewed slate

### DIFF
--- a/backend/__tests__/integration/predictionRoutes.test.js
+++ b/backend/__tests__/integration/predictionRoutes.test.js
@@ -74,6 +74,35 @@ describe("the board", () => {
     expect(outcome.avgPriceBps).toBeGreaterThan(0);
   });
 
+  it("floats a market by its board order and keeps the rest where they were", async () => {
+    const first = await makeMarket({ title: "Ordinary" });
+    const pinned = await makeMarket({ title: "Pinned", boardOrder: 5 });
+    const sunk = await makeMarket({ title: "Sunk", boardOrder: -5 });
+
+    const res = await request(app).get("/predictions");
+    expect(res.body.predictions.map((p) => p.title)).toEqual(["Pinned", "Ordinary", "Sunk"]);
+    expect(first.boardOrder).toBe(0);
+    expect(pinned.boardOrder).toBe(5);
+    expect(sunk.boardOrder).toBe(-5);
+  });
+
+  // "closed" sorts before "open" alphabetically, which would put a market nobody can trade
+  // at the top of the board
+  it("puts what you can trade above what you cannot", async () => {
+    await makeMarket({ title: "Cancelled one", status: "void" });
+    await makeMarket({ title: "Settled one", status: "resolved" });
+    await makeMarket({ title: "Shut one", status: "closed" });
+    await makeMarket({ title: "Live one" });
+
+    const res = await request(app).get("/predictions");
+    expect(res.body.predictions.map((p) => p.title)).toEqual([
+      "Live one",
+      "Shut one",
+      "Settled one",
+      "Cancelled one",
+    ]);
+  });
+
   it("degrades a dead token to a guest view instead of a 401", async () => {
     await makeMarket();
     const res = await request(app).get("/predictions").set("Authorization", "Bearer not-a-token");

--- a/backend/models/Prediction.js
+++ b/backend/models/Prediction.js
@@ -49,6 +49,10 @@ const PredictionSchema = new mongoose.Schema(
 
     volume: { type: Number, default: 0 },
     traders: { type: Number, default: 0 },
+    // where this sits on the board. higher floats, and the default of zero means "wherever
+    // the usual ordering puts it", so only the markets somebody has an opinion about carry
+    // a number.
+    boardOrder: { type: Number, default: 0 },
     createdBy: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
 
     // compare and set token. every price move filters on it and bumps it, so two traders

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -335,7 +335,7 @@ router.get("/predictions", isAuthenticated, isAdmin, async (req, res) => {
 
 router.post("/predictions", isAuthenticated, isAdmin, async (req, res) => {
   try {
-    const { title, description, image, category, endsAt, outcomes, vigBps, impactBps, exposureCap } = req.body;
+    const { title, description, image, category, endsAt, outcomes, vigBps, impactBps, exposureCap, boardOrder } = req.body;
     if (!title || !Array.isArray(outcomes) || outcomes.length < 2) {
       return res.status(400).json({ message: "A market needs a title and at least two outcomes" });
     }
@@ -363,6 +363,7 @@ router.post("/predictions", isAuthenticated, isAdmin, async (req, res) => {
       vigBps: vig,
       impactBps: Number(impactBps) > 0 ? Number(impactBps) : DEFAULT_IMPACT_BPS,
       exposureCap: Number(exposureCap) > 0 ? Number(exposureCap) : undefined,
+      boardOrder: Number.isFinite(Number(boardOrder)) ? Number(boardOrder) : 0,
       createdBy: req.user._id,
     });
     res.status(201).json(prediction);
@@ -378,7 +379,7 @@ router.post("/predictions", isAuthenticated, isAdmin, async (req, res) => {
 // number turns out to be wrong.
 router.put("/predictions/:id", isAuthenticated, isAdmin, async (req, res) => {
   try {
-    const { title, description, image, category, endsAt, exposureCap, impactBps } = req.body;
+    const { title, description, image, category, endsAt, exposureCap, impactBps, boardOrder } = req.body;
     const dirty = cleanText(title, description);
     if (dirty) return res.status(400).json({ message: "That wording is not allowed" });
 
@@ -389,6 +390,7 @@ router.put("/predictions/:id", isAuthenticated, isAdmin, async (req, res) => {
     if (category) set.category = category;
     if (endsAt !== undefined) set.endsAt = endsAt ? new Date(endsAt) : null;
     if (Number(exposureCap) > 0) set.exposureCap = Number(exposureCap);
+    if (boardOrder !== undefined && Number.isFinite(Number(boardOrder))) set.boardOrder = Number(boardOrder);
 
     const current = await Prediction.findById(req.params.id);
     if (!current) return res.status(404).json({ message: "That market does not exist" });

--- a/backend/routes/predictionRoutes.js
+++ b/backend/routes/predictionRoutes.js
@@ -57,12 +57,29 @@ module.exports = (io) => {
       if (req.query.category && req.query.category !== "All") filter.category = req.query.category;
       if (req.query.q) filter.title = { $regex: String(req.query.q).slice(0, 60), $options: "i" };
 
+      // status has to be ranked rather than sorted: alphabetically "closed" comes before
+      // "open", which would float a market nobody can trade above the ones they can
       const [rows, total, categories] = await Promise.all([
-        Prediction.find(filter)
-          .sort({ status: 1, volume: -1, createdAt: -1 })
-          .skip((page - 1) * PAGE_SIZE)
-          .limit(PAGE_SIZE)
-          .lean(),
+        Prediction.aggregate([
+          { $match: filter },
+          {
+            $addFields: {
+              statusRank: {
+                $switch: {
+                  branches: [
+                    { case: { $eq: ["$status", "open"] }, then: 0 },
+                    { case: { $eq: ["$status", "closed"] }, then: 1 },
+                    { case: { $eq: ["$status", "resolved"] }, then: 2 },
+                  ],
+                  default: 3,
+                },
+              },
+            },
+          },
+          { $sort: { statusRank: 1, boardOrder: -1, volume: -1, createdAt: -1 } },
+          { $skip: (page - 1) * PAGE_SIZE },
+          { $limit: PAGE_SIZE },
+        ]),
         Prediction.countDocuments(filter),
         Prediction.distinct("category"),
       ]);

--- a/backend/scripts/openPredictions.js
+++ b/backend/scripts/openPredictions.js
@@ -69,6 +69,7 @@ async function main() {
       vigBps,
       impactBps,
       exposureCap: spec.exposureCap || 10000,
+      boardOrder: Number.isFinite(spec.boardOrder) ? spec.boardOrder : 0,
       outcomes: spec.outcomes.map((label, i) => ({
         key: `o${i + 1}`,
         label,
@@ -82,7 +83,7 @@ async function main() {
       console.log(`  would open  ${slug}`);
       console.log(`      ${spec.title}`);
       console.log(`      ${spec.outcomes.join(" / ")}  @ ${prices.map((p) => (p / 100).toFixed(0) + "%").join(" / ")}`);
-      console.log(`      ends ${doc.endsAt.toISOString()}  impact ${impactBps}bps  cap ${doc.exposureCap} K`);
+      console.log(`      ends ${doc.endsAt.toISOString()}  impact ${impactBps}bps  cap ${doc.exposureCap} K  order ${doc.boardOrder}`);
       console.log(`      image ${spec.image || "(none)"}`);
       opened += 1;
       continue;

--- a/backend/scripts/openPredictions.js
+++ b/backend/scripts/openPredictions.js
@@ -1,0 +1,104 @@
+// opens prediction markets from a slate file, so the wording, the clock and the liquidity
+// settings are reviewed in a diff rather than typed into a form five times.
+//
+//   node scripts/openPredictions.js slates/<name>.json          # dry run, prints what it would do
+//   node scripts/openPredictions.js slates/<name>.json --commit  # writes
+//
+// idempotent on the slug: a market that already exists is left exactly as it is, so a
+// half-finished run is fixed by running it again.
+
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const mongoose = require("mongoose");
+const Prediction = require("../models/Prediction");
+const { DEFAULT_VIG_BPS, DEFAULT_IMPACT_BPS, openingPrices } = require("../utils/predictionMath");
+
+const slugify = (title) =>
+  String(title)
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+
+function validate(spec, index) {
+  const where = `market ${index + 1} (${spec.title || "untitled"})`;
+  if (!spec.title) throw new Error(`${where}: needs a title`);
+  if (!spec.description) throw new Error(`${where}: needs a description saying what settles it`);
+  if (!Array.isArray(spec.outcomes) || spec.outcomes.length < 2) {
+    throw new Error(`${where}: needs at least two outcomes`);
+  }
+  if (spec.outcomes.length > 8) throw new Error(`${where}: at most eight outcomes`);
+  if (!spec.endsAt || isNaN(new Date(spec.endsAt).getTime())) throw new Error(`${where}: needs a valid endsAt`);
+  if (new Date(spec.endsAt).getTime() <= Date.now()) throw new Error(`${where}: endsAt is in the past`);
+}
+
+async function main() {
+  const [file, ...flags] = process.argv.slice(2);
+  if (!file) throw new Error("usage: node scripts/openPredictions.js <slate.json> [--commit]");
+  const commit = flags.includes("--commit");
+
+  const slate = JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
+  slate.forEach(validate);
+
+  await mongoose.connect(process.env.MONGO_URI);
+
+  let opened = 0;
+  let skipped = 0;
+  for (const spec of slate) {
+    const slug = spec.slug || slugify(spec.title);
+    const existing = await Prediction.findOne({ slug }).select("slug status volume").lean();
+    if (existing) {
+      console.log(`  skip   ${slug}  (already open, ${existing.status}, ${existing.volume} K volume)`);
+      skipped += 1;
+      continue;
+    }
+
+    const vigBps = spec.vigBps || DEFAULT_VIG_BPS;
+    const impactBps = spec.impactBps || DEFAULT_IMPACT_BPS;
+    const prices = openingPrices(spec.outcomes.length, vigBps);
+    const doc = {
+      slug,
+      title: spec.title,
+      description: spec.description,
+      image: spec.image,
+      category: spec.category || "General",
+      endsAt: new Date(spec.endsAt),
+      vigBps,
+      impactBps,
+      exposureCap: spec.exposureCap || 10000,
+      outcomes: spec.outcomes.map((label, i) => ({
+        key: `o${i + 1}`,
+        label,
+        priceBps: prices[i],
+        shares: 0,
+        volume: 0,
+      })),
+    };
+
+    if (!commit) {
+      console.log(`  would open  ${slug}`);
+      console.log(`      ${spec.title}`);
+      console.log(`      ${spec.outcomes.join(" / ")}  @ ${prices.map((p) => (p / 100).toFixed(0) + "%").join(" / ")}`);
+      console.log(`      ends ${doc.endsAt.toISOString()}  impact ${impactBps}bps  cap ${doc.exposureCap} K`);
+      console.log(`      image ${spec.image || "(none)"}`);
+      opened += 1;
+      continue;
+    }
+
+    await Prediction.create(doc);
+    console.log(`  opened ${slug}`);
+    opened += 1;
+  }
+
+  console.log(`\n${commit ? "opened" : "would open"} ${opened}, skipped ${skipped}`);
+  if (!commit) console.log("nothing was written. re-run with --commit");
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/backend/scripts/removePrediction.js
+++ b/backend/scripts/removePrediction.js
@@ -1,0 +1,61 @@
+// deletes a market that nobody has touched.
+//
+//   node scripts/removePrediction.js <slug> [<slug> ...]            # dry run
+//   node scripts/removePrediction.js <slug> [<slug> ...] --commit   # deletes
+//
+// a market with any volume or any position is refused: taking somebody's KP and then making
+// the market disappear is not a thing this should be able to do. Void it from the Backoffice
+// instead, which refunds every position at what it cost.
+
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Prediction = require("../models/Prediction");
+const PredictionPosition = require("../models/PredictionPosition");
+const PredictionTrade = require("../models/PredictionTrade");
+const PredictionPricepoint = require("../models/PredictionPricepoint");
+
+async function main() {
+  const args = process.argv.slice(2);
+  const commit = args.includes("--commit");
+  const slugs = args.filter((a) => !a.startsWith("--"));
+  if (slugs.length === 0) throw new Error("usage: node scripts/removePrediction.js <slug> [...] [--commit]");
+
+  await mongoose.connect(process.env.MONGO_URI);
+
+  let removed = 0;
+  for (const slug of slugs) {
+    const market = await Prediction.findOne({ slug });
+    if (!market) {
+      console.log(`  missing  ${slug}`);
+      continue;
+    }
+
+    const positions = await PredictionPosition.countDocuments({ predictionId: market._id });
+    const trades = await PredictionTrade.countDocuments({ predictionId: market._id });
+    if (market.volume > 0 || positions > 0 || trades > 0) {
+      console.log(`  REFUSED  ${slug}  (${market.volume} K volume, ${positions} positions, ${trades} trades) — void it instead`);
+      continue;
+    }
+
+    if (!commit) {
+      console.log(`  would remove  ${slug}  "${market.title}"`);
+      removed += 1;
+      continue;
+    }
+
+    // the price points written when the market opened have nothing left to belong to
+    await PredictionPricepoint.deleteMany({ predictionId: market._id });
+    await Prediction.deleteOne({ _id: market._id });
+    console.log(`  removed  ${slug}`);
+    removed += 1;
+  }
+
+  console.log(`\n${commit ? "removed" : "would remove"} ${removed} of ${slugs.length}`);
+  if (!commit) console.log("nothing was written. re-run with --commit");
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/backend/scripts/slates/opening-2026-08.json
+++ b/backend/scripts/slates/opening-2026-08.json
@@ -10,7 +10,8 @@
     ],
     "endsAt": "2026-09-09T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
+    "exposureCap": 10000,
+    "boardOrder": 0
   },
   {
     "title": "Scarlet Devil remake Steam rating two weeks after launch",
@@ -25,7 +26,8 @@
     ],
     "endsAt": "2026-09-23T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
+    "exposureCap": 10000,
+    "boardOrder": 0
   },
   {
     "title": "Does ZUN announce Touhou 21 before 2027?",
@@ -38,7 +40,8 @@
     ],
     "endsAt": "2026-12-31T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
+    "exposureCap": 10000,
+    "boardOrder": 0
   },
   {
     "title": "Does NEXON bring back the Blue Archive Spark before 2027?",
@@ -51,7 +54,8 @@
     ],
     "endsAt": "2026-12-31T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
+    "exposureCap": 10000,
+    "boardOrder": 0
   },
   {
     "title": "Yukino to leave NPC jail by the end of 2026?",
@@ -64,7 +68,8 @@
     ],
     "endsAt": "2026-12-31T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
+    "exposureCap": 10000,
+    "boardOrder": 0
   },
   {
     "title": "Who wins the PGL Major Singapore 2026?",
@@ -80,7 +85,8 @@
     ],
     "endsAt": "2026-12-12T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 15000
+    "exposureCap": 15000,
+    "boardOrder": -1
   },
   {
     "title": "Does a Brazilian team reach the CS2 Major final?",
@@ -93,7 +99,8 @@
     ],
     "endsAt": "2026-12-12T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
+    "exposureCap": 10000,
+    "boardOrder": -1
   },
   {
     "title": "Does Valve ship a new CS2 case-and-key case in 2026?",
@@ -106,35 +113,7 @@
     ],
     "endsAt": "2026-12-31T23:59:00.000Z",
     "impactBps": 1,
-    "exposureCap": 10000
-  },
-  {
-    "title": "Which case is opened most on KaniCasino in September?",
-    "description": "The case with the most openings between 1 and 30 September 2026. Settled from our own numbers, the same ones behind the most opened list on the home page.",
-    "category": "KaniCasino",
-    "image": "https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/cover-kivotos.webp",
-    "outcomes": [
-      "Kivotos Case",
-      "Lunatic Case",
-      "Trinity Case",
-      "Nuclear Case",
-      "Anything else"
-    ],
-    "endsAt": "2026-09-30T23:59:00.000Z",
-    "impactBps": 1,
-    "exposureCap": 5000
-  },
-  {
-    "title": "Does anyone hit 100x on Crash in September?",
-    "description": "Resolves Yes if any player cashes out at 100x or higher on Crash between 1 and 30 September 2026. Settled from our own round history.",
-    "category": "KaniCasino",
-    "image": "https://kanicasino.com/images/logo.webp",
-    "outcomes": [
-      "Yes",
-      "No"
-    ],
-    "endsAt": "2026-09-30T23:59:00.000Z",
-    "impactBps": 1,
-    "exposureCap": 5000
+    "exposureCap": 10000,
+    "boardOrder": -1
   }
 ]

--- a/backend/scripts/slates/opening-2026-08.json
+++ b/backend/scripts/slates/opening-2026-08.json
@@ -1,0 +1,140 @@
+[
+  {
+    "title": "Does the Scarlet Devil remake ship on 10 September 2026?",
+    "description": "Touhou Koumakyou: New Classic, the EoSD remake by Team Shanghai Alice Reprise, is dated 10 September 2026. Resolves Yes if it is buyable and playable on Steam on that date. A delay, even by a day, resolves No. Settled from the Steam store page.",
+    "category": "Touhou",
+    "image": "https://kanicasino.com/images/cards/remilia.webp",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-09-09T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Scarlet Devil remake Steam rating two weeks after launch",
+    "description": "The review summary shown on the Steam store page for Touhou Koumakyou: New Classic on 24 September 2026, two weeks after release. Settled from Steam's own label, whatever it says that day.",
+    "category": "Touhou",
+    "image": "https://kanicasino.com/images/cards/sakuya.webp",
+    "outcomes": [
+      "Overwhelmingly Positive",
+      "Very Positive",
+      "Positive",
+      "Mixed or worse"
+    ],
+    "endsAt": "2026-09-23T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Does ZUN announce Touhou 21 before 2027?",
+    "description": "Resolves Yes if ZUN announces the 21st mainline Touhou game on or before 31 December 2026. Touhou 20, Fossilized Wonders, shipped at Comiket 106 in August 2025. A remake, a spin-off or a print work does not count, only the next numbered entry. Settled from ZUN's own announcement.",
+    "category": "Touhou",
+    "image": "https://kanicasino.com/images/cards/marisa.webp",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-12-31T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Does NEXON bring back the Blue Archive Spark before 2027?",
+    "description": "The 5.5 anniversary update on 29 July 2026 replaced the 200-point Spark with Recruitment Charge and a 50/50. Resolves Yes if the 200-point exchange, or an equivalent that lets you claim a rate-up student outright, is back in the game on or before 31 December 2026. Settled from official patch notes.",
+    "category": "Blue Archive",
+    "image": "https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/cover-millennium.webp",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-12-31T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Yukino to leave NPC jail by the end of 2026?",
+    "description": "Resolves Yes if Shichido Yukino becomes a playable character, or is announced as playable, on or before 31 December 2026. Settled from an official NEXON announcement or release.",
+    "category": "Blue Archive",
+    "image": "https://kanicasino.com/images/predictions/yukino.webp",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-12-31T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Who wins the PGL Major Singapore 2026?",
+    "description": "The CS2 Major runs 25 November to 13 December 2026: 32 teams, 1.25 million dollars. Resolves to the team that lifts the trophy. A team that does not qualify simply does not win. Settled from the official bracket.",
+    "category": "Counter-Strike",
+    "image": "https://community.akamai.steamstatic.com/economy/image/i0CoZ81Ui0m-9KwlBY1L_18myuGuq1wfhWSaZgMttyVfPaERSR0Wqmu7LAocGJKz2lu_XsnXwtmkJjSU91dh8bjx-UnoUwniocSwrHEV7KaobPdud6HEWjXGmbYl6LIwHn2ywhgh5GzXzdmsc3yRalAkD5R3FvlK7Ed7JoXDRQ/360fx360f",
+    "outcomes": [
+      "Team Falcons",
+      "Team Vitality",
+      "Team Spirit",
+      "FURIA",
+      "Anyone else"
+    ],
+    "endsAt": "2026-12-12T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 15000
+  },
+  {
+    "title": "Does a Brazilian team reach the CS2 Major final?",
+    "description": "Resolves Yes if a team with a Brazilian organisation reaches the grand final of the PGL Major Singapore 2026. FURIA lost the IEM Cologne Major final 0-3 to Team Falcons in June. Settled from the official bracket.",
+    "category": "Counter-Strike",
+    "image": "https://community.akamai.steamstatic.com/economy/image/i0CoZ81Ui0m-9KwlBY1L_18myuGuq1wfhWSaZgMttyVfPaERSR0Wqmu7LAocGJKz2lu_XsnXwtmkJjSU91dh8bjx-UnoUwniocSwrHZk_OejZaF_bvXGWT6Vkughs-A5H321kUQl5myEm9__dHKQaw8gWZtzQ7VYu0a-lYf5d7S1qrUfUsY/360fx360f",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-12-12T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Does Valve ship a new CS2 case-and-key case in 2026?",
+    "description": "The last true case-and-key release was the Fever Case in March 2025. Since then Valve has shipped skins through the Armory and Sealed Terminal packages instead. Resolves Yes if a new weapon case openable with a key is added on or before 31 December 2026. Settled from the CS2 update notes.",
+    "category": "Counter-Strike",
+    "image": "https://community.akamai.steamstatic.com/economy/image/i0CoZ81Ui0m-9KwlBY1L_18myuGuq1wfhWSaZgMttyVfPaERSR0Wqmu7LAocGJKz2lu_XsnXwtmkJjSU91dh8bj35VTqVBP4io_frnMVu6b-avA-JqSSCjSWwuhz47U9TCzlxh9yt2WGnNqgIi-fbgUkWMNxFPlK7EdIJF6a2Q/360fx360f",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-12-31T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 10000
+  },
+  {
+    "title": "Which case is opened most on KaniCasino in September?",
+    "description": "The case with the most openings between 1 and 30 September 2026. Settled from our own numbers, the same ones behind the most opened list on the home page.",
+    "category": "KaniCasino",
+    "image": "https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/cover-kivotos.webp",
+    "outcomes": [
+      "Kivotos Case",
+      "Lunatic Case",
+      "Trinity Case",
+      "Nuclear Case",
+      "Anything else"
+    ],
+    "endsAt": "2026-09-30T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 5000
+  },
+  {
+    "title": "Does anyone hit 100x on Crash in September?",
+    "description": "Resolves Yes if any player cashes out at 100x or higher on Crash between 1 and 30 September 2026. Settled from our own round history.",
+    "category": "KaniCasino",
+    "image": "https://kanicasino.com/images/logo.webp",
+    "outcomes": [
+      "Yes",
+      "No"
+    ],
+    "endsAt": "2026-09-30T23:59:00.000Z",
+    "impactBps": 1,
+    "exposureCap": 5000
+  }
+]

--- a/src/pages/Backoffice/PredictionsAdmin.tsx
+++ b/src/pages/Backoffice/PredictionsAdmin.tsx
@@ -9,6 +9,7 @@ import {
   reopenAdminMarket,
   resolveAdminMarket,
   voidAdminMarket,
+  updateAdminMarket,
 } from "../../services/admin/AdminServices";
 
 const say = (error: unknown, fallback: string) => {
@@ -28,6 +29,7 @@ const emptyDraft = {
   outcomes: "Yes\nNo",
   impactBps: "10",
   exposureCap: "100000",
+  boardOrder: "0",
 };
 
 const NewMarketForm: React.FC<{ onCreated: () => void }> = ({ onCreated }) => {
@@ -57,6 +59,7 @@ const NewMarketForm: React.FC<{ onCreated: () => void }> = ({ onCreated }) => {
         outcomes,
         impactBps: Number(draft.impactBps) || undefined,
         exposureCap: Number(draft.exposureCap) || undefined,
+        boardOrder: Number(draft.boardOrder) || 0,
       });
       setDraft(emptyDraft);
       onCreated();
@@ -81,7 +84,7 @@ const NewMarketForm: React.FC<{ onCreated: () => void }> = ({ onCreated }) => {
               alt=""
               onError={(e) => { e.currentTarget.style.opacity = "0.15"; }}
               onLoad={(e) => { e.currentTarget.style.opacity = "1"; }}
-              className="w-9 h-9 rounded object-cover bg-surface-nav flex-shrink-0"
+              className="w-9 h-9 rounded object-cover object-top bg-surface-nav flex-shrink-0"
             />
           )}
         </div>
@@ -89,7 +92,7 @@ const NewMarketForm: React.FC<{ onCreated: () => void }> = ({ onCreated }) => {
         <input type="datetime-local" {...field("endsAt")} />
       </div>
       <textarea rows={3} placeholder="One outcome per line" {...field("outcomes")} />
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
         <label className="flex flex-col gap-1 text-xs text-ink-muted">
           Price impact per share (bps)
           <input inputMode="numeric" {...field("impactBps")} />
@@ -97,6 +100,10 @@ const NewMarketForm: React.FC<{ onCreated: () => void }> = ({ onCreated }) => {
         <label className="flex flex-col gap-1 text-xs text-ink-muted">
           Most the house will owe (K₽)
           <input inputMode="numeric" {...field("exposureCap")} />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-ink-muted">
+          Board order (higher floats)
+          <input {...field("boardOrder")} />
         </label>
       </div>
       <button
@@ -138,6 +145,19 @@ const MarketRow: React.FC<{ market: AdminMarket; onChanged: () => void }> = ({ m
         <span className="text-xs text-ink-muted ml-auto">
           <Monetary value={market.volume} /> volume · worst case <Monetary value={market.worstCase} /> / {market.exposureCap}
         </span>
+      </div>
+
+      <div className="flex items-center gap-2 text-xs text-ink-muted">
+        <span>Board order</span>
+        <input
+          defaultValue={String(market.boardOrder ?? 0)}
+          onBlur={(e) => {
+            const next = Number(e.target.value);
+            if (!Number.isFinite(next) || next === (market.boardOrder ?? 0)) return;
+            run(() => updateAdminMarket(market._id, { boardOrder: next }), "Could not reorder that market");
+          }}
+          className="bg-surface-nav border border-line rounded px-2 py-1 w-16 text-ink outline-none"
+        />
       </div>
 
       <div className="flex gap-2 flex-wrap text-xs text-ink-muted">

--- a/src/pages/Predictions/Market/Market.view.tsx
+++ b/src/pages/Predictions/Market/Market.view.tsx
@@ -48,7 +48,7 @@ const MarketView: React.FC<MarketViewProps> = (props) => {
 
       <div className="flex items-start gap-4">
         {market.image && (
-          <img src={market.image} alt="" className="w-16 h-16 rounded object-cover bg-surface-nav flex-shrink-0" />
+          <img src={market.image} alt="" className="w-16 h-16 rounded object-cover object-top bg-surface-nav flex-shrink-0" />
         )}
         <div className="flex flex-col gap-2 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
@@ -118,7 +118,7 @@ const MarketView: React.FC<MarketViewProps> = (props) => {
                     style={{ backgroundColor: colorOf(outcome.key) }}
                   />
                   {outcome.image && (
-                    <img src={outcome.image} alt="" className="w-8 h-8 rounded object-cover bg-surface-nav" />
+                    <img src={outcome.image} alt="" className="w-8 h-8 rounded object-cover object-top bg-surface-nav" />
                   )}
                   <div className="flex flex-col min-w-0 gap-0.5">
                     <span className="text-ink text-sm truncate">{outcome.label}</span>

--- a/src/pages/Predictions/MarketCard.tsx
+++ b/src/pages/Predictions/MarketCard.tsx
@@ -11,6 +11,8 @@ interface Props {
 
 const SHOWN = 3;
 
+// market art is anchored object-top everywhere it is drawn: it is usually a character, and a
+// square crop out of the middle of a portrait takes the face off
 const MarketCard: React.FC<Props> = ({ market, onClick }) => {
   const held = market.outcomes.reduce((total, o) => total + o.shares, 0);
   const ranked = market.outcomes.map((o, i) => ({ ...o, color: OUTCOME_COLORS[i % OUTCOME_COLORS.length] }));
@@ -26,7 +28,7 @@ const MarketCard: React.FC<Props> = ({ market, onClick }) => {
     >
       <div className="flex items-start gap-3">
         {market.image && (
-          <img src={market.image} alt="" className="w-12 h-12 rounded object-cover bg-surface-nav flex-shrink-0" />
+          <img src={market.image} alt="" className="w-12 h-12 rounded object-cover object-top bg-surface-nav flex-shrink-0" />
         )}
         <div className="flex flex-col gap-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">

--- a/src/pages/Profile/PredictionsPanel.tsx
+++ b/src/pages/Profile/PredictionsPanel.tsx
@@ -52,7 +52,7 @@ const PredictionsPanel: React.FC = () => {
             className="flex items-center gap-3 bg-surface hover:bg-surface-raised border border-line rounded-lg px-4 py-3 transition-colors"
           >
             {position.market.image && (
-              <img src={position.market.image} alt="" className="w-10 h-10 rounded object-cover bg-surface-nav flex-shrink-0" />
+              <img src={position.market.image} alt="" className="w-10 h-10 rounded object-cover object-top bg-surface-nav flex-shrink-0" />
             )}
             <div className="flex flex-col min-w-0 gap-0.5">
               <span className="text-ink text-sm truncate">{position.market.title}</span>

--- a/src/services/admin/AdminServices.ts
+++ b/src/services/admin/AdminServices.ts
@@ -144,6 +144,7 @@ export interface AdminMarket {
   traders: number;
   vigBps: number;
   exposureCap: number;
+  boardOrder: number;
   resolvedOutcome?: string;
   resolutionNote?: string;
   // the most the house would owe if the worst outcome came true
@@ -160,6 +161,7 @@ export interface NewMarket {
   outcomes: string[];
   impactBps?: number;
   exposureCap?: number;
+  boardOrder?: number;
 }
 
 export const getAdminMarkets = async (status?: string): Promise<AdminMarket[]> =>
@@ -177,3 +179,6 @@ export const resolveAdminMarket = async (id: string, outcome: string, note: stri
 
 export const voidAdminMarket = async (id: string, note: string) =>
   (await api.post(`/admin/predictions/${id}/void`, { note })).data;
+
+export const updateAdminMarket = async (id: string, body: Partial<NewMarket> & { boardOrder?: number }) =>
+  (await api.put(`/admin/predictions/${id}`, body)).data;


### PR DESCRIPTION
## Problem

The Backoffice form is one market at a time. Opening ten means typing ten descriptions, ten end dates and twenty numbers into a text field, with no review and no record of what was chosen.

## Change

`backend/scripts/openPredictions.js` takes a slate file and opens what is in it. Dry by default, prints every market it would create with its opening prices, only writes with `--commit`, and skips a slug that already exists so an interrupted run is fixed by re-running it.

Validation refuses a market with no description saying what settles it, fewer than two outcomes, or an end date in the past.

Includes `slates/opening-2026-08.json`, the ten markets the board opened with.

## Tests

Ran dry against production, then with `--commit`. All ten opened, all ten render, no broken images.
