### PR TITLE
fix(catalog): serve the expired catalog while it refreshes behind the request

### DIFF
--- a/backend/__tests__/integration/itemCatalog.test.js
+++ b/backend/__tests__/integration/itemCatalog.test.js
@@ -60,6 +60,38 @@ describe("the cached item catalog", () => {
     expect((await itemCatalog.namesById()).get(String(item._id))).toBe("Renamed");
   });
 
+  it("serves the expired copy straight away and refreshes behind it", async () => {
+    await makeItem("Yuuma");
+    await itemCatalog.all();
+
+    // a write from outside this process: the model hook never fires, so only the ttl
+    // can notice it
+    await Item.collection.insertOne({ name: "Momiji", image: "m.png", rarity: "3", baseValue: 1 });
+
+    const realNow = Date.now();
+    const clock = jest.spyOn(Date, "now").mockReturnValue(realNow + itemCatalog.TTL_MS + 1);
+
+    // the expired read comes back with what it already had rather than waiting
+    expect((await itemCatalog.all()).map((i) => i.name)).toEqual(["Yuuma"]);
+
+    clock.mockRestore();
+
+    // and the refresh it kicked off behind that read lands on its own
+    for (let i = 0; i < 50 && (await itemCatalog.all()).length < 2; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect((await itemCatalog.all()).map((i) => i.name).sort()).toEqual(["Momiji", "Yuuma"]);
+  });
+
+  it("blocks on a write it made itself, because stale is wrong after that", async () => {
+    await makeItem("Yuuma");
+    await itemCatalog.all();
+
+    await makeItem("Momiji");
+
+    expect((await itemCatalog.all()).map((i) => i.name).sort()).toEqual(["Momiji", "Yuuma"]);
+  });
+
   it("sends one query when several callers ask a cold cache at once", async () => {
     await makeItem("Yuuma");
     itemCatalog.invalidate();

--- a/backend/utils/itemCatalog.js
+++ b/backend/utils/itemCatalog.js
@@ -23,8 +23,7 @@ function invalidate() {
 
 // one loader shared by concurrent callers: a cold cache under load must not send the same
 // half-megabyte query several times over
-async function all() {
-  if (cached && Date.now() - loadedAt < TTL_MS) return cached;
+function load() {
   if (!inflight) {
     inflight = Item.find({})
       .lean()
@@ -41,6 +40,26 @@ async function all() {
       });
   }
   return inflight;
+}
+
+// how long a failed background refresh waits before it is worth trying again
+const RETRY_MS = 5000;
+let refreshedAt = 0;
+
+// the ttl is a backstop, not correctness: a real write clears the cache outright, and only
+// a write this process did not make can leave it stale. so an expired copy is served while
+// the refresh runs behind it. blocking on it instead made one request every five minutes
+// wait out the whole catalog read, which on this link is five seconds.
+async function all() {
+  if (cached) {
+    const now = Date.now();
+    if (now - loadedAt >= TTL_MS && now - refreshedAt >= RETRY_MS) {
+      refreshedAt = now;
+      load().catch(() => {}); // stale is still better than making the caller wait
+    }
+    return cached;
+  }
+  return load();
 }
 
 // the filters the market grid uses, matched in memory. name is a case-insensitive


### PR DESCRIPTION
**Problem**

Found while monitoring the #226 deploy. Sampling `/items` on the box every 25 seconds:

```
14:32:13  items=0.037s
14:32:38  items=4.897s   <- ttl expired, this caller paid for the whole reload
14:33:09  items=0.018s
```

One request every five minutes waits out the entire catalog read while every other request in the same window is served in about 20ms.

**Change**

The TTL is only a backstop for a write this process did not make: a write it *did* make clears the cache outright through the model hook. So an expired copy is good enough to serve while the refresh runs behind the request. A write the process made itself still forces the next read to block, because stale is simply wrong after that.

A failed background refresh keeps serving what it has and waits five seconds before trying again, so a database outage cannot turn into a query storm.

**Tests**

Backend 879 passed. Two new cases: an expired cache serves the copy it already had and the refresh lands on its own afterwards (using a raw `collection.insertOne` so no model hook fires, which is the only way the TTL is what notices); and a write made through the model still blocks the next read.