### PR TITLE
fix(plinko): pace an auto run against the board instead of a timer

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -133,28 +133,11 @@
   }
 }
 
-/* plinko peg struck by a ball; runs outside react so mass drops stay smooth */
-.peg-pulse {
-  animation: peg-pulse 0.35s ease-out;
+/* plinko pegs; the strike animation runs off the web animations api, so this only fixes
+   the box the scale is measured from */
+.peg {
   transform-box: fill-box;
   transform-origin: center;
-}
-
-@keyframes peg-pulse {
-  0% {
-    transform: scale(1);
-    fill: #cfccdf;
-  }
-
-  40% {
-    transform: scale(1.8);
-    fill: #ffe08a;
-  }
-
-  100% {
-    transform: scale(1);
-    fill: #cfccdf;
-  }
 }
 
 /* plinko ball waiting at the drop mouth while its request is in flight */

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -3,7 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import UserContext from "../../UserContext";
 import { dropPlinko } from "../../services/games/GamesServices";
-import { MAX_BET, PlinkoRisk } from "./plinkoBoard";
+import { DROP_DURATION_S, MAX_BET, PlinkoRisk } from "./plinkoBoard";
+import { autoStep } from "./autoRun";
 import { PlinkoBall, PlinkoDropResult } from "./Plinko.types";
 import i18n from "../../i18n";
 
@@ -40,25 +41,35 @@ export const usePlinkoServices = () => {
   const maxBet = MAX_BET[risk];
   const betValue = Math.min(Math.max(Math.floor(Number(betInput)) || 1, 1), maxBet);
 
+  // the wallet only refreshes when a ball lands, so count the stakes still in the air
+  const available = () => (userData?.walletBalance ?? 0) - pendingStake.current;
+  const releaseStake = (stake: number) => {
+    pendingStake.current = Math.max(0, pendingStake.current - stake);
+  };
+
   const fireDrop = async (): Promise<boolean> => {
     if (userData == null) {
       toogleUserFlow(true);
       return false;
     }
-    // the wallet only refreshes when a ball lands, so count the stakes still in the air
-    if (userData.walletBalance - pendingStake.current < betValue) {
+    if (available() < betValue) {
       toast.error(i18n.t("blackjack.insufficientFunds"), { theme: "dark" });
       return false;
     }
-    pendingStake.current += betValue;
+    const stake = betValue;
+    pendingStake.current += stake;
     setPendingDrops((n) => n + 1);
     try {
-      const result: PlinkoDropResult = await dropPlinko(betValue, risk);
+      const result: PlinkoDropResult = await dropPlinko(stake, risk);
       ballSeq.current += 1;
       setBalls((prev) => [...prev, { ...result, key: `b${ballSeq.current}` }]);
+      // released on a clock rather than when the ball lands: the server sends the new
+      // balance on its own schedule, and a dropped frame must not strand a stake and
+      // lock a player out of money they still have
+      window.setTimeout(() => releaseStake(stake), DROP_DURATION_S * 1000);
       return true;
     } catch (error: any) {
-      pendingStake.current -= betValue;
+      releaseStake(stake);
       toast.error(error?.response?.data?.message || "Could not drop the ball", { theme: "dark" });
       return false;
     } finally {
@@ -66,9 +77,18 @@ export const usePlinkoServices = () => {
     }
   };
 
-  // the auto interval reads through a ref so it always sees the current bet and risk
+  // the auto interval reads through refs so it always sees the current bet, risk and board
   const fireDropRef = useRef(fireDrop);
   fireDropRef.current = fireDrop;
+  const stepRef = useRef(() => autoStep({ left: 0, inFlight: 0, available: 0, bet: 1, maxInFlight: MAX_IN_FLIGHT }));
+  stepRef.current = () =>
+    autoStep({
+      left: autoLeftRef.current,
+      inFlight: balls.length + pendingDrops,
+      available: available(),
+      bet: betValue,
+      maxInFlight: MAX_IN_FLIGHT,
+    });
 
   const stopAuto = useCallback(() => {
     if (autoTimer.current) clearInterval(autoTimer.current);
@@ -88,10 +108,15 @@ export const usePlinkoServices = () => {
     autoLeftRef.current = autoCount;
     setAutoLeft(autoCount);
     const tick = async () => {
-      if (autoLeftRef.current <= 0) {
-        stopAuto();
-        return;
+      const step = stepRef.current();
+      if (step === "done") return stopAuto();
+      if (step === "broke") {
+        toast.error(i18n.t("blackjack.insufficientFunds"), { theme: "dark" });
+        return stopAuto();
       }
+      // a full board or a shortfall a falling ball may still cover costs a tick, never a
+      // ball: the run picks up again on the next one instead of ending half finished
+      if (step === "wait") return;
       autoLeftRef.current -= 1;
       setAutoLeft(autoLeftRef.current);
       const ok = await fireDropRef.current();
@@ -115,7 +140,6 @@ export const usePlinkoServices = () => {
   const settleBall = useCallback((ball: PlinkoBall) => {
     if (settled.current.has(ball.key)) return;
     settled.current.add(ball.key);
-    pendingStake.current -= ball.betAmount; // the landing balance update covers it now
     hitSeq.current += 1;
     setBalls((prev) => prev.filter((b) => b.key !== ball.key));
     setLastHit({ bin: ball.bin, seq: hitSeq.current });

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -40,19 +40,33 @@ const PegField = memo(() => (
   <>
     {PEG_ROWS.map((row, i) =>
       row.map((peg, k) => (
-        <circle key={`${i}-${k}`} id={`peg-${i}-${k}`} cx={peg.x} cy={peg.y} r={PEG_RADIUS} fill="#cfccdf" />
+        <circle
+          key={`${i}-${k}`}
+          id={`peg-${i}-${k}`}
+          className="peg"
+          cx={peg.x}
+          cy={peg.y}
+          r={PEG_RADIUS}
+          fill="#cfccdf"
+        />
       ))
     )}
   </>
 ));
 
+const PEG_PULSE: Keyframe[] = [
+  { transform: "scale(1)", fill: "#cfccdf" },
+  { transform: "scale(1.8)", fill: "#ffe08a", offset: 0.4 },
+  { transform: "scale(1)", fill: "#cfccdf" },
+];
+
 const pulsePegElement = (row: number, index: number) => {
   const peg = document.getElementById(`peg-${row}-${index}`);
-  if (!peg) return;
-  // remove and reflow so a peg struck twice in a row restarts its animation
-  peg.classList.remove("peg-pulse");
-  void peg.getBoundingClientRect();
-  peg.classList.add("peg-pulse");
+  if (!peg || typeof peg.animate !== "function") return;
+  // a web animation restarts on its own. the css class needed a forced reflow to do the
+  // same, and sixteen of those per ball is what made a long auto run stutter.
+  peg.getAnimations().forEach((animation) => animation.cancel());
+  peg.animate(PEG_PULSE, { duration: 350, easing: "ease-out" });
 };
 
 const FallingBall = memo(({ ball, onSettle }: { ball: PlinkoBall; onSettle: (ball: PlinkoBall) => void }) => {

--- a/src/pages/Plinko/autoRun.test.ts
+++ b/src/pages/Plinko/autoRun.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { autoStep } from "./autoRun";
+
+const state = (over: Partial<Parameters<typeof autoStep>[0]> = {}) => ({
+  left: 100,
+  inFlight: 0,
+  available: 1000,
+  bet: 10,
+  maxInFlight: 12,
+  ...over,
+});
+
+describe("an auto run", () => {
+  test("fires while there is room and money", () => {
+    expect(autoStep(state())).toBe("fire");
+  });
+
+  test("ends when the count runs out", () => {
+    expect(autoStep(state({ left: 0 }))).toBe("done");
+  });
+
+  test("waits instead of spending a ball when the board is full", () => {
+    expect(autoStep(state({ inFlight: 12 }))).toBe("wait");
+    expect(autoStep(state({ inFlight: 13 }))).toBe("wait");
+  });
+
+  test("waits out a shortfall that balls in the air may still cover", () => {
+    expect(autoStep(state({ available: 0, inFlight: 3 }))).toBe("wait");
+  });
+
+  test("stops only once nothing is left to land", () => {
+    expect(autoStep(state({ available: 0, inFlight: 0 }))).toBe("broke");
+  });
+
+  test("counts the board before the wallet, so a full board never reads as broke", () => {
+    expect(autoStep(state({ available: 0, inFlight: 12 }))).toBe("wait");
+  });
+});

--- a/src/pages/Plinko/autoRun.ts
+++ b/src/pages/Plinko/autoRun.ts
@@ -1,0 +1,24 @@
+// what one tick of an auto run should do. pulled out of the hook so the pacing rules are
+// a pure function: this is the part that decides whether a hundred-ball run finishes.
+export type AutoStep = "fire" | "wait" | "done" | "broke";
+
+export interface AutoState {
+  left: number;
+  inFlight: number;
+  available: number;
+  bet: number;
+  maxInFlight: number;
+}
+
+export const autoStep = ({ left, inFlight, available, bet, maxInFlight }: AutoState): AutoStep => {
+  if (left <= 0) return "done";
+  // the board is full: skip this tick without spending a ball, so the run paces itself
+  // against how fast balls actually land rather than against a fixed timer
+  if (inFlight >= maxInFlight) return "wait";
+  if (available < bet) {
+    // a ball still falling may yet pay for this one, so being short is only fatal once
+    // nothing is left in the air
+    return inFlight > 0 ? "wait" : "broke";
+  }
+  return "fire";
+};


### PR DESCRIPTION
**Problem**

Reported by a player: a 100-ball auto run dropped only some of the balls, then went laggy and stopped. Three defects that compound into exactly that:

- The auto tick fired every `AUTO_DROP_INTERVAL_MS` regardless of the board. Only the manual button checked `MAX_IN_FLIGHT`; auto called `fireDrop` straight through, so nothing bounded the number of balls and pending requests once a frame was dropped or the server got slow.
- `pendingStake` was released in `settleBall`, which runs on framer-motion's `onAnimationComplete`. A missed or late callback stranded a stake, so `walletBalance - pendingStake` read as insufficient funds permanently: the run stopped and stayed broken until reload.
- A shortfall ended the whole run, even when it was only temporary because balls in the air had not paid out yet. One bad tick killed 60 remaining balls.

The lag is separate and self-inflicted: `pulsePegElement` restarted a CSS animation with the `classList.remove` + `getBoundingClientRect` + `add` trick. That forces a synchronous layout, 16 times per ball, on a board of 168 pegs with up to a dozen balls animating.

**Change**

- Pacing rules move to `autoRun.ts:autoStep`, a pure function: a full board or a shortfall that falling balls may still cover costs a tick, never a ball, so the run finishes late instead of finishing short. It only stops when the count runs out, or when the player is short with nothing left in the air.
- `pendingStake` is released on a clock rather than on the animation callback. Money no longer depends on pixels.
- The peg pulse is a `peg.animate(...)` web animation, which restarts on its own. `.peg-pulse` and its keyframes are gone; `.peg` now only sets the box the scale is measured from.

No backend change. The `plinkoDropLimiter` was never the cause: auto runs at 2.5 requests/sec against a 40-per-10s cap.

**Tests**

Six new cases in `autoRun.test.ts` covering the pacing rules, including that a full board never reads as broke. Frontend unit 118 passed, lint at baseline, build clean, 26 Playwright e2e passed.