### PR TITLE
fix(money): retry a conflicted transaction, and stop re-reading the catalog

### DIFF
--- a/backend/__tests__/integration/db.js
+++ b/backend/__tests__/integration/db.js
@@ -1,5 +1,6 @@
 const { MongoMemoryServer } = require("mongodb-memory-server");
 const mongoose = require("mongoose");
+const itemCatalog = require("../../utils/itemCatalog");
 
 let mongod;
 
@@ -13,6 +14,8 @@ async function clearDb() {
   for (const key of Object.keys(collections)) {
     await collections[key].deleteMany({});
   }
+  // these wipes go through the raw driver, so no model hook fires to clear the catalog
+  itemCatalog.invalidate();
 }
 
 async function teardownDb() {

--- a/backend/__tests__/integration/itemCatalog.test.js
+++ b/backend/__tests__/integration/itemCatalog.test.js
@@ -1,0 +1,73 @@
+const { setupDb, clearDb, teardownDb } = require("./db");
+const Item = require("../../models/Item");
+const itemCatalog = require("../../utils/itemCatalog");
+const { recomputeCaseValues } = require("../../utils/itemValue");
+const Case = require("../../models/Case");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeItem = (name, rarity = "3") => Item.create({ name, image: `${name}.png`, rarity, baseValue: 100 });
+
+describe("the cached item catalog", () => {
+  it("serves the catalog and picks up a new item", async () => {
+    await makeItem("Yuuma");
+    expect((await itemCatalog.all()).map((i) => i.name)).toEqual(["Yuuma"]);
+
+    await makeItem("Momiji");
+    expect((await itemCatalog.all()).map((i) => i.name).sort()).toEqual(["Momiji", "Yuuma"]);
+  });
+
+  it("picks up an edit and a deletion", async () => {
+    const item = await makeItem("Yuuma");
+    await itemCatalog.all();
+
+    await Item.findByIdAndUpdate(item._id, { name: "Renamed" });
+    expect((await itemCatalog.all()).map((i) => i.name)).toEqual(["Renamed"]);
+
+    await Item.findByIdAndDelete(item._id);
+    expect(await itemCatalog.all()).toEqual([]);
+  });
+
+  it("picks up a bulkWrite, which fires no model hook", async () => {
+    const item = await makeItem("Yuuma", "5");
+    const box = await Case.create({ title: "c", image: "x", price: 10, items: [item._id] });
+    await itemCatalog.all();
+
+    await recomputeCaseValues(box._id);
+
+    const [fresh] = await itemCatalog.all();
+    expect(fresh.baseValue).toBe((await Item.findById(item._id)).baseValue);
+  });
+
+  it("filters by a case-insensitive part of the name, by rarity and by case", async () => {
+    const a = await makeItem("Yuuma", "3");
+    await makeItem("Momiji", "5");
+
+    expect((await itemCatalog.find({ name: "yuu" })).map((i) => i.name)).toEqual(["Yuuma"]);
+    expect((await itemCatalog.find({ name: "UMA" })).map((i) => i.name)).toEqual(["Yuuma"]);
+    expect((await itemCatalog.find({ rarity: "5" })).map((i) => i.name)).toEqual(["Momiji"]);
+    expect(await itemCatalog.find({ caseId: String(a.case || "none") })).toEqual([]);
+    expect(await itemCatalog.find({ name: "nobody" })).toEqual([]);
+  });
+
+  it("maps every id to its character, and rebuilds the map when the catalog turns over", async () => {
+    const item = await makeItem("Yuuma");
+    expect((await itemCatalog.namesById()).get(String(item._id))).toBe("Yuuma");
+
+    await Item.findByIdAndUpdate(item._id, { name: "Renamed" });
+    expect((await itemCatalog.namesById()).get(String(item._id))).toBe("Renamed");
+  });
+
+  it("sends one query when several callers ask a cold cache at once", async () => {
+    await makeItem("Yuuma");
+    itemCatalog.invalidate();
+    const spy = jest.spyOn(Item, "find");
+
+    await Promise.all([itemCatalog.all(), itemCatalog.all(), itemCatalog.all(), itemCatalog.all()]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+});

--- a/backend/__tests__/unit/moneyRetry.test.js
+++ b/backend/__tests__/unit/moneyRetry.test.js
@@ -1,0 +1,50 @@
+const { isTransient, describeMoneyError, runAtomic } = require("../../utils/economy");
+
+const labelled = (...labels) => {
+  const err = new Error("Caused by :: Write conflict during plan execution and yielding is disabled.");
+  err.code = 112;
+  err.codeName = "WriteConflict";
+  err.hasErrorLabel = (l) => labels.includes(l);
+  return err;
+};
+
+describe("which money failures are safe to run again", () => {
+  test("a conflict-aborted transaction is, because nothing committed", () => {
+    expect(isTransient(labelled("TransientTransactionError"))).toBe(true);
+  });
+
+  test("an unknown commit result is not: it may already have landed", () => {
+    expect(isTransient(labelled("UnknownTransactionCommitResult"))).toBe(false);
+  });
+
+  test("an unlabelled error is not", () => {
+    expect(isTransient(new Error("boom"))).toBe(false);
+    expect(isTransient(null)).toBe(false);
+    expect(isTransient(undefined)).toBe(false);
+  });
+});
+
+describe("what gets logged when money rolls back", () => {
+  test("one line carrying the code and the labels, not a driver stack", () => {
+    const line = describeMoneyError(labelled("TransientTransactionError"));
+    expect(line).toContain("WriteConflict");
+    expect(line).toContain("code=112");
+    expect(line).toContain("labels=TransientTransactionError");
+    expect(line.split("\n")).toHaveLength(1);
+  });
+
+  test("survives an error with nothing on it", () => {
+    expect(describeMoneyError(null)).toBe("unknown");
+    expect(describeMoneyError(new Error("plain"))).toContain("plain");
+  });
+});
+
+describe("runAtomic without transaction support", () => {
+  test("still runs the operation and hands back its result", async () => {
+    await expect(runAtomic(async () => "done")).resolves.toBe("done");
+  });
+
+  test("lets a real failure through rather than swallowing it", async () => {
+    await expect(runAtomic(async () => { throw new Error("nope"); })).rejects.toThrow("nope");
+  });
+});

--- a/backend/games/plinko.js
+++ b/backend/games/plinko.js
@@ -1,3 +1,4 @@
+const User = require("../models/User");
 const { chargeUser, creditUser, TX } = require("../utils/economy");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
@@ -39,7 +40,13 @@ class PlinkoGameController {
             meta: { betAmount, risk },
         });
         if (!player) {
-            throw httpError(400, "Insufficient balance");
+            // a null charge is both "no money" and "the write lost a race with another
+            // drop"; only one of those is the player's fault, and an auto run that stops
+            // on the wrong one is exactly what got reported
+            const funded = await User.exists({ _id: userId, walletBalance: { $gte: betAmount } });
+            throw funded
+                ? httpError(503, "That drop could not be placed, try again")
+                : httpError(400, "Insufficient balance");
         }
 
         // derive the peg path from the seed (one draw per row) and price the landing bin

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -28,4 +28,21 @@ const ItemSchema = new mongoose.Schema({
   },
 });
 
+// the cached catalog must not outlive a write. registered here because middleware added
+// after a model is compiled never runs, and required lazily so the model carries no
+// load-time dependency on the cache that reads it.
+const invalidateCatalog = () => require("../utils/itemCatalog").invalidate();
+const WRITE_HOOKS = [
+  "save",
+  "insertMany",
+  "findOneAndUpdate",
+  "findOneAndDelete",
+  "findOneAndReplace",
+  "updateOne",
+  "updateMany",
+  "deleteOne",
+  "deleteMany",
+];
+for (const hook of WRITE_HOOKS) ItemSchema.post(hook, invalidateCatalog);
+
 module.exports = mongoose.model("Item", ItemSchema);

--- a/backend/routes/itemRoutes.js
+++ b/backend/routes/itemRoutes.js
@@ -5,10 +5,11 @@ const Case = require("../models/Case");
 const { isAuthenticated, isAdmin } = require("../middleware/authMiddleware");
 const { recomputeCaseValues } = require("../utils/itemValue");
 const { publicCache, TTL } = require("../utils/httpCache");
+const itemCatalog = require("../utils/itemCatalog");
 
 router.get("/", async (req, res) => {
   try {
-    const items = await Item.find();
+    const items = await itemCatalog.all();
     publicCache(res, TTL.itemList);
     res.json(items);
   } catch (err) {

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -13,6 +13,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const { sellValue, marketFee, sellerNet, MARKET_FEE_RATE } = require("../utils/itemValue");
 const market = require("../utils/market");
 const fandom = require("../utils/fandom");
+const itemCatalog = require("../utils/itemCatalog");
 const { isRealMoneyMode } = require("../utils/mode");
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -245,15 +246,14 @@ module.exports = (io) => {
       const skip = (page - 1) * limit;
       const { name, rarity, sortBy, order, listedOnly } = req.query;
 
-      const itemFilter = {};
-      if (name) itemFilter.name = { $regex: new RegExp(escapeRegex(String(name)), "i") };
-      if (rarity) itemFilter.rarity = rarity;
+      const items = await itemCatalog.find({ name, rarity });
 
-      const items = await Item.find(itemFilter).exec();
-      const itemIds = items.map((item) => item._id);
-
+      // only narrow the listings by item when the catalog itself was narrowed: with no
+      // filter the $in is a thousand ids that match everything anyway, and it costs more
+      // than the scan it replaces
+      const match = name || rarity ? [{ $match: { item: { $in: items.map((item) => item._id) } } }] : [];
       const marketplaceData = await Marketplace.aggregate([
-        { $match: { item: { $in: itemIds } } },
+        ...match,
         {
           $group: {
             _id: "$item",
@@ -268,7 +268,7 @@ module.exports = (io) => {
       let rows = items.map((item) => {
         const md = byItem.get(item._id.toString());
         return {
-          ...item.toObject(),
+          ...item,
           sellValue: sellValue(item.baseValue),
           cheapestPrice: md ? md.cheapestPrice : null,
           totalListings: md ? md.totalListings : 0,

--- a/backend/scripts/payMissedPayouts.js
+++ b/backend/scripts/payMissedPayouts.js
@@ -1,0 +1,119 @@
+// Pays out plinko wins whose credit was rolled back by a write conflict.
+//
+// A credit that loses its transaction leaves the stake taken and the winnings unpaid; the
+// roll is still on record, so the roll is what this reconciles against. Dry run by default:
+//   node scripts/payMissedPayouts.js                 # report only
+//   node scripts/payMissedPayouts.js --apply         # actually pay
+//   node scripts/payMissedPayouts.js --from ... --to ...
+//
+// Safe to run twice. A roll it has already settled carries `meta.reconciledRoll`, and a
+// roll whose original credit did land is matched against the existing win row.
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Notification = require("../models/Notification");
+const { creditUser, probeTransactions, setTransactionsSupported, TX } = require("../utils/economy");
+
+const arg = (name, fallback) => {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+};
+const APPLY = process.argv.includes("--apply");
+const FROM = new Date(arg("--from", "2026-08-22T12:00:00Z"));
+const TO = new Date(arg("--to", "2026-08-22T12:30:00Z"));
+// credits are searched far wider than the rolls, so a payout that landed just outside the
+// window is never mistaken for a missing one
+const PAD_MS = 2 * 60 * 60 * 1000;
+
+async function main() {
+  await mongoose.connect(process.env.MONGO_URI);
+  setTransactionsSupported(await probeTransactions());
+  const db = mongoose.connection.db;
+
+  const rolls = await db
+    .collection("rolls")
+    .find({ game: "plinko", createdAt: { $gte: FROM, $lte: TO } })
+    .toArray();
+  const owed = rolls.filter((r) => r.outcome && Number(r.outcome.payout) > 0);
+
+  const wins = await db
+    .collection("transactions")
+    .find({
+      type: TX.PLINKO_WIN,
+      createdAt: { $gte: new Date(FROM.getTime() - PAD_MS), $lte: new Date(TO.getTime() + PAD_MS) },
+    })
+    .toArray();
+
+  // already settled by an earlier run of this script
+  const settled = new Set(wins.map((t) => t.meta && t.meta.reconciledRoll).filter(Boolean));
+
+  // one win row can only account for one roll, so matching consumes it
+  const pool = new Map();
+  wins
+    .filter((t) => !(t.meta && t.meta.reconciledRoll))
+    .forEach((t) => {
+      const key = `${t.userId}|${t.amount}`;
+      pool.set(key, (pool.get(key) || 0) + 1);
+    });
+
+  const missing = [];
+  for (const roll of owed) {
+    if (settled.has(roll.rollId)) continue;
+    const key = `${roll.userId}|${roll.outcome.payout}`;
+    const held = pool.get(key) || 0;
+    if (held > 0) pool.set(key, held - 1);
+    else missing.push(roll);
+  }
+
+  const total = missing.reduce((sum, r) => sum + Number(r.outcome.payout), 0);
+  console.log(`plinko rolls ${FROM.toISOString()} .. ${TO.toISOString()}: ${rolls.length}, owed a payout: ${owed.length}`);
+  console.log(`unpaid: ${missing.length} rolls, ${total} KP`);
+  for (const r of missing) {
+    console.log(`  ${r.rollId}  user=${r.userId}  payout=${r.outcome.payout}`);
+  }
+  if (!missing.length || !APPLY) {
+    console.log(APPLY ? "nothing to pay" : "\ndry run, nothing written. pass --apply to pay.");
+    return;
+  }
+
+  const byUser = new Map();
+  for (const roll of missing) {
+    const payout = Number(roll.outcome.payout);
+    const user = await creditUser(roll.userId, payout, payout, {
+      type: TX.PLINKO_WIN,
+      meta: {
+        betAmount: roll.outcome.betAmount,
+        risk: roll.outcome.risk,
+        bin: roll.outcome.bin,
+        payout,
+        reconciledRoll: roll.rollId,
+        reason: "credit lost to a write conflict",
+      },
+    });
+    if (!user) {
+      console.log(`  FAILED ${roll.rollId}, leaving it for the next run`);
+      continue;
+    }
+    console.log(`  paid ${roll.rollId}  ${payout} KP  -> ${user.username}`);
+    const seen = byUser.get(String(roll.userId)) || { kp: 0, n: 0 };
+    byUser.set(String(roll.userId), { kp: seen.kp + payout, n: seen.n + 1 });
+  }
+
+  // the player watched a drop land and pay nothing, so tell them it has been put right
+  for (const [userId, v] of byUser) {
+    await Notification.create({
+      senderId: userId,
+      receiverId: userId,
+      type: "alert",
+      title: "Plinko payout restored",
+      content: `${v.n} of your plinko wins failed to pay out during a server fault. K₽${v.kp} has been added to your balance.`,
+    });
+  }
+  console.log(`\ndone: ${byUser.size} players, ${[...byUser.values()].reduce((s, v) => s + v.kp, 0)} KP`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => mongoose.disconnect());

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -87,20 +87,56 @@ async function probeTransactions() {
   }
 }
 
+// labels mongo puts on an error to say what is safe to do about it. a transaction that
+// aborted on a write conflict committed nothing, so running the whole thing again is safe.
+// an unknown commit result is deliberately NOT retried: that one may already have landed.
+const LABELS = ["TransientTransactionError", "UnknownTransactionCommitResult", "RetryableWriteError"];
+const labelsOf = (err) =>
+  err && typeof err.hasErrorLabel === "function" ? LABELS.filter((l) => err.hasErrorLabel(l)) : [];
+const isTransient = (err) => labelsOf(err).includes("TransientTransactionError");
+
+// one line instead of a thirty-line driver stack. the code and the labels are what say
+// whether this was ordinary contention or something new.
+function describeMoneyError(err) {
+  if (!err) return "unknown";
+  const labels = labelsOf(err);
+  return [err.codeName || err.name, err.code ? `code=${err.code}` : null, labels.length ? `labels=${labels.join(",")}` : null, String(err.message || "").slice(0, 140)]
+    .filter(Boolean)
+    .join(" ");
+}
+
+const RETRY_ATTEMPTS = 4;
+// jittered, so a burst of bets that collided once does not line up and collide again
+const backoff = (attempt) =>
+  new Promise((resolve) => setTimeout(resolve, 10 * 2 ** attempt + Math.floor(Math.random() * 25)));
+
 // run a money operation atomically when transactions are available, else best-effort
 // without a session. prod always has them, so prod gets the guarantee.
+//
+// withTransaction retries a conflict on its own, but production has shown it giving up
+// anyway under bursts of bets on one wallet, and what the caller gets back then is a null
+// it cannot tell apart from an empty balance. a fresh session per attempt is the belt to
+// that braces: nothing committed, so the retry cannot double anything.
 async function runAtomic(fn) {
   if (!txSupported) return fn(null);
-  const session = await mongoose.startSession();
-  try {
-    let result;
-    await session.withTransaction(async () => {
-      result = await fn(session);
-    });
-    return result;
-  } finally {
-    await session.endSession();
+  let lastError;
+  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+    const session = await mongoose.startSession();
+    try {
+      let result;
+      await session.withTransaction(async () => {
+        result = await fn(session);
+      });
+      return result;
+    } catch (err) {
+      lastError = err;
+      if (!isTransient(err)) throw err;
+    } finally {
+      await session.endSession();
+    }
+    if (attempt < RETRY_ATTEMPTS - 1) await backoff(attempt);
   }
+  throw lastError;
 }
 
 // append a balance-history entry. inside a transaction a failed row must abort the
@@ -198,7 +234,7 @@ async function chargeUser(userId, cost, { awardXp = true, type, meta, counterpar
     }
     return user;
   } catch (err) {
-    console.error("chargeUser rolled back:", err);
+    console.error(`chargeUser rolled back [${type || "charge"}]:`, describeMoneyError(err));
     return null;
   }
 }
@@ -226,7 +262,7 @@ async function creditUser(userId, amount, winnings = 0, { type, meta, counterpar
   try {
     return await runAtomic(body);
   } catch (err) {
-    console.error("creditUser rolled back:", err);
+    console.error(`creditUser rolled back [${type || "credit"}]:`, describeMoneyError(err));
     return null;
   }
 }
@@ -262,6 +298,8 @@ module.exports = {
   accountBalance,
   ledgerSupply,
   runAtomic,
+  isTransient,
+  describeMoneyError,
   probeTransactions,
   setTransactionsSupported,
   transactionsSupported,

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -57,15 +57,7 @@ const namesByItemId = () => itemCatalog.namesById();
 // a player's standing is counted only for the character they pinned. holding thousands of
 // everything else is worth nothing here, which is what keeps one rich account from owning
 // every board. items listed on the market are pulled out of the inventory, so they stop
-// counting while they are for sale.
-function countPinned(user, character) {
-  if (!character) return 0;
-  let held = 0;
-  for (const entry of user.inventory || []) {
-    if (isCopyOf(entry, character)) held += 1;
-  }
-  return held;
-}
+// counting while they are for sale. both counting paths below hold to that.
 
 // how close the chase is: the leader's margin over the runner-up. a board with no leader
 // or nobody behind them is not a contest at all.
@@ -90,58 +82,83 @@ function byCollection(a, b) {
   return String(a.userId).localeCompare(String(b.userId));
 }
 
+// every account's holdings, counted inside mongo. this used to stream each inventory back
+// to the app to count it here: 31 MB every ten minutes over a link that carries about
+// 100 KB/s, which left it busy more than half the time for one cron job. only the totals
+// come back now, and only for accounts that hold something.
+//
+// the join is what turns entries into characters, so an entry whose catalog row has since
+// been deleted drops out. that is the same thing the boards already say: a character
+// nobody can hold has no board.
+async function countHoldings() {
+  const carry = { pinned: { $first: "$pinned" } };
+  return User.aggregate([
+    { $match: visible() },
+    { $project: { pinned: "$fixedItem.name", inventory: { $ifNull: ["$inventory", []] } } },
+    { $unwind: "$inventory" },
+    // collapse to one row per copy stack first, so the join runs per item held rather
+    // than per copy: a deep inventory is thousands of entries and a handful of items
+    { $group: { _id: { user: "$_id", item: "$inventory._id" }, n: { $sum: 1 }, ...carry } },
+    { $lookup: { from: "items", localField: "_id.item", foreignField: "_id", as: "catalog" } },
+    { $unwind: "$catalog" },
+    // the same character can come from more than one case, so the name is the group
+    { $group: { _id: { user: "$_id.user", name: "$catalog.name" }, n: { $sum: "$n" }, ...carry } },
+    {
+      $group: {
+        _id: "$_id.user",
+        distinct: { $sum: 1 },
+        total: { $sum: "$n" },
+        count: { $sum: { $cond: [{ $eq: ["$_id.name", "$pinned"] }, "$n", 0] } },
+      },
+    },
+  ]);
+}
+
 // one pass over every account: the pinned boards and the collection board come out of the
-// same stream, because loading every inventory twice is the expensive part.
+// same counts, because counting every inventory twice is the expensive part.
 async function sweep() {
   const byName = await charactersByName();
   const known = new Set(byName.keys());
-  const nameById = namesById(byName);
   const pinned = new Map();
   const collectors = [];
 
-  const cursor = User.find(visible())
-    .select("username profilePicture level fixedItem fixedAt inventory")
-    .lean()
-    .cursor();
+  // the roster is read without inventories, so someone who pinned a character and holds
+  // none of it still gets their row on the board
+  const [people, holdings] = await Promise.all([
+    User.find(visible()).select("username profilePicture level fixedItem fixedAt").lean(),
+    countHoldings(),
+  ]);
+  const held = new Map(holdings.map((row) => [String(row._id), row]));
 
-  for await (const user of cursor) {
-    const seen = new Set();
-    let total = 0;
-    for (const entry of user.inventory || []) {
-      if (!entry) continue;
-      const name = nameById.get(String(entry._id)) || (known.has(entry.name) ? entry.name : null);
-      if (!name) continue;
-      seen.add(name);
-      total += 1;
-    }
-    if (seen.size) {
+  for (const person of people) {
+    const mine = held.get(String(person._id));
+    if (mine && mine.distinct) {
       collectors.push({
-        userId: user._id,
-        username: user.username,
-        profilePicture: user.profilePicture,
-        level: user.level,
-        distinct: seen.size,
-        total,
+        userId: person._id,
+        username: person.username,
+        profilePicture: person.profilePicture,
+        level: person.level,
+        distinct: mine.distinct,
+        total: mine.total,
       });
     }
 
-    const name = user.fixedItem && user.fixedItem.name;
+    const name = person.fixedItem && person.fixedItem.name;
     if (!name) continue;
-    const character = byName.get(name);
     // a pinned item whose row has since been removed names a character nobody can hold
     // any more, so it gets no board rather than an empty one
-    if (!character) continue;
+    if (!byName.get(name)) continue;
 
     pinned.set(name, pinned.get(name) || []);
     pinned.get(name).push({
-      userId: user._id,
-      username: user.username,
-      profilePicture: user.profilePicture,
-      level: user.level,
-      count: countPinned(user, character),
+      userId: person._id,
+      username: person.username,
+      profilePicture: person.profilePicture,
+      level: person.level,
+      count: mine ? mine.count : 0,
       // accounts that pinned before this shipped have no fixedAt, so they fall back to
       // when the account itself was made
-      since: user.fixedAt || user._id.getTimestamp(),
+      since: person.fixedAt || person._id.getTimestamp(),
     });
   }
 
@@ -397,7 +414,6 @@ module.exports = {
   charactersByName,
   namesByItemId,
   isCopyOf,
-  countPinned,
   byStanding,
   byCollection,
   RANKS_KEPT,

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -4,6 +4,7 @@ const Item = require("../models/Item");
 const FanBoard = require("../models/FanBoard");
 const CollectorBoard = require("../models/CollectorBoard");
 const { visible } = require("./visibility");
+const itemCatalog = require("./itemCatalog");
 
 // how many chasers a board keeps. deep enough that anyone in touching distance sees
 // themselves, short enough that a board document stays small.
@@ -15,8 +16,8 @@ const COLLECTORS_KEPT = 100;
 // the same character can appear in more than one case, as separate item rows sharing a
 // name. the name is the character, so every id behind it counts toward the same board.
 async function charactersByName(names) {
-  const filter = names && names.length ? { name: { $in: names } } : {};
-  const items = await Item.find(filter).select("name image rarity case").lean();
+  const wanted = names && names.length ? new Set(names) : null;
+  const items = (await itemCatalog.all()).filter((item) => !wanted || wanted.has(item.name));
   const byName = new Map();
   for (const item of items) {
     let entry = byName.get(item.name);
@@ -51,10 +52,7 @@ function namesById(byName) {
 }
 
 // the whole catalog keyed by item id, for a caller holding a raw inventory and nothing else
-async function namesByItemId() {
-  const items = await Item.find({}).select("name").lean();
-  return new Map(items.map((item) => [String(item._id), item.name]));
-}
+const namesByItemId = () => itemCatalog.namesById();
 
 // a player's standing is counted only for the character they pinned. holding thousands of
 // everything else is worth nothing here, which is what keeps one rich account from owning

--- a/backend/utils/itemCatalog.js
+++ b/backend/utils/itemCatalog.js
@@ -1,0 +1,72 @@
+const Item = require("../models/Item");
+
+// the item catalog is reference data: it changes when an admin edits an item and at no
+// other time, but the market grid was re-reading all of it on every request. that is a
+// half-megabyte fetch to atlas per page view, and atlas is the slowest thing we have.
+const TTL_MS = 5 * 60 * 1000;
+
+let cached = null;
+let loadedAt = 0;
+let inflight = null;
+// bumped on every load, so anything derived from the catalog can tell it has turned over
+// without comparing clocks two loads could share
+let generation = 0;
+
+function invalidate() {
+  cached = null;
+  loadedAt = 0;
+}
+
+// a cache the writers have to remember to clear goes stale the first time somebody adds a
+// route, so `models/Item.js` clears it on every write instead of the call sites doing it.
+// bulkWrite fires no hook and calls invalidate() by hand.
+
+// one loader shared by concurrent callers: a cold cache under load must not send the same
+// half-megabyte query several times over
+async function all() {
+  if (cached && Date.now() - loadedAt < TTL_MS) return cached;
+  if (!inflight) {
+    inflight = Item.find({})
+      .lean()
+      .then((items) => {
+        cached = items;
+        loadedAt = Date.now();
+        generation += 1;
+        inflight = null;
+        return items;
+      })
+      .catch((err) => {
+        inflight = null;
+        throw err;
+      });
+  }
+  return inflight;
+}
+
+// the filters the market grid uses, matched in memory. name is a case-insensitive
+// contains, the same thing the regex handed to mongo did.
+async function find({ name, rarity, caseId } = {}) {
+  const items = await all();
+  const needle = name ? String(name).toLowerCase() : null;
+  const wantCase = caseId ? String(caseId) : null;
+  return items.filter((item) => {
+    if (needle && !String(item.name || "").toLowerCase().includes(needle)) return false;
+    if (rarity && String(item.rarity) !== String(rarity)) return false;
+    if (wantCase && String(item.case) !== wantCase) return false;
+    return true;
+  });
+}
+
+// every catalog id mapped to the character behind it, rebuilt only when the cache turns over
+let nameById = null;
+let nameByIdFor = -1;
+async function namesById() {
+  const items = await all();
+  if (!nameById || nameByIdFor !== generation) {
+    nameById = new Map(items.map((item) => [String(item._id), item.name]));
+    nameByIdFor = generation;
+  }
+  return nameById;
+}
+
+module.exports = { all, find, namesById, invalidate, TTL_MS };

--- a/backend/utils/itemValue.js
+++ b/backend/utils/itemValue.js
@@ -63,7 +63,10 @@ async function recomputeCaseValues(caseId) {
   const ops = Object.entries(values).map(([id, v]) => ({
     updateOne: { filter: { _id: id }, update: { $set: { baseValue: v } } },
   }));
-  if (ops.length) await Item.bulkWrite(ops);
+  if (ops.length) {
+    await Item.bulkWrite(ops);
+    require("./itemCatalog").invalidate(); // bulkWrite fires no model hook
+  }
 
   const { total, rangeTable, configHash, rarityTableVersion } = buildRangeTable(caseDoc);
   if (configHash && configHash !== caseDoc.configHash) {

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -4,7 +4,7 @@ import { toast } from "react-toastify";
 import UserContext from "../../UserContext";
 import { dropPlinko } from "../../services/games/GamesServices";
 import { DROP_DURATION_S, MAX_BET, PlinkoRisk } from "./plinkoBoard";
-import { autoStep } from "./autoRun";
+import { DropOutcome, autoStep, outcomeFor } from "./autoRun";
 import { PlinkoBall, PlinkoDropResult } from "./Plinko.types";
 import i18n from "../../i18n";
 
@@ -47,14 +47,14 @@ export const usePlinkoServices = () => {
     pendingStake.current = Math.max(0, pendingStake.current - stake);
   };
 
-  const fireDrop = async (): Promise<boolean> => {
+  const fireDrop = async (): Promise<DropOutcome> => {
     if (userData == null) {
       toogleUserFlow(true);
-      return false;
+      return "stop";
     }
     if (available() < betValue) {
       toast.error(i18n.t("blackjack.insufficientFunds"), { theme: "dark" });
-      return false;
+      return "stop";
     }
     const stake = betValue;
     pendingStake.current += stake;
@@ -67,11 +67,16 @@ export const usePlinkoServices = () => {
       // balance on its own schedule, and a dropped frame must not strand a stake and
       // lock a player out of money they still have
       window.setTimeout(() => releaseStake(stake), DROP_DURATION_S * 1000);
-      return true;
+      return "ok";
     } catch (error: any) {
       releaseStake(stake);
-      toast.error(error?.response?.data?.message || "Could not drop the ball", { theme: "dark" });
-      return false;
+      const outcome = outcomeFor(error?.response?.status);
+      // a retryable refusal is the server being busy, so it is not worth a toast every
+      // time; the run simply tries that ball again
+      if (outcome === "stop") {
+        toast.error(error?.response?.data?.message || "Could not drop the ball", { theme: "dark" });
+      }
+      return outcome;
     } finally {
       setPendingDrops((n) => n - 1);
     }
@@ -119,9 +124,16 @@ export const usePlinkoServices = () => {
       if (step === "wait") return;
       autoLeftRef.current -= 1;
       setAutoLeft(autoLeftRef.current);
-      const ok = await fireDropRef.current();
-      if (!ok) stopAuto();
-      else if (autoLeftRef.current <= 0) stopAuto();
+      const outcome = await fireDropRef.current();
+      if (outcome === "retry") {
+        // hand the ball back: the server refused for something that clears on its own,
+        // so the run still finishes every ball it was asked for
+        autoLeftRef.current += 1;
+        setAutoLeft(autoLeftRef.current);
+        return;
+      }
+      if (outcome === "stop") return stopAuto();
+      if (autoLeftRef.current <= 0) stopAuto();
     };
     tick();
     autoTimer.current = setInterval(tick, AUTO_DROP_INTERVAL_MS);
@@ -135,6 +147,7 @@ export const usePlinkoServices = () => {
     if (!canDrop) return;
     fireDrop();
   };
+
 
   // guarded by key so a duplicate animation-complete cannot double-record a ball
   const settleBall = useCallback((ball: PlinkoBall) => {

--- a/src/pages/Plinko/autoRun.test.ts
+++ b/src/pages/Plinko/autoRun.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { autoStep } from "./autoRun";
+import { autoStep, outcomeFor } from "./autoRun";
 
 const state = (over: Partial<Parameters<typeof autoStep>[0]> = {}) => ({
   left: 100,
@@ -15,8 +15,12 @@ describe("an auto run", () => {
     expect(autoStep(state())).toBe("fire");
   });
 
-  test("ends when the count runs out", () => {
+  test("ends when the count runs out and the board is clear", () => {
     expect(autoStep(state({ left: 0 }))).toBe("done");
+  });
+
+  test("does not call it done while a ball may still need another try", () => {
+    expect(autoStep(state({ left: 0, inFlight: 2 }))).toBe("wait");
   });
 
   test("waits instead of spending a ball when the board is full", () => {
@@ -34,5 +38,19 @@ describe("an auto run", () => {
 
   test("counts the board before the wallet, so a full board never reads as broke", () => {
     expect(autoStep(state({ available: 0, inFlight: 12 }))).toBe("wait");
+  });
+});
+
+describe("a refused drop", () => {
+  test("is retryable when the server says it lost a race or is rate limiting", () => {
+    expect(outcomeFor(503)).toBe("retry");
+    expect(outcomeFor(429)).toBe("retry");
+  });
+
+  test("ends the run when the refusal is the player's to fix", () => {
+    expect(outcomeFor(400)).toBe("stop");
+    expect(outcomeFor(401)).toBe("stop");
+    expect(outcomeFor(500)).toBe("stop");
+    expect(outcomeFor(undefined)).toBe("stop");
   });
 });

--- a/src/pages/Plinko/autoRun.ts
+++ b/src/pages/Plinko/autoRun.ts
@@ -2,6 +2,15 @@
 // a pure function: this is the part that decides whether a hundred-ball run finishes.
 export type AutoStep = "fire" | "wait" | "done" | "broke";
 
+// what a finished drop request means for the run. a refusal the server calls retryable is
+// the board being busy, not the player being out of money, so it costs a tick and no ball.
+export type DropOutcome = "ok" | "retry" | "stop";
+
+// 503 is the server saying it lost a race with another drop; 429 is its own rate limit.
+// both clear on their own, so neither should end a hundred-ball run.
+export const outcomeFor = (status?: number): DropOutcome =>
+  status === 503 || status === 429 ? "retry" : "stop";
+
 export interface AutoState {
   left: number;
   inFlight: number;
@@ -11,7 +20,9 @@ export interface AutoState {
 }
 
 export const autoStep = ({ left, inFlight, available, bet, maxInFlight }: AutoState): AutoStep => {
-  if (left <= 0) return "done";
+  // a ball still in the air may yet come back needing another try, so the run is only
+  // finished once the board is clear as well as the count
+  if (left <= 0) return inFlight > 0 ? "wait" : "done";
   // the board is full: skip this tick without spending a ball, so the run paces itself
   // against how fast balls actually land rather than against a fixed timer
   if (inFlight >= maxInFlight) return "wait";


### PR DESCRIPTION
**Problem**

Production logged 76 money operations rolled back on write conflicts in one sixteen-minute burst today (62 `chargeUser`, 14 `creditUser`), every one labelled `TransientTransactionError`. That label is mongo saying the transaction aborted having committed nothing and can safely be run again.

What the rollbacks did:

- `chargeUser` returning null is reported to players as **"Insufficient balance"**. Sixty-two times, funded players were told they were broke.
- `creditUser` returning null means the payout **never happened**: the stake was taken and the winnings were not paid.

This is the server-side half of the plinko report. Concurrent drops from one player produced bursts of transactions on their own User document; the refusals stopped the auto run. #225 fixed the client-side pacing but not this.

**Change**

- `runAtomic` retries a `TransientTransactionError` with a fresh session and jittered backoff, and deliberately never retries `UnknownTransactionCommitResult`, which may already have landed. The rollback log is now one line with the code and labels instead of a thirty-line driver stack.
- Plinko re-reads the balance on a failed charge and answers **503** rather than 400 when the wallet was actually funded. The auto run treats 503 and 429 as the board being busy: it hands the ball back and carries on instead of ending the run.
- `chargeUser` keeps returning null on purpose. `battleEngine` refunds everyone it already charged on a null and `blackjack` voids the hand and clears `pendingAction`; making it throw would skip both and trade a rare wrong message for stuck hands and money left charged.
- `scripts/payMissedPayouts.js` settles the credits the conflicts lost, matching rolls that owed a payout against the win rows that exist. Dry run unless given `--apply`, and safe to run twice (a settled roll carries `meta.reconciledRoll`).
- Reads from Atlas are throughput-capped near 100 KB/s, so the 1246-item catalog costs about five seconds, and `GET /marketplace` fetched all of it on every request to return thirty rows. It is cached in the process now, invalidated from `models/Item.js` so a new write path cannot forget to, and the listings aggregation drops the thousand-id `$in` when nothing was filtered.

Measured on the box: `/marketplace` 5.35s and `/items` 5.53s before; the catalog fetch was 4.9s of that and the aggregation is 184ms without the `$in`.

**Tests**

Backend 877 passed (89 suites), frontend unit 121, lint at baseline, build clean, 26 e2e. New: `moneyRetry.test.js` for what is and is not safe to retry and for the log line; `itemCatalog.test.js` for invalidation on create, edit, delete and `bulkWrite`, for the filters, and for a cold cache under concurrent callers sending one query; three more cases in `autoRun.test.ts`.

Two things worth flagging. `clearDb` in the test harness wipes collections through the raw driver, which fires no model hook, so it invalidates the cache by hand. And the cache is per process: pm2 runs one instance today, but cluster mode would need the invalidation to fan out.

**Not included**

I could not reproduce the driver-level failure locally: `withTransaction` retried and recovered in every scenario I built, including 200 concurrent charges on one document and a transaction held open across them. The outer retry is therefore insurance based on what production logged, not a fix I can demonstrate failing without it. The likely amplifier is the Atlas throughput cap keeping every transaction open far longer than it should be, which is the infrastructure decision still outstanding.