### PR TITLE
feat(predictions): show what a position cost next to what selling it pays

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -758,6 +758,9 @@
     "working": "Läuft...",
     "youHold": "Du hältst {{count}}",
     "youPay": "Du zahlst",
+    "loss": "Verlust",
+    "profit": "Gewinn",
+    "youPaid": "Du hast gezahlt",
     "youReceive": "Du erhältst"
   },
   "profile": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -758,6 +758,9 @@
     "working": "Working...",
     "youHold": "You hold {{count}}",
     "youPay": "You pay",
+    "loss": "Loss",
+    "profit": "Profit",
+    "youPaid": "You paid",
     "youReceive": "You receive"
   },
   "profile": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -758,6 +758,9 @@
     "working": "Procesando...",
     "youHold": "Tienes {{count}}",
     "youPay": "Pagas",
+    "loss": "Pérdida",
+    "profit": "Ganancia",
+    "youPaid": "Pagaste",
     "youReceive": "Recibes"
   },
   "profile": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -758,6 +758,9 @@
     "working": "En cours...",
     "youHold": "Vous détenez {{count}}",
     "youPay": "Vous payez",
+    "loss": "Perte",
+    "profit": "Profit",
+    "youPaid": "Vous avez payé",
     "youReceive": "Vous recevez"
   },
   "profile": {

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -758,6 +758,9 @@
     "working": "Memproses...",
     "youHold": "Kamu punya {{count}}",
     "youPay": "Kamu bayar",
+    "loss": "Rugi",
+    "profit": "Untung",
+    "youPaid": "Kamu bayar",
     "youReceive": "Kamu terima"
   },
   "profile": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -758,6 +758,9 @@
     "working": "In corso...",
     "youHold": "Ne hai {{count}}",
     "youPay": "Paghi",
+    "loss": "Perdita",
+    "profit": "Profitto",
+    "youPaid": "Hai pagato",
     "youReceive": "Ricevi"
   },
   "profile": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -758,6 +758,9 @@
     "working": "処理中...",
     "youHold": "保有 {{count}}",
     "youPay": "支払額",
+    "loss": "損失",
+    "profit": "利益",
+    "youPaid": "支払額",
     "youReceive": "受取額"
   },
   "profile": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -758,6 +758,9 @@
     "working": "처리 중...",
     "youHold": "보유 {{count}}",
     "youPay": "지불액",
+    "loss": "손실",
+    "profit": "수익",
+    "youPaid": "지불한 금액",
     "youReceive": "수령액"
   },
   "profile": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -758,6 +758,9 @@
     "working": "Processando...",
     "youHold": "Você tem {{count}}",
     "youPay": "Você paga",
+    "loss": "Prejuízo",
+    "profit": "Lucro",
+    "youPaid": "Você pagou",
     "youReceive": "Você recebe"
   },
   "profile": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -758,6 +758,9 @@
     "working": "Đang xử lý...",
     "youHold": "Bạn có {{count}}",
     "youPay": "Bạn trả",
+    "loss": "Lỗ",
+    "profit": "Lợi nhuận",
+    "youPaid": "Bạn đã trả",
     "youReceive": "Bạn nhận"
   },
   "profile": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -758,6 +758,9 @@
     "working": "处理中...",
     "youHold": "你持有 {{count}}",
     "youPay": "支付",
+    "loss": "亏损",
+    "profit": "盈利",
+    "youPaid": "你支付了",
     "youReceive": "到账"
   },
   "profile": {

--- a/src/pages/Predictions/Market/Market.services.ts
+++ b/src/pages/Predictions/Market/Market.services.ts
@@ -161,6 +161,11 @@ export const useMarketServices = () => {
     return outcome ? outcome.avgPriceBps : 0;
   };
 
+  const spentOf = (key: string) => {
+    const outcome = market ? market.outcomes.find((o) => o.key === key) : null;
+    return outcome ? outcome.spent : 0;
+  };
+
   const colorOf = useMemo(() => {
     const byKey = new Map((market ? market.outcomes : []).map((o, i) => [o.key, OUTCOME_COLORS[i % OUTCOME_COLORS.length]]));
     return (key: string) => byKey.get(key) || OUTCOME_COLORS[0];
@@ -277,6 +282,7 @@ export const useMarketServices = () => {
     bumpShares: (by: number) => setSharesInput(String(clamp(shares + by))),
     heldOf,
     avgOf,
+    spentOf,
     colorOf,
     movedOf: (key: string) => moved[key] || null,
   };

--- a/src/pages/Predictions/Market/Market.types.ts
+++ b/src/pages/Predictions/Market/Market.types.ts
@@ -35,6 +35,7 @@ export interface MarketViewProps {
   bumpShares: (by: number) => void;
   heldOf: (key: string) => number;
   avgOf: (key: string) => number;
+  spentOf: (key: string) => number;
   colorOf: (key: string) => string;
   movedOf: (key: string) => "up" | "down" | null;
 }

--- a/src/pages/Predictions/Market/TradePanel.tsx
+++ b/src/pages/Predictions/Market/TradePanel.tsx
@@ -1,6 +1,7 @@
 import Monetary from "../../../components/Monetary";
 import { toPercent } from "../../../services/predictions/PredictionService";
 import { MarketViewProps } from "./Market.types";
+import { paidFor, profitOf } from "./position";
 import i18n from "../../../i18n";
 
 type Props = Pick<
@@ -24,6 +25,8 @@ type Props = Pick<
   | "setSharesTo"
   | "bumpShares"
   | "heldOf"
+  | "avgOf"
+  | "spentOf"
   | "colorOf"
 >;
 
@@ -55,6 +58,8 @@ const TradePanel: React.FC<Props> = ({
   setSharesTo,
   bumpShares,
   heldOf,
+  avgOf,
+  spentOf,
   colorOf,
 }) => {
   if (!market || !selected) return null;
@@ -63,6 +68,9 @@ const TradePanel: React.FC<Props> = ({
   if (!outcome) return null;
 
   const held = heldOf(selected);
+  // what the shares being sold actually cost, so the quote can be read against something
+  const paid = paidFor(spentOf(selected), shares, held);
+  const result = action === "sell" ? profitOf(quote ? quote.amount : null, paid) : null;
   // a yes-or-no market has no outcome list above it, so the two prices are the picker
   const binary = market.outcomes.length === 2;
   const closed = market.status !== "open";
@@ -197,6 +205,26 @@ const TradePanel: React.FC<Props> = ({
             {quoting ? <Pending w="w-20" /> : quote ? `${toPercent(quote.startBps)}% → ${toPercent(quote.endBps)}%` : "-"}
           </span>
         </div>
+        {action === "sell" && held > 0 && (
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-ink-muted">{i18n.t("predictions.youPaid")}</span>
+            <span className="text-ink-soft tabular-nums">
+              <Monetary value={paid} />
+              {avgOf(selected) > 0 && ` · ${(avgOf(selected) / 100).toFixed(1)}%`}
+            </span>
+          </div>
+        )}
+        {result && paid > 0 && (
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-ink-muted">
+              {i18n.t(result.profit >= 0 ? "predictions.profit" : "predictions.loss")}
+            </span>
+            <span className={`tabular-nums ${result.profit >= 0 ? "text-emerald-400" : "text-red-400"}`}>
+              {result.profit >= 0 ? "+" : "-"}
+              <Monetary value={Math.abs(result.profit)} /> ({result.pct}%)
+            </span>
+          </div>
+        )}
         {action === "buy" && quote && (
           <div className="flex items-center justify-between text-xs">
             <span className="text-ink-muted">{i18n.t("predictions.ifItHappens")}</span>

--- a/src/pages/Predictions/Market/position.test.ts
+++ b/src/pages/Predictions/Market/position.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { paidFor, profitOf } from "./position";
+
+describe("what a sale cost", () => {
+  test("the whole position carries everything spent on it", () => {
+    expect(paidFor(367, 660, 660)).toBe(367);
+  });
+
+  test("a partial sale carries its slice", () => {
+    expect(paidFor(367, 330, 660)).toBe(184);
+    expect(paidFor(367, 1, 660)).toBe(1);
+  });
+
+  test("selling more than is held still only counts what is held", () => {
+    expect(paidFor(367, 5000, 660)).toBe(367);
+  });
+
+  test("holding nothing costs nothing, and does not divide by zero", () => {
+    expect(paidFor(0, 10, 0)).toBe(0);
+    expect(paidFor(367, 10, 0)).toBe(0);
+  });
+});
+
+describe("what a sale makes", () => {
+  // the real position that prompted this: 660 shares bought around 55%, quoted at 95.7%
+  test("reads a gain as a gain", () => {
+    expect(profitOf(631, 367)).toEqual({ profit: 264, pct: 72 });
+  });
+
+  test("reads a loss as a loss", () => {
+    expect(profitOf(300, 367)).toEqual({ profit: -67, pct: -18 });
+  });
+
+  test("is blank until there is a quote", () => {
+    expect(profitOf(null, 367)).toBeNull();
+  });
+
+  test("does not divide by a cost of zero", () => {
+    expect(profitOf(50, 0)).toEqual({ profit: 50, pct: 0 });
+  });
+});

--- a/src/pages/Predictions/Market/position.ts
+++ b/src/pages/Predictions/Market/position.ts
@@ -1,0 +1,19 @@
+// what a sale is worth measured against what it cost. showing only the proceeds made a
+// position bought at 55% and quoted at 96% read as a loss to the player holding it.
+
+// the slice of the position being sold. `spent` is the KP that actually left the wallet
+// for the shares still held, so a partial sale carries its share of it.
+export const paidFor = (spent: number, shares: number, held: number) =>
+  held > 0 ? Math.round((spent * Math.min(Math.max(shares, 0), held)) / held) : 0;
+
+export interface SaleResult {
+  profit: number;
+  pct: number;
+}
+
+// null while there is no quote yet: a blank row is honest, a zero is not
+export const profitOf = (proceeds: number | null, paid: number): SaleResult | null => {
+  if (proceeds === null) return null;
+  const profit = proceeds - paid;
+  return { profit, pct: paid > 0 ? Math.round((profit / paid) * 100) : 0 };
+};


### PR DESCRIPTION
**Problem**

Reported from the Yukino market. A player held 660 shares of "No", bought at an average of 55.3% for **367 KP**, and the sell panel quoted:

```
You receive      K₽631
Average price    95.7%
Price after      99% → 92%
```

Every one of those numbers is correct (660 × 95.7% = 631.62, floor 631; 660 shares × 1bp impact walks 99% down to 92.4%). But the panel shows the proceeds with nothing to read them against, so a **72% gain looked like a loss**. The share count and the price paid are easy to conflate in memory, and only one of them was on screen.

**Change**

The market payload already carries `shares`, `spent` and `avgPriceBps` per outcome for the viewer ([predictions.js:50-52](backend/utils/predictions.js#L50-L52)), so this is rendering, not plumbing. `spentOf` is exposed alongside the existing `heldOf`/`avgOf`, and the sell side gains two rows:

```
You paid      K₽367 · 55.3%
Profit        +K₽264 (72%)
```

Prorated when only part of the position is sold, and it reads "Loss" in red when it is one. The arithmetic is in `position.ts` rather than inline in the panel, so it is testable.

**Tests**

8 new cases in `position.test.ts` covering the full sale, partial sales, selling more than is held, a zero position, a gain, a loss, no quote yet, and a zero cost basis. Frontend unit 129 passed, lint at baseline, build clean, 26 e2e passed. Three i18n keys added across all 11 locales, so the parity test still passes.

**Not a bug**

Worth stating plainly since it was reported as one: the pricing curve is correct and nobody lost money. This is a display gap.