### PR TITLE
fix(money): stop handing the whole inventory back from every wallet write

### DIFF
--- a/backend/__tests__/integration/walletWrites.test.js
+++ b/backend/__tests__/integration/walletWrites.test.js
@@ -9,9 +9,8 @@ beforeAll(setupDb);
 afterEach(clearDb);
 afterAll(teardownDb);
 
-// a wallet write used to hand the whole document back. on production that is a two
-// megabyte inventory for the deepest account, which measured 20.5 seconds against 31 ms
-// with the inventory left out, and every bet does two of them.
+// a wallet write used to hand the whole document back: two megabytes for the deepest
+// account on production, 20.5 seconds against 31 ms without it, and a bet does two.
 const deepUser = async (entries = 200) => {
   const s = uniqueSuffix();
   return User.create({

--- a/backend/__tests__/integration/walletWrites.test.js
+++ b/backend/__tests__/integration/walletWrites.test.js
@@ -1,0 +1,60 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const { chargeUser, creditUser, awardXp, TX } = require("../../utils/economy");
+
+beforeAll(setupDb);
+afterEach(clearDb);
+afterAll(teardownDb);
+
+// a wallet write used to hand the whole document back. on production that is a two
+// megabyte inventory for the deepest account, which measured 20.5 seconds against 31 ms
+// with the inventory left out, and every bet does two of them.
+const deepUser = async (entries = 200) => {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 1000,
+    inventory: Array.from({ length: entries }, () => ({ rarity: "1" })),
+  });
+};
+
+const heldBy = async (id) => (await User.findById(id).lean()).inventory.length;
+
+describe("a wallet write", () => {
+  it("does not carry the inventory back with the balance", async () => {
+    const user = await deepUser();
+
+    const charged = await chargeUser(user._id, 100, { type: TX.PLINKO_BET, meta: {} });
+    expect(charged.walletBalance).toBe(900);
+    expect(charged.inventory).toBeUndefined();
+
+    const credited = await creditUser(user._id, 250, 250, { type: TX.PLINKO_WIN, meta: {} });
+    expect(credited.walletBalance).toBe(1150);
+    expect(credited.inventory).toBeUndefined();
+
+    const levelled = await awardXp(user._id, 5000);
+    expect(levelled.xp).toBe(5500);
+    expect(levelled.inventory).toBeUndefined();
+  });
+
+  it("leaves the stored inventory alone while doing it", async () => {
+    const user = await deepUser(37);
+
+    await chargeUser(user._id, 10, { type: TX.PLINKO_BET, meta: {} });
+    await creditUser(user._id, 10, 0, { type: TX.PLINKO_WIN, meta: {} });
+    await awardXp(user._id, 10);
+
+    expect(await heldBy(user._id)).toBe(37);
+  });
+
+  it("still refuses a charge the balance cannot cover", async () => {
+    const user = await deepUser(5);
+    expect(await chargeUser(user._id, 5000, { type: TX.PLINKO_BET, meta: {} })).toBeNull();
+    expect((await User.findById(user._id)).walletBalance).toBe(1000);
+  });
+});

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -14,7 +14,7 @@ const BlackjackGameController = require("../games/blackjack");
 const DiceGameController = require("../games/dice");
 const MinesGameController = require("../games/mines");
 const HiloGameController = require("../games/hilo");
-const { calculateLevelFromXp, recordTransaction, runAtomic, TX } = require("../utils/economy");
+const { calculateLevelFromXp, recordTransaction, runAtomic, TX, WITHOUT_INVENTORY } = require("../utils/economy");
 const referrals = require("../utils/referrals");
 const fandom = require("../utils/fandom");
 const { addUniqueInfoToItem, toInventoryEntry } = require("../utils/caseOpening");
@@ -114,7 +114,9 @@ module.exports = (io) => {
           $inc: { walletBalance: -cost, xp: cost * 5 },
           $push: { inventory: { $each: winningItems.map(toInventoryEntry) } },
         };
-        const options = { new: true, session };
+        // the push has just made this inventory bigger; handing it back would cost more
+        // than the opening did
+        const options = { new: true, projection: WITHOUT_INVENTORY, session };
 
         // spend the openings in the same update that hands over the items, and require
         // the count to still cover it, so two concurrent opens cannot overdraw one grant

--- a/backend/routes/giftRoutes.js
+++ b/backend/routes/giftRoutes.js
@@ -8,6 +8,7 @@ const gift = require("../utils/dailyGift");
 const { roll, TOTAL } = require("../utils/provablyFair");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
+const { WITHOUT_INVENTORY } = require("../utils/economy");
 
 const living = (user, now = new Date()) =>
   (user.freeOpens || []).filter((g) => g.remaining > 0 && new Date(g.expiresAt) > now);
@@ -200,7 +201,7 @@ router.post("/spin", isAuthenticated, async (req, res) => {
         giftStreak: streak,
       },
     };
-    const options = { new: true };
+    const options = { new: true, projection: WITHOUT_INVENTORY };
     if (existing) {
       update.$inc = { "freeOpens.$[g].remaining": opens };
       update.$set["freeOpens.$[g].expiresAt"] = expiresAt;

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -13,7 +13,7 @@ const Transaction = require("../models/Transaction");
 const authMiddleware = require("../middleware/authMiddleware");
 const { loginLimiter, registerLimiter, registerDailyLimiter } = require("../middleware/rateLimit");
 const { sellValue } = require("../utils/itemValue");
-const { creditUser, recordTransaction, runAtomic, TX } = require("../utils/economy");
+const { creditUser, recordTransaction, runAtomic, TX, WITHOUT_INVENTORY } = require("../utils/economy");
 const { findReferrer, payReferralBonuses } = require("../utils/referrals");
 const { sellUniqueIds } = require("../utils/inventorySell");
 const getRandomPlaceholderImage = require("../utils/placeholderImages");
@@ -696,7 +696,7 @@ router.post('/claimBonus', authMiddleware.isAuthenticated, async (req, res) => {
           $inc: { walletBalance: currentBonus },
           $set: { nextBonus, bonusAmount: nextBonusAmount },
         },
-        { new: true, session }
+        { new: true, projection: WITHOUT_INVENTORY, session }
       );
       if (!u) return null;
       await recordTransaction(

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -194,9 +194,8 @@ async function ledgerSupply() {
   return -(await accountBalance(MINT));
 }
 
-// what a wallet write is allowed to hand back. never the inventory: a deep one runs to two
-// megabytes, and returning it turned a single bet into a twenty-second write on a link that
-// carries about 100 KB/s. nothing downstream of a money write reads it.
+// what a wallet write hands back. never the inventory: a deep one is two megabytes, and
+// returning it made a single bet a twenty-second write on a 100 KB/s link.
 const WITHOUT_INVENTORY = { inventory: 0 };
 
 // debit `cost` if the balance covers it, with its ledger row in the same transaction:

--- a/backend/utils/economy.js
+++ b/backend/utils/economy.js
@@ -194,6 +194,11 @@ async function ledgerSupply() {
   return -(await accountBalance(MINT));
 }
 
+// what a wallet write is allowed to hand back. never the inventory: a deep one runs to two
+// megabytes, and returning it turned a single bet into a twenty-second write on a link that
+// carries about 100 KB/s. nothing downstream of a money write reads it.
+const WITHOUT_INVENTORY = { inventory: 0 };
+
 // debit `cost` if the balance covers it, with its ledger row in the same transaction:
 // a failed row rolls the charge back and returns null, like insufficient funds
 async function chargeUser(userId, cost, { awardXp = true, type, meta, counterparty, session } = {}) {
@@ -205,7 +210,7 @@ async function chargeUser(userId, cost, { awardXp = true, type, meta, counterpar
     const user = await User.findOneAndUpdate(
       { _id: userId, walletBalance: { $gte: cost } },
       { $inc: inc },
-      { new: true, session: s }
+      { new: true, projection: WITHOUT_INVENTORY, session: s }
     );
     if (!user) return null;
 
@@ -246,7 +251,7 @@ async function creditUser(userId, amount, winnings = 0, { type, meta, counterpar
     const user = await User.findByIdAndUpdate(
       userId,
       { $inc: { walletBalance: amount, weeklyWinnings: winnings } },
-      { new: true, session: s }
+      { new: true, projection: WITHOUT_INVENTORY, session: s }
     );
     if (!user) return null;
 
@@ -275,7 +280,7 @@ async function awardXp(userId, xpAmount) {
   const user = await User.findByIdAndUpdate(
     userId,
     { $inc: { xp: xpAmount } },
-    { new: true }
+    { new: true, projection: WITHOUT_INVENTORY }
   );
   if (!user) return null;
 
@@ -298,6 +303,7 @@ module.exports = {
   accountBalance,
   ledgerSupply,
   runAtomic,
+  WITHOUT_INVENTORY,
   isTransient,
   describeMoneyError,
   probeTransactions,

--- a/backend/utils/market.js
+++ b/backend/utils/market.js
@@ -3,7 +3,7 @@ const Marketplace = require("../models/Marketplace");
 const MarketSale = require("../models/MarketSale");
 const BuyOrder = require("../models/BuyOrder");
 const Notification = require("../models/Notification");
-const { creditUser, recordTransaction, runAtomic, TX } = require("./economy");
+const { creditUser, recordTransaction, runAtomic, TX, WITHOUT_INVENTORY } = require("./economy");
 const { marketFee, sellerNet } = require("./itemValue");
 const { HOUSE, ESCROW } = require("./accounts");
 const fandom = require("./fandom");
@@ -116,7 +116,7 @@ async function purchaseListing({ listingId, buyerId, io }) {
     const u = await User.findOneAndUpdate(
       { _id: buyerId, walletBalance: { $gte: claimed.price } },
       { $inc: { walletBalance: -claimed.price }, $push: { inventory: inventoryEntryFrom(claimed) } },
-      { new: true, session }
+      { new: true, projection: WITHOUT_INVENTORY, session }
     );
     if (!u) return null;
     // player-to-player, so the buyer and seller legs carry no counterparty; they and the
@@ -163,7 +163,7 @@ async function purchaseListing({ listingId, buyerId, io }) {
       const r = await User.findOneAndUpdate(
         { _id: buyerId },
         { $inc: { walletBalance: claimed.price }, $pull: { inventory: { uniqueId: claimed.uniqueId } } },
-        { new: true, session }
+        { new: true, projection: WITHOUT_INVENTORY, session }
       );
       await recordTransaction(
         {


### PR DESCRIPTION
**Problem**

This is the plinko slowness, and it is much worse than the client-side pacing I fixed in #225.

`chargeUser`, `creditUser` and `awardXp` all use `{ new: true }` and no projection, so **the entire user document, inventory included, comes back over the Atlas link on every bet, every payout and every case opening.** Measured on production against the deepest account (21,456 items, a 1960 KB document):

```
findOneAndUpdate, no projection   20473 ms   returned 2054 KB
findOneAndUpdate, inventory: 0       31 ms   returned    0.9 KB
```

660x. A game that charges and then credits pays it twice, so one plinko drop costs that player about forty seconds. That is the report: balls taking ten seconds to fall and the later ones worse, because they queue.

It is also, I think, the real cause of the write conflicts from earlier today. A transaction that holds a lock on a user document for twenty seconds while streaming two megabytes will collide with the same player's next bet every time. The retry in #226 was treating the symptom.

**Change**

`WITHOUT_INVENTORY` in `utils/economy.js`, applied to every write that updates a user and reads the result back: the three in `economy.js`, the case open (`gamesRoutes.js`), the market buy and its reversal (`utils/market.js`), the bonus claim (`userRoutes.js`) and the daily gift (`giftRoutes.js`).

It is an **exclusion**, not a whitelist, on purpose. A whitelist would hand `undefined` to any caller reading a field nobody remembered, and the callers read `walletBalance`, `xp`, `level`, `username`, `profilePicture`, `fixedItem`, `weeklyWinnings`, `nextBonus` and `freeOpens` between them. Excluding the one field that is big and provably unread is the safe shape.

`games/upgrade.js` and `utils/inventorySell.js` deliberately keep the full document: both read what their `$pull` removed, so the inventory *is* the result.

**Tests**

Backend 880 passed (90 suites). New `walletWrites.test.js`: a charge, a credit and an xp award all come back without the inventory field, the stored inventory is untouched by all three, and an unaffordable charge is still refused.