### PR TITLE
Stop loading the inventory on every authenticated request

### DIFF
--- a/backend/__tests__/integration/authInventory.test.js
+++ b/backend/__tests__/integration/authInventory.test.js
@@ -1,0 +1,115 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const { isAuthenticated } = require("../../middleware/authMiddleware");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const itemId = new mongoose.Types.ObjectId();
+
+const stack = (n) =>
+  Array.from({ length: n }, (_, i) => ({
+    _id: itemId,
+    uniqueId: `u-${i}`,
+    name: "Keine",
+    image: "keine.png",
+    rarity: "1",
+  }));
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance: 500,
+    ...overrides,
+  });
+}
+
+// the middleware runs on every authenticated request, so anything it carries is paid for
+// on every bet, every case open and every page load
+describe("what isAuthenticated loads", () => {
+  it("leaves the inventory behind", async () => {
+    const user = await makeUser({ inventory: stack(30) });
+    const req = { header: () => `Bearer ${tokenFor(user)}` };
+    let passed = false;
+
+    await isAuthenticated(req, {}, () => {
+      passed = true;
+    });
+
+    expect(passed).toBe(true);
+    expect(req.user.inventory).toBeUndefined();
+  });
+
+  it("still carries everything a route reads off req.user", async () => {
+    const fanRank = { name: "Keine", image: "k.png", rarity: "1", count: 9, rank: 1, fans: 3 };
+    const user = await makeUser({
+      inventory: stack(12),
+      fanRank,
+      selectedBadge: "topFan",
+      cardStyle: "agit",
+      walletBalance: 1234,
+      level: 7,
+    });
+    const req = { header: () => `Bearer ${tokenFor(user)}` };
+    await isAuthenticated(req, {}, () => {});
+
+    expect(req.user.username).toBe(user.username);
+    expect(req.user.walletBalance).toBe(1234);
+    expect(req.user.level).toBe(7);
+    expect(req.user.fanRank.name).toBe("Keine");
+    expect(req.user.selectedBadge).toBe("topFan");
+    expect(req.user.password).toBeUndefined();
+  });
+
+  it("keeps rejecting a revoked token and a disabled account", async () => {
+    const revoked = await makeUser({ inventory: stack(5), tokenVersion: 2 });
+    const token = tokenFor(revoked);
+    const stale = await request(app).get("/users/me").set("Authorization", `Bearer ${token}`);
+    expect(stale.status).toBe(401);
+
+    const off = await makeUser({ inventory: stack(5), disabled: true });
+    const blocked = await request(app).get("/users/me").set("Authorization", `Bearer ${tokenFor(off)}`);
+    expect(blocked.status).toBe(403);
+  });
+});
+
+describe("routes that do need an inventory", () => {
+  it("pins an item, because that route reads its own copy", async () => {
+    await Item.create({ _id: itemId, name: "Keine", image: "keine.png", rarity: "1" });
+    const user = await makeUser({ inventory: stack(3) });
+    const res = await request(app)
+      .put("/users/fixedItem")
+      .set("Authorization", `Bearer ${tokenFor(user)}`)
+      .send({ item: itemId.toString() });
+
+    expect(res.status).toBe(200);
+    const saved = await User.findById(user._id).select("fixedItem").lean();
+    expect(saved.fixedItem.name).toBe("Keine");
+  });
+
+  it("serves the profile with the inventory count intact", async () => {
+    const user = await makeUser({ inventory: stack(4) });
+    const res = await request(app).get("/users/me").set("Authorization", `Bearer ${tokenFor(user)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe(user.username);
+    const stored = await User.findById(user._id).select("inventory").lean();
+    expect(stored.inventory).toHaveLength(4);
+  });
+});

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,6 +1,7 @@
 const jwt = require("jsonwebtoken");
 require("dotenv").config();
 const User = require("../models/User");
+const { WITHOUT_INVENTORY } = require("../utils/economy");
 
 
 const isAuthenticated = async (req, res, next) => {
@@ -20,7 +21,9 @@ const isAuthenticated = async (req, res, next) => {
   // Verify the token
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    const user = await User.findById(decoded.userId).select("-password");
+    // no route reads an inventory off req.user, and it reaches 21k entries: carrying it
+    // here cost the deepest account 20 seconds on every authenticated request
+    const user = await User.findById(decoded.userId).select({ password: 0, ...WITHOUT_INVENTORY });
 
     // a valid token for an account that no longer exists is not a session
     if (!user) {


### PR DESCRIPTION
**Problem.** `isAuthenticated` runs on every request that carries a token and loaded the whole user document, inventory included. Nothing reads it.

Measured against production, three runs each:

| document | `select("-password")` | without inventory |
| --- | --- | --- |
| 1,959.5 KB | **20,367 ms** | 24 ms |
| 974.2 KB | **10,139 ms** | 25 ms |
| 959.2 KB | **10,036 ms** | 33 ms |
| 879.1 KB | **9,157 ms** | 26 ms |
| 1.3 KB (median account) | 33 ms | — |

Size over time on all four is 95.6 to 96.2 KB/s, so this is the Atlas link at its cap and the only variable is how many bytes were asked for.

It is the active players who are heavy. Of the 18 accounts that moved a balance in the last 24 hours the mean document is 116.7 KB and p90 is 258 KB, against a 1.3 KB median across all 2,861 accounts. Inventories reach 21,456 entries; without one, no account exceeds 93.7 KB and every read lands in 24-40 ms.

This is on every game route, so the deepest account paid it on each plinko drop, dice roll and case open, on top of the wallet write that was fixed separately.

**Change.** One projection, reusing `WITHOUT_INVENTORY` from `utils/economy.js`. Nothing references `req.user.inventory` and nothing calls `req.user.save()`; the routes that need an inventory (collections, marketplace, upgrade, fandom, admin, pin) already fetch their own copy.

**Tests.** 5 new cases: the middleware drops the inventory, still carries balance, level, fanRank, badges and the selected style, still rejects a revoked token and a disabled account, and the pin route and profile still work with an inventory present. Full backend suite 897 passing across 92 suites.

Follow-up, not in here: `PUT /users/fixedItem` loads a whole inventory of its own to check that one item exists.