### PR TITLE
fix(fandom): count a copy by the catalog, and recount the board on write

### DIFF
--- a/backend/__tests__/integration/adRewards.test.js
+++ b/backend/__tests__/integration/adRewards.test.js
@@ -82,11 +82,18 @@ describe("rewarded ads", () => {
   });
 
   test("claiming faster than a video could play is refused", async () => {
-    const u = await makeUser();
-    const s = await start(u);
-    const res = await claim(u, s.body.token); // immediate
-    expect(res.status).toBe(400);
-    expect((await User.findById(u._id)).walletBalance).toBe(0);
+    // the gap between start and claim is real wall clock, so a 50ms window is one a
+    // loaded runner can wait out by accident. widen it for this case only.
+    process.env.AD_REWARD_MIN_WATCH_MS = "60000";
+    try {
+      const u = await makeUser();
+      const s = await start(u);
+      const res = await claim(u, s.body.token); // immediate
+      expect(res.status).toBe(400);
+      expect((await User.findById(u._id)).walletBalance).toBe(0);
+    } finally {
+      process.env.AD_REWARD_MIN_WATCH_MS = "50";
+    }
   });
 
   test("a token pays exactly once and only for its owner", async () => {

--- a/backend/__tests__/integration/fandom.test.js
+++ b/backend/__tests__/integration/fandom.test.js
@@ -9,6 +9,8 @@ const Item = require("../../models/Item");
 const FanBoard = require("../../models/FanBoard");
 const CollectorBoard = require("../../models/CollectorBoard");
 const fandom = require("../../utils/fandom");
+const Case = require("../../models/Case");
+const { recomputeCaseValues } = require("../../utils/itemValue");
 
 let app;
 
@@ -23,7 +25,14 @@ async function makeItem(name, rarity = "3") {
   return Item.create({ name, image: `${name}.png`, rarity, baseValue: 100 });
 }
 
+// what a copy actually looks like on the user document: name, image and case live on the
+// catalog and are joined on read, so the entry only identifies the copy
 function copies(item, count) {
+  return Array.from({ length: count }, () => ({ _id: item._id, rarity: item.rarity }));
+}
+
+// rows written before that change still carry their own name, and must still count
+function legacyCopies(item, count) {
   return Array.from({ length: count }, () => ({
     _id: item._id,
     name: item.name,
@@ -32,13 +41,13 @@ function copies(item, count) {
   }));
 }
 
-async function makeUser({ pinned, inventory = [], fixedAt } = {}) {
+async function makeUser({ pinned, inventory = [], fixedAt, walletBalance = 0 } = {}) {
   const s = uniqueSuffix();
   return User.create({
     username: `user-${s}`,
     email: `user-${s}@example.com`,
     password: "x",
-    walletBalance: 0,
+    walletBalance,
     inventory,
     fixedAt,
     fixedItem: pinned
@@ -157,6 +166,22 @@ describe("fan boards", () => {
     expect((await FanBoard.findOne({ name: "Yuuma" }).lean()).fanCount).toBe(0);
   });
 
+  it("counts a copy whether or not it carries its own name", async () => {
+    const yuuma = await makeItem("Yuuma");
+    const momiji = await makeItem("Momiji");
+    const me = await makeUser({
+      pinned: yuuma,
+      inventory: [...copies(yuuma, 4), ...legacyCopies(yuuma, 2), ...legacyCopies(momiji, 1)],
+    });
+
+    await fandom.rebuild();
+
+    expect((await FanBoard.findOne({ name: "Yuuma" }).lean()).topCount).toBe(6);
+    const mine = await User.findById(me._id).lean();
+    expect(mine.fanRank.count).toBe(6);
+    expect(mine.collectionRank).toMatchObject({ distinct: 2, total: 7 });
+  });
+
   it("ranks the collection board by distinct characters", async () => {
     const a = await makeItem("Yuuma");
     const b = await makeItem("Momiji");
@@ -261,5 +286,25 @@ describe("fandom routes", () => {
     const board = await FanBoard.findOne({ name: "Momiji" }).lean();
     expect(board.topCount).toBe(6);
     expect((await User.findById(me._id).lean()).fanRank.name).toBe("Momiji");
+  });
+});
+
+describe("a drop of the pinned character", () => {
+  it("recounts the board before the next sweep", async () => {
+    const yuuma = await makeItem("Yuuma", "1");
+    const box = await Case.create({ title: `c-${uniqueSuffix()}`, image: "x", price: 10, items: [yuuma._id] });
+    await recomputeCaseValues(box._id);
+    const me = await makeUser({ pinned: yuuma, walletBalance: 1000 });
+    await fandom.rebuild();
+    expect((await User.findById(me._id).lean()).fanRank.count).toBe(0);
+
+    const res = await request(app)
+      .post(`/games/openCase/${box._id}`)
+      .set("Authorization", `Bearer ${tokenFor(me)}`)
+      .send({ quantity: 5 });
+    expect(res.status).toBe(200);
+
+    expect((await User.findById(me._id).lean()).fanRank.count).toBe(5);
+    expect((await FanBoard.findOne({ name: "Yuuma" }).lean()).topCount).toBe(5);
   });
 });

--- a/backend/games/battleEngine.js
+++ b/backend/games/battleEngine.js
@@ -5,6 +5,7 @@ const Transaction = require("../models/Transaction");
 const { addUniqueInfoToItem } = require("../utils/caseOpening");
 const { chargeUser, creditUser, awardXp, TX } = require("../utils/economy");
 const { modeConfig, evaluateWinner, splitItemsEvenly } = require("../utils/battle");
+const fandom = require("../utils/fandom");
 const {
   generateServerSeed,
   hashServerSeed,
@@ -234,6 +235,7 @@ async function finishBattle(battle, io = noopIo) {
     }));
     if (invItems.length) {
       await User.updateOne({ _id: w.userId }, { $push: { inventory: { $each: invItems } } });
+      await fandom.touch(w.userId, invItems.map((it) => it._id));
     }
   }
 

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -83,9 +83,10 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
           return reply({ error: "You already have a bet this round" });
         }
 
-        // atomically take the stake from the real balance (crash grants no xp).
-        // roundId on the ledger row is what lets a restart work out who to give back.
-        const roundId = String(round._id);
+        // atomically take the stake (crash grants no xp). the round is captured before the
+        // await so the ledger row a restart reads names the same round the bet is on.
+        const activeRound = round;
+        const roundId = String(activeRound._id);
         pendingBets.add(userId);
         let updatedUser;
         try {
@@ -101,10 +102,27 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
           return reply({ error: "Insufficient funds" });
         }
 
+        // a whole round turned over while the charge was in flight: the stake belongs to
+        // a round that is gone, so give it back rather than seat it in the live one free
+        if (round !== activeRound) {
+          const refunded = await creditUser(userId, amount, 0, {
+            type: TX.CRASH_REFUND,
+            meta: { bet: amount, roundId, reason: "round closed mid-bet" },
+          });
+          if (refunded) {
+            io.to(userId.toString()).emit("userDataUpdated", {
+              walletBalance: refunded.walletBalance,
+              xp: refunded.xp,
+              level: refunded.level,
+            });
+          }
+          return reply({ error: "Betting is closed for this round" });
+        }
+
         // the round may have started while the charge was in flight; the stake is
         // already gone, so record it and let the reveal or the boot sweep settle it
         await Round.updateOne(
-          { _id: round._id },
+          { _id: activeRound._id },
           {
             $push: {
               bets: { userId, username: updatedUser.username, amount, payout: 0 },

--- a/backend/games/upgrade.js
+++ b/backend/games/upgrade.js
@@ -2,6 +2,7 @@ const User = require("../models/User");
 const Item = require("../models/Item");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
+const fandom = require("../utils/fandom");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
 
 const UPGRADE_ALGO_VERSION = 3; // bump if calculateSuccessRate ever changes
@@ -138,6 +139,10 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
         }
       );
     }
+
+    // both ends of an upgrade can be a pinned character: the copies it ate and the
+    // one it produced
+    await fandom.touch(userId, [...selectedItems.map((invItem) => invItem._id), targetItem._id]);
 
     const rec = await rolls.recordRoll({
       game: "upgrade",

--- a/backend/routes/fandomRoutes.js
+++ b/backend/routes/fandomRoutes.js
@@ -5,6 +5,7 @@ const { isAuthenticated } = require("../middleware/authMiddleware");
 const User = require("../models/User");
 const FanBoard = require("../models/FanBoard");
 const CollectorBoard = require("../models/CollectorBoard");
+const fandom = require("../utils/fandom");
 
 const PAGE_SIZE = 24;
 const REACH_KEPT = 12;
@@ -96,10 +97,13 @@ router.get("/reach", isAuthenticated, async (req, res) => {
     const user = await User.findById(req.user._id).select("inventory fixedItem").lean();
     if (!user) return res.status(404).json({ message: "User not found" });
 
+    const nameById = await fandom.namesByItemId();
     const held = new Map();
     for (const entry of user.inventory || []) {
-      if (!entry || !entry.name) continue;
-      held.set(entry.name, (held.get(entry.name) || 0) + 1);
+      if (!entry) continue;
+      const name = nameById.get(String(entry._id)) || entry.name;
+      if (!name) continue;
+      held.set(name, (held.get(name) || 0) + 1);
     }
     if (!held.size) return res.json({ reach: [] });
 
@@ -145,10 +149,11 @@ router.get("/:name/me", isAuthenticated, async (req, res) => {
     const user = await User.findById(req.user._id).select("inventory fixedItem").lean();
     if (!user) return res.status(404).json({ message: "User not found" });
 
+    const character = (await fandom.charactersByName([name])).get(name);
     let mine = 0;
     let itemId = null;
     for (const entry of user.inventory || []) {
-      if (!entry || entry.name !== name) continue;
+      if (!fandom.isCopyOf(entry, character)) continue;
       mine += 1;
       if (!itemId) itemId = entry._id;
     }

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -16,6 +16,7 @@ const MinesGameController = require("../games/mines");
 const HiloGameController = require("../games/hilo");
 const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const referrals = require("../utils/referrals");
+const fandom = require("../utils/fandom");
 const { addUniqueInfoToItem, toInventoryEntry } = require("../utils/caseOpening");
 const { buildRangeTable } = require("../utils/caseRanges");
 const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
@@ -192,6 +193,10 @@ module.exports = (io) => {
         user: winnerUser,
         caseImage: caseData.image,
       });
+
+      // the fan boards are a ten-minute snapshot, so a player who just pulled the
+      // character they pinned would read the old count next to their new inventory
+      await fandom.touch(user._id, winningItems.map((item) => item._id));
 
       res.json({
         items: winningItems.map((i, idx) => ({

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -12,6 +12,7 @@ const BuyOrder = require("../models/BuyOrder");
 const { chargeUser, creditUser, TX } = require("../utils/economy");
 const { sellValue, marketFee, sellerNet, MARKET_FEE_RATE } = require("../utils/itemValue");
 const market = require("../utils/market");
+const fandom = require("../utils/fandom");
 const { isRealMoneyMode } = require("../utils/mode");
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -205,6 +206,9 @@ module.exports = (io) => {
       if (!results.length) {
         return res.status(404).json({ message: "Item not found in inventory" });
       }
+
+      // a copy on the market has left the inventory, so it stops counting on the board
+      await fandom.touch(user._id, itemDocument._id);
 
       // one copy keeps the original response shape, so existing callers are untouched
       const soldNow = results.filter((r) => r.sold);
@@ -599,6 +603,7 @@ module.exports = (io) => {
         { _id: req.user._id },
         { $push: { inventory: market.inventoryEntryFrom(item) } }
       );
+      await fandom.touch(req.user._id, item.item);
 
       res.json({ message: "Item removed" });
     } catch (err) {

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -14,8 +14,9 @@ const COLLECTORS_KEPT = 100;
 
 // the same character can appear in more than one case, as separate item rows sharing a
 // name. the name is the character, so every id behind it counts toward the same board.
-async function charactersByName() {
-  const items = await Item.find({}).select("name image rarity case").lean();
+async function charactersByName(names) {
+  const filter = names && names.length ? { name: { $in: names } } : {};
+  const items = await Item.find(filter).select("name image rarity case").lean();
   const byName = new Map();
   for (const item of items) {
     let entry = byName.get(item.name);
@@ -32,6 +33,29 @@ async function charactersByName() {
   return byName;
 }
 
+// an inventory entry identifies its copy by catalog id; only rows written before name,
+// image and case moved to the catalog still carry a name of their own, so both count.
+const isCopyOf = (entry, character) =>
+  !!entry &&
+  !!character &&
+  (entry.name === character.name || (!!entry._id && character.ids.has(String(entry._id))));
+
+// every catalog id mapped to the character behind it, for the passes that have nothing
+// but an inventory entry to go on
+function namesById(byName) {
+  const map = new Map();
+  for (const character of byName.values()) {
+    for (const id of character.ids) map.set(id, character.name);
+  }
+  return map;
+}
+
+// the whole catalog keyed by item id, for a caller holding a raw inventory and nothing else
+async function namesByItemId() {
+  const items = await Item.find({}).select("name").lean();
+  return new Map(items.map((item) => [String(item._id), item.name]));
+}
+
 // a player's standing is counted only for the character they pinned. holding thousands of
 // everything else is worth nothing here, which is what keeps one rich account from owning
 // every board. items listed on the market are pulled out of the inventory, so they stop
@@ -40,8 +64,7 @@ function countPinned(user, character) {
   if (!character) return 0;
   let held = 0;
   for (const entry of user.inventory || []) {
-    if (!entry) continue;
-    if (entry.name === character.name || (entry._id && character.ids.has(String(entry._id)))) held += 1;
+    if (isCopyOf(entry, character)) held += 1;
   }
   return held;
 }
@@ -74,6 +97,7 @@ function byCollection(a, b) {
 async function sweep() {
   const byName = await charactersByName();
   const known = new Set(byName.keys());
+  const nameById = namesById(byName);
   const pinned = new Map();
   const collectors = [];
 
@@ -86,8 +110,10 @@ async function sweep() {
     const seen = new Set();
     let total = 0;
     for (const entry of user.inventory || []) {
-      if (!entry || !entry.name || !known.has(entry.name)) continue;
-      seen.add(entry.name);
+      if (!entry) continue;
+      const name = nameById.get(String(entry._id)) || (known.has(entry.name) ? entry.name : null);
+      if (!name) continue;
+      seen.add(name);
       total += 1;
     }
     if (seen.size) {
@@ -232,32 +258,59 @@ async function rebuild() {
   return { boards: boards.length, players: standings.size, collectors: collectors.length };
 }
 
+// one board's rows, counted inside mongo. a fan's inventory runs to thousands of entries
+// and this reruns on every drop of a pinned character, so only the total comes back.
+async function countRows(character) {
+  const ids = [...character.ids].map((id) => new mongoose.Types.ObjectId(id));
+  const docs = await User.aggregate([
+    { $match: visible({ "fixedItem.name": character.name }) },
+    {
+      $project: {
+        username: 1,
+        profilePicture: 1,
+        level: 1,
+        fixedAt: 1,
+        count: {
+          $size: {
+            $filter: {
+              input: { $ifNull: ["$inventory", []] },
+              as: "entry",
+              cond: {
+                $or: [
+                  { $eq: ["$$entry.name", character.name] },
+                  { $in: [{ $ifNull: ["$$entry._id", null] }, ids] },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  ]);
+  return docs.map((doc) => ({
+    userId: doc._id,
+    username: doc.username,
+    profilePicture: doc.profilePicture,
+    level: doc.level,
+    count: doc.count,
+    since: doc.fixedAt || doc._id.getTimestamp(),
+  }));
+}
+
 // pinning is the moment a player cares most about where they stand, so the boards they
 // just joined or left are redone straight away instead of waiting for the next sweep.
 async function refreshCharacters(names) {
   const wanted = [...new Set((names || []).filter(Boolean))];
   if (!wanted.length) return { boards: 0 };
 
-  const byName = await charactersByName();
+  const byName = await charactersByName(wanted);
   const at = new Date();
   const boards = [];
 
   for (const name of wanted) {
     const character = byName.get(name);
     if (!character) continue;
-    const users = await User.find(visible({ "fixedItem.name": name }))
-      .select("username profilePicture level fixedAt inventory")
-      .lean();
-    const rows = users
-      .map((user) => ({
-        userId: user._id,
-        username: user.username,
-        profilePicture: user.profilePicture,
-        level: user.level,
-        count: countPinned(user, character),
-        since: user.fixedAt || user._id.getTimestamp(),
-      }))
-      .sort(byStanding);
+    const rows = (await countRows(character)).sort(byStanding);
     boards.push({
       name,
       image: character.image,
@@ -312,12 +365,40 @@ async function refreshCharacters(names) {
   return { boards: boards.length };
 }
 
+// an inventory change only moves a board when the item was that player's own pinned
+// character. most players pin nothing, so that is the cheap half and it goes first.
+async function touchInventory(userIds, itemIds) {
+  const ids = [...new Set((Array.isArray(userIds) ? userIds : [userIds]).filter(Boolean).map(String))];
+  const items = [...new Set((Array.isArray(itemIds) ? itemIds : [itemIds]).filter(Boolean).map(String))];
+  if (!ids.length || !items.length) return { boards: 0 };
+
+  const users = await User.find({ _id: { $in: ids.map((id) => new mongoose.Types.ObjectId(id)) } })
+    .select("fixedItem.name")
+    .lean();
+  const pinned = new Set(users.map((user) => user.fixedItem && user.fixedItem.name).filter(Boolean));
+  if (!pinned.size) return { boards: 0 };
+
+  const rows = await Item.find({ _id: { $in: items.map((id) => new mongoose.Types.ObjectId(id)) } })
+    .select("name")
+    .lean();
+  return refreshCharacters([...new Set(rows.map((row) => row.name).filter((name) => pinned.has(name)))]);
+}
+
+// a board recount must never be what fails the sale, upgrade or opening that moved
+// the item: the next sweep would put it right anyway
+const touch = (userIds, itemIds) =>
+  touchInventory(userIds, itemIds).catch((err) => console.error("fandom touch:", err.message));
+
 module.exports = {
   rebuild,
   refreshCharacters,
+  touchInventory,
+  touch,
   sweep,
   standingsFrom,
   charactersByName,
+  namesByItemId,
+  isCopyOf,
   countPinned,
   byStanding,
   byCollection,

--- a/backend/utils/inventorySell.js
+++ b/backend/utils/inventorySell.js
@@ -1,6 +1,7 @@
 const User = require("../models/User");
 const Item = require("../models/Item");
 const { creditUser, TX } = require("./economy");
+const fandom = require("./fandom");
 const { sellValue } = require("./itemValue");
 
 // shared, race-safe core behind both the inventory-sell endpoint and the
@@ -53,6 +54,9 @@ async function sellUniqueIds(userId, ids, extraMeta = {}) {
     console.error("sellUniqueIds: credit skipped, user vanished mid-sell", String(userId));
   }
   const walletBalance = updated ? updated.walletBalance : before.walletBalance;
+
+  // selling down a pinned character loses the board too, and the profile shows both
+  await fandom.touch(userId, itemIds);
 
   return { sold: removed.length, value, walletBalance, removed };
 }

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -6,6 +6,7 @@ const Notification = require("../models/Notification");
 const { creditUser, recordTransaction, runAtomic, TX } = require("./economy");
 const { marketFee, sellerNet } = require("./itemValue");
 const { HOUSE, ESCROW } = require("./accounts");
+const fandom = require("./fandom");
 
 // the house cut on a settled trade, booked to HOUSE so the three trade legs (buyer,
 // seller, house) sum to zero. best-effort, like the rest of the ledger for now.
@@ -185,8 +186,10 @@ async function purchaseListing({ listingId, buyerId, io }) {
         level: reversed.level,
       });
     }
+    await fandom.touch(buyerId, claimed.item);
     return { ok: false, code: 410, message: "Seller no longer available; purchase reversed" };
   }
+  await fandom.touch(buyerId, claimed.item);
 
   await recordMarketFee({
     price: claimed.price,
@@ -246,6 +249,7 @@ async function fillOrderWithItem({ pending, order, io }) {
     await BuyOrder.updateOne({ _id: order._id }, { $inc: { filled: -1, escrow: price } });
     return { ok: false, reason: "buyer gone" };
   }
+  await fandom.touch(claimedOrder.userId, pending.item);
 
   const net = sellerNet(price);
   const seller = await creditUser(pending.sellerId, net, 0, {
@@ -281,6 +285,7 @@ async function fillOrderWithItem({ pending, order, io }) {
         session
       );
     });
+    await fandom.touch(claimedOrder.userId, pending.item);
     return { ok: false, reason: "seller gone" };
   }
 


### PR DESCRIPTION
**Problem**

A player reported his Top Fan count reading 47 while the same profile showed 52 copies of the character. Three things behind it:

- An inventory entry stores only the catalog id; name, image and case are joined on read. Every pass that filtered on `entry.name` counted upgrade output and pre-migration rows and read zero for everything else. That emptied the collection board, `GET /fandom/reach` and `GET /fandom/:name/me`. On the live collectors board every row has `total` equal to `distinct`, which is the symptom.
- The board count was only rebuilt by the ten-minute sweep, so a drop of a pinned character left a stale number next to a live inventory count on the same screen.
- CI on `main` is red on `roundRecords.test.js`. Crash captured its round before the charge for the ledger row but re-read the live one after it, so a charge straddling a turnover wrote the stake and the bet on two different rounds, and seated the player in a round they had not paid for.

**Change**

- One shared `isCopyOf` resolves an entry through the catalog; the sweep, `/reach` and `/:name/me` all use it.
- Every path that moves an item calls `fandom.touch`, which recounts the affected board from scratch instead of nudging a counter: case open, inventory sell and quicksell, upgrade, list, delist, market buy, order fill, battle payout. It returns without reading the catalog when nobody involved has pinned anything.
- `refreshCharacters` counts inside mongo rather than pulling every fan's whole inventory back, so it is cheap enough to run per drop, and scopes its catalog query to the names asked for.
- Crash uses one captured round for both the ledger row and the bet, and refunds a bet whose round is gone rather than playing it.
- The ad reward test measured a real round trip against a 50ms window; that case now uses a window a loaded runner cannot wait out.

**Tests**

Full backend suite green, run three times end to end. The fandom test helper now writes the real nameless entry shape, which is what surfaced the `/reach` and `/:name/me` bugs; a `legacyCopies` helper keeps the older named shape covered. New cases: a copy counts with or without its own name on both boards, and a 5x open of a pinned character moves the board before any sweep runs.

No backfill needed. The collection board and everyone's `collectionRank` are rebuilt whole by the next `*/10` cron, so expect those numbers to jump after deploy.