### PR TITLE
chore(market): stop sending a description the grid never renders

### DIFF
--- a/backend/__tests__/integration/market.test.js
+++ b/backend/__tests__/integration/market.test.js
@@ -369,3 +369,15 @@ describe("buy orders", () => {
     expect(res.body.orders[1]).toEqual({ price: 50, quantity: 1 });
   });
 });
+
+test("the browse grid leaves out the description it never renders", async () => {
+  const item = await Item.create({ name: `d-${uniqueSuffix()}`, image: "x", rarity: "3", baseValue: 100, description: "a long line of flavour text nobody sees here" });
+
+  const res = await request(app).get("/marketplace").set(...auth(await makeUser()));
+
+  expect(res.status).toBe(200);
+  const row = res.body.items.find((i) => String(i._id) === String(item._id));
+  expect(row).toBeTruthy();
+  expect(row.name).toBe(item.name);
+  expect(row).not.toHaveProperty("description");
+});

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -267,8 +267,11 @@ module.exports = (io) => {
 
       let rows = items.map((item) => {
         const md = byItem.get(item._id.toString());
+        // the grid never renders a description and it is the biggest field on an item, so
+        // it is most of this payload for nothing. the collections page is where one shows.
+        const { description, ...card } = item;
         return {
-          ...item,
+          ...card,
           sellValue: sellValue(item.baseValue),
           cheapestPrice: md ? md.cheapestPrice : null,
           totalListings: md ? md.totalListings : 0,


### PR DESCRIPTION
The browse payload carried every item's `description`, which is the largest field on an item and roughly half that response, for nothing. Nothing in `src/pages/Market` renders one. Descriptions are shown on the collections page (`ItemCard.tsx:119`), which reads its own endpoint and is untouched.

One test: an item with a description appears in the grid with its name intact and no `description` property.