### PR TITLE
fix(auth): make the socket handshake revocable, and cap what a signup is worth

### DIFF
--- a/backend/__tests__/integration/socketAuth.test.js
+++ b/backend/__tests__/integration/socketAuth.test.js
@@ -1,0 +1,100 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const jwt = require("jsonwebtoken");
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const { identify } = require("../../middleware/socketAuth");
+const { createdAnAccount } = require("../../middleware/rateLimit");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    ...overrides,
+  });
+}
+
+describe("socket handshake identity", () => {
+  it("binds the account behind a live token", async () => {
+    const user = await makeUser();
+    expect(await identify(tokenFor(user))).toBe(String(user._id));
+  });
+
+  it("refuses a token revoked by a logout-everywhere", async () => {
+    const user = await makeUser();
+    const token = tokenFor(user);
+    await User.updateOne({ _id: user._id }, { $inc: { tokenVersion: 1 } });
+    expect(await identify(token)).toBeNull();
+  });
+
+  it("accepts a token issued after the revoke", async () => {
+    const user = await makeUser({ tokenVersion: 3 });
+    const token = jwt.sign(
+      { userId: String(user._id), tokenVersion: 3 },
+      process.env.JWT_SECRET,
+      { expiresIn: "1h" }
+    );
+    expect(await identify(token)).toBe(String(user._id));
+  });
+
+  it("refuses a disabled account", async () => {
+    const user = await makeUser({ disabled: true });
+    expect(await identify(tokenFor(user))).toBeNull();
+  });
+
+  it("refuses a token whose account is gone", async () => {
+    const user = await makeUser();
+    const token = tokenFor(user);
+    await User.deleteOne({ _id: user._id });
+    expect(await identify(token)).toBeNull();
+  });
+
+  it("connects as a guest with no token, a forged one, or an expired one", async () => {
+    const user = await makeUser();
+    const expired = jwt.sign({ userId: String(user._id) }, process.env.JWT_SECRET, { expiresIn: -10 });
+    expect(await identify(null)).toBeNull();
+    expect(await identify("")).toBeNull();
+    expect(await identify("not-a-token")).toBeNull();
+    expect(await identify(jwt.sign({ userId: String(user._id) }, "wrong-secret"))).toBeNull();
+    expect(await identify(expired)).toBeNull();
+  });
+
+  it("hangs up the live sockets when a session is revoked", async () => {
+    const user = await makeUser();
+    const hungUp = [];
+    require("../../utils/realtime").setIo({
+      in: (room) => ({ disconnectSockets: () => hungUp.push(room) }),
+    });
+
+    const res = await request(app)
+      .post("/users/logout-all")
+      .set("Authorization", `Bearer ${tokenFor(user)}`);
+
+    expect(res.status).toBe(200);
+    expect(hungUp).toEqual([String(user._id)]);
+    expect((await User.findById(user._id)).tokenVersion).toBe(1);
+    require("../../utils/realtime").setIo(null);
+  });
+});
+
+describe("the register budget", () => {
+  it("is spent by a created account and nothing else", () => {
+    expect(createdAnAccount({}, { locals: { createdAccount: true } })).toBe(true);
+    expect(createdAnAccount({}, { locals: {} })).toBe(false);
+    expect(createdAnAccount({}, { locals: { createdAccount: false } })).toBe(false);
+  });
+});

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,7 +6,8 @@ const socketIO = require("socket.io");
 const cronJobs = require("./tasks/cronJobs");
 const checkApiKey = require("./middleware/checkApiKey");
 const tunnel = require("./utils/tunnel");
-const jwt = require("jsonwebtoken");
+const { socketAuth } = require("./middleware/socketAuth");
+const realtime = require("./utils/realtime");
 
 require("dotenv").config();
 
@@ -65,11 +66,11 @@ const io = socketIO(server, {
     credentials: true,
   },
 });
+realtime.setIo(io);
 
 const coinFlip = require("./games/coinFlip");
 const crash = require("./games/crash");
 const caseBattle = require("./games/caseBattle");
-const User = require("./models/User");
 const { recoverStuckRounds } = require("./utils/rounds");
 const { completeStuckBattles } = require("./games/battleEngine");
 const { sweepBlackjackHands } = require("./games/blackjack");
@@ -204,21 +205,7 @@ let onlineUsers = 0;
 
 // optional auth: a valid token binds socket.userId; anonymous sockets may still
 // watch games but the game handlers ignore any client-supplied identity.
-io.use(async (socket, next) => {
-  try {
-    const token = socket.handshake.auth && socket.handshake.auth.token;
-    if (token) {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET);
-      // the http side refuses a disabled account, and the socket games have to as well or
-      // a banned player can still sit in crash and coin flip on a live connection
-      const account = await User.findById(decoded.userId).select("disabled").lean();
-      if (!account || !account.disabled) socket.userId = decoded.userId;
-    }
-  } catch (err) {
-    // invalid/expired token: continue unauthenticated
-  }
-  next();
-});
+io.use(socketAuth);
 
 io.on("connection", (socket) => {
   onlineUsers++;

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -23,11 +23,34 @@ const loginLimiter = rateLimit({
   message: { message: "Too many login attempts. Try again in a few minutes." },
 });
 
-// caps account farming (each new account is handed a starting balance and a bonus)
+// only a request that actually created an account spends the budget. a typo'd email, a
+// taken username or a returning player signing back in with google must not burn it:
+// carriers and campuses put thousands of real people behind one address.
+const createdAnAccount = (req, res) => res.locals.createdAccount === true;
+
+// caps account farming. a new account is handed a starting balance, and a referral code
+// on top of it pays the referrer too, which makes registration the cheapest faucet here.
 const registerLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
-  max: 10,
+  max: 3,
   keyGenerator: clientIp,
+  skipFailedRequests: true,
+  requestWasSuccessful: createdAnAccount,
+  skip: skipInTests,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  message: { message: "Too many accounts created from this address. Try again later." },
+});
+
+// the hourly cap on its own still allows 72 accounts a day from one address, which is the
+// exact shape of the farm it exists to stop
+const registerDailyLimiter = rateLimit({
+  windowMs: 24 * 60 * 60 * 1000,
+  max: 8,
+  keyGenerator: clientIp,
+  skipFailedRequests: true,
+  requestWasSuccessful: createdAnAccount,
   skip: skipInTests,
   standardHeaders: true,
   legacyHeaders: false,
@@ -85,4 +108,13 @@ const hiloActionLimiter = rateLimit({
   message: { message: "Too many actions, slow down a little." },
 });
 
-module.exports = { loginLimiter, registerLimiter, plinkoDropLimiter, diceRollLimiter, minesActionLimiter, hiloActionLimiter };
+module.exports = {
+  loginLimiter,
+  registerLimiter,
+  registerDailyLimiter,
+  createdAnAccount,
+  plinkoDropLimiter,
+  diceRollLimiter,
+  minesActionLimiter,
+  hiloActionLimiter,
+};

--- a/backend/middleware/socketAuth.js
+++ b/backend/middleware/socketAuth.js
@@ -1,0 +1,32 @@
+const jwt = require("jsonwebtoken");
+const User = require("../models/User");
+
+// the socket half of isAuthenticated, and it has to make every check the http side makes.
+// a connection that skips one is a session the site has no way to take back: socket
+// identity is claimed once at the handshake and then trusted for the life of the socket.
+async function identify(token) {
+  if (!token) return null;
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    const account = await User.findById(decoded.userId).select("disabled tokenVersion").lean();
+    // a token for an account that no longer exists is not a session
+    if (!account || account.disabled) return null;
+    // revoked by a logout-everywhere or a ban: the http side refuses it, so must this
+    if ((decoded.tokenVersion || 0) !== (account.tokenVersion || 0)) return null;
+    return String(decoded.userId);
+  } catch (err) {
+    return null; // invalid or expired: a guest connection, not an error
+  }
+}
+
+// an unusable token connects as a guest rather than being refused: crash and coin flip
+// are watchable logged out, and only the bet handlers require socket.userId.
+async function socketAuth(socket, next) {
+  const handshake = socket.handshake || {};
+  const token = handshake.auth && handshake.auth.token;
+  const userId = await identify(token);
+  if (userId) socket.userId = userId;
+  next();
+}
+
+module.exports = { socketAuth, identify };

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -11,7 +11,7 @@ const badges = require("../utils/badges");
 const Notification = require("../models/Notification");
 const Transaction = require("../models/Transaction");
 const authMiddleware = require("../middleware/authMiddleware");
-const { loginLimiter, registerLimiter } = require("../middleware/rateLimit");
+const { loginLimiter, registerLimiter, registerDailyLimiter } = require("../middleware/rateLimit");
 const { sellValue } = require("../utils/itemValue");
 const { creditUser, recordTransaction, runAtomic, TX } = require("../utils/economy");
 const { findReferrer, payReferralBonuses } = require("../utils/referrals");
@@ -23,11 +23,13 @@ const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const { resolvePassword } = require("../utils/password");
 const nameFilter = require("../utils/nameFilter");
 const { visible, isVisible } = require("../utils/visibility");
+const realtime = require("../utils/realtime");
 
 // Register user
 router.post(
   "/register",
   registerLimiter,
+  registerDailyLimiter,
   [
     check("email", "Please include a valid email").isEmail(),
     check(
@@ -89,6 +91,8 @@ router.post(
 
       // Save user to the database
       await user.save();
+      // the register limiters count accounts created, not requests attempted
+      res.locals.createdAccount = true;
 
       await recordTransaction({
         userId: user._id,
@@ -179,7 +183,7 @@ router.post(
 );
 
 // Google login
-router.post('/googlelogin', async (req, res) => {
+router.post('/googlelogin', registerLimiter, registerDailyLimiter, async (req, res) => {
   const { token, referralCode, marketingOptIn } = req.body;
   try {
     const ticket = await client.verifyIdToken({
@@ -214,6 +218,8 @@ router.post('/googlelogin', async (req, res) => {
       });
       if (referrer) user.referredBy = referrer._id;
       await user.save();
+      // a returning player signing in is not a signup and must not spend the budget
+      res.locals.createdAccount = true;
 
       await recordTransaction({
         userId: user._id,
@@ -718,6 +724,9 @@ router.post('/claimBonus', authMiddleware.isAuthenticated, async (req, res) => {
 router.post('/logout-all', authMiddleware.isAuthenticated, async (req, res) => {
   try {
     await User.updateOne({ _id: req.user._id }, { $inc: { tokenVersion: 1 } });
+    // the bump only stops the next handshake; a socket already connected keeps the
+    // identity it claimed, so the live ones have to be hung up here
+    realtime.disconnectUser(req.user._id);
     res.json({ message: "Signed out of all devices." });
   } catch (err) {
     console.error(err);

--- a/backend/utils/realtime.js
+++ b/backend/utils/realtime.js
@@ -1,0 +1,18 @@
+// the one socket.io server, handed over once at boot. the routers that are factories take
+// io as an argument; this is for the ones that are not and still have to reach it.
+let io = null;
+
+const setIo = (instance) => {
+  io = instance;
+};
+
+const getIo = () => io;
+
+// hang up every live socket belonging to one account. revoking a token only stops the
+// next handshake, and a socket that stays connected would keep its identity for good.
+function disconnectUser(userId) {
+  if (!io || !userId) return;
+  io.in(String(userId)).disconnectSockets(true);
+}
+
+module.exports = { setIo, getIo, disconnectUser };

--- a/src/components/header/userFlow/Login.tsx
+++ b/src/components/header/userFlow/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { login, googleLogin } from "../../../services/auth/auth";
+import { login, googleLogin, authError } from "../../../services/auth/auth";
 import { saveTokens } from "../../../services/auth/authUtils";
 import { getPendingReferralCode, clearPendingReferralCode } from "../../../services/referrals/ReferralServices";
 import MainButton from "../../MainButton";
@@ -50,6 +50,7 @@ const LoginPage = () => {
       }
     } catch (error) {
       console.error('Error during Google login', error);
+      setErrorMessage(authError(error, i18n.t("nav.invalidEmailOrPassword")));
     }
   };
 

--- a/src/components/header/userFlow/SignUp.tsx
+++ b/src/components/header/userFlow/SignUp.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { GoogleLogin } from "@react-oauth/google";
-import { register, googleLogin } from "../../../services/auth/auth";
+import { register, googleLogin, authError } from "../../../services/auth/auth";
 import MainButton from "../../MainButton";
 import { saveTokens } from "../../../services/auth/authUtils";
 import UserContext from "../../../UserContext";
@@ -59,7 +59,7 @@ const SignUpPage: React.FC = () => {
       }
     } catch (error) {
       console.log(error);
-      setError(i18n.t("nav.invalidFormatPleaseTry"));
+      setError(authError(error, i18n.t("nav.invalidFormatPleaseTry")));
     }
   };
 

--- a/src/services/auth/auth.ts
+++ b/src/services/auth/auth.ts
@@ -1,5 +1,12 @@
 import api from '../api';
 
+// the server's own reason when it sent one: a rate-limited signup and a disabled account
+// both say something more useful than "please try again"
+export function authError(error: unknown, fallback: string) {
+    const data = (error as { response?: { data?: { message?: string } } })?.response?.data;
+    return data?.message || fallback;
+}
+
 export async function login(email: string, password: string) {
     const response = await api.post('/users/login', { email, password });
     return response.data;


### PR DESCRIPTION
**Problem**

`socket.userId` is claimed once at the handshake and then trusted for the life of the connection, so anything the handshake skips is a session the site cannot take back. It read only `disabled`, so `tokenVersion` was never compared: `POST /users/logout-all` bumped the version, HTTP refused the token, and crash and coin flip kept serving it for the rest of its 30 days. It also bound an identity when the account lookup returned null.

Separately, registration mints a starting balance, and a referral code on top of it pays the referrer as well, so a completed signup is the cheapest KP on the site. It was capped at 10/hour per IP counting every request, and `/googlelogin`, which also creates accounts and pays referral bonuses, had no limiter at all.

**Change**

- Handshake auth moves to `middleware/socketAuth.js` and makes the same three checks `isAuthenticated` makes: the account exists, is not disabled, and the token version matches.
- The version bump only stops the next handshake, so `/logout-all` hangs up the sockets already connected. `utils/realtime.js` carries the io instance, since `userRoutes` is not an `(io) => router` factory.
- Register caps drop to 3/hour with 8/day behind them, and both count accounts created rather than requests attempted (`skipFailedRequests` + `requestWasSuccessful: createdAnAccount`). A typo'd email or a taken username now costs nothing.
- `/googlelogin` gets the same pair, setting the flag only in its creation branch: it is also the sign-in path, and counting logins would throttle returning players off their own accounts, since carriers and campuses put many real people behind one address.
- Google auth showed no server message at all on the login side and a generic one on signup, which would have made a rate-limited attempt look like a broken form. Both surface it through a typed `authError` helper.

**Tests**

Backend suite green (864). New `socketAuth.test.js` covers: a live token binds, a revoked one is refused, a token issued after the revoke still works, disabled and deleted accounts are refused, no/forged/expired tokens connect as guests, and `/logout-all` hangs up the right room. Limiters are skipped under `NODE_ENV=test`, so their behaviour was verified separately: six failed attempts cost nothing, the fourth created account returns 429, another address is unaffected, and the daily limiter allows eight then blocks.

**Note**

This tightens the referral tap, it does not close it. The payout still fires on account creation with no verification, so rotating addresses still farm it, just slower. The limiter store is also in-process, so a deploy resets the counters. Gating the payout itself changes the signup flow, so it is left out deliberately.