### PR TITLE
Serve every card image from our own origin, and re-host the catalog

### DIFF
--- a/backend/__tests__/integration/artRoute.test.js
+++ b/backend/__tests__/integration/artRoute.test.js
@@ -1,0 +1,94 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const artProxy = require("../../utils/artProxy");
+
+let app;
+let realFetch;
+
+const STEAM = "https://community.akamai.steamstatic.com/economy/image/abc/360fx360f";
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+  realFetch = global.fetch;
+});
+afterEach(async () => {
+  global.fetch = realFetch;
+  await clearDb();
+});
+afterAll(teardownDb);
+
+const pixels = Buffer.from("89504e470d0a1a0a", "hex");
+
+const upstream = (over = {}) => {
+  const headers = new Map(Object.entries({ "content-type": "image/png", "content-length": String(pixels.length), ...over.headers }));
+  return {
+    ok: over.ok !== false,
+    headers: { get: (k) => headers.get(k.toLowerCase()) ?? null },
+    arrayBuffer: async () => (over.body || pixels).buffer.slice(0),
+  };
+};
+
+async function auth() {
+  const s = uniqueSuffix();
+  const user = await User.create({ username: `u-${s}`, email: `u-${s}@example.com`, password: "x" });
+  return `Bearer ${tokenFor(user)}`;
+}
+
+describe("GET /items/art", () => {
+  it("serves an allowed image and tells the browser to keep it", async () => {
+    global.fetch = jest.fn(async () => upstream());
+    const res = await request(app).get("/items/art").query({ url: STEAM }).set("Authorization", await auth());
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/^image\/png/);
+    expect(res.headers["cache-control"]).toBe(`public, max-age=${artProxy.CACHE_SECONDS}, immutable`);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch.mock.calls[0][0]).toBe(STEAM);
+  });
+
+  it("never leaves the allowlist, and never reaches upstream to find out", async () => {
+    global.fetch = jest.fn(async () => upstream());
+    const auths = await auth();
+
+    for (const url of ["https://example.com/x.png", "http://169.254.169.254/latest/meta-data/", "", undefined]) {
+      const res = await request(app).get("/items/art").query(url === undefined ? {} : { url }).set("Authorization", auths);
+      expect(res.status).toBe(400);
+    }
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("wants a session", async () => {
+    global.fetch = jest.fn(async () => upstream());
+    const res = await request(app).get("/items/art").query({ url: STEAM });
+
+    expect(res.status).toBe(401);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("refuses what came back if it is not an image, or is too big", async () => {
+    const auths = await auth();
+
+    global.fetch = jest.fn(async () => upstream({ headers: { "content-type": "text/html" } }));
+    expect((await request(app).get("/items/art").query({ url: STEAM }).set("Authorization", auths)).status).toBe(502);
+
+    global.fetch = jest.fn(async () => upstream({ headers: { "content-length": String(artProxy.MAX_BYTES + 1) } }));
+    expect((await request(app).get("/items/art").query({ url: STEAM }).set("Authorization", auths)).status).toBe(502);
+
+    global.fetch = jest.fn(async () => upstream({ ok: false }));
+    expect((await request(app).get("/items/art").query({ url: STEAM }).set("Authorization", auths)).status).toBe(502);
+  });
+
+  it("answers rather than hangs when the cdn does not", async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error("timed out");
+    });
+    const res = await request(app).get("/items/art").query({ url: STEAM }).set("Authorization", await auth());
+    expect(res.status).toBe(504);
+  });
+});

--- a/backend/__tests__/unit/artProxy.test.js
+++ b/backend/__tests__/unit/artProxy.test.js
@@ -1,0 +1,40 @@
+const artProxy = require("../../utils/artProxy");
+
+describe("which art the proxy will fetch", () => {
+  it("takes the hosts our own art and steam's art live on", () => {
+    expect(artProxy.allow("https://kanicases.s3.amazonaws.com/touhou/Keine.png")).toBeTruthy();
+    expect(artProxy.allow("https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/10033.webp")).toBeTruthy();
+    expect(artProxy.allow("https://community.akamai.steamstatic.com/economy/image/abc/360fx360f")).toBeTruthy();
+  });
+
+  it("refuses anything else, which is the point of the list", () => {
+    expect(artProxy.allow("https://example.com/x.png")).toBeNull();
+    expect(artProxy.allow("https://kanicases.s3.amazonaws.com.evil.test/x.png")).toBeNull();
+    expect(artProxy.allow("https://evil.test/?u=community.akamai.steamstatic.com")).toBeNull();
+  });
+
+  it("refuses the schemes that would reach inside the box", () => {
+    expect(artProxy.allow("http://community.akamai.steamstatic.com/x.png")).toBeNull();
+    expect(artProxy.allow("file:///etc/passwd")).toBeNull();
+    expect(artProxy.allow("http://169.254.169.254/latest/meta-data/")).toBeNull();
+    expect(artProxy.allow("https://127.0.0.1:5001/users/me")).toBeNull();
+  });
+
+  it("refuses what is not a url at all", () => {
+    expect(artProxy.allow(undefined)).toBeNull();
+    expect(artProxy.allow("")).toBeNull();
+    expect(artProxy.allow("not a url")).toBeNull();
+    expect(artProxy.allow(["https://community.akamai.steamstatic.com/x.png"])).toBeNull();
+    expect(artProxy.allow("https://community.akamai.steamstatic.com/" + "x".repeat(3000))).toBeNull();
+  });
+});
+
+describe("the size guard", () => {
+  it("reads a content-length over the cap, and shrugs at a missing one", () => {
+    expect(artProxy.tooBig(String(artProxy.MAX_BYTES + 1))).toBe(true);
+    expect(artProxy.tooBig(String(artProxy.MAX_BYTES))).toBe(false);
+    expect(artProxy.tooBig("75394")).toBe(false);
+    expect(artProxy.tooBig(null)).toBe(false);
+    expect(artProxy.tooBig("nonsense")).toBe(false);
+  });
+});

--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -108,7 +108,21 @@ const hiloActionLimiter = rateLimit({
   message: { message: "Too many actions, slow down a little." },
 });
 
+// the share card pulls one image per character it draws, and the browser caches it for
+// a year, so a caller asking for many in a minute is not drawing cards
+const artLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 40,
+  keyGenerator: (req) => String(req.user._id),
+  skip: skipInTests,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { xForwardedForHeader: false },
+  message: { message: "Too many images requested, slow down." },
+});
+
 module.exports = {
+  artLimiter,
   loginLimiter,
   registerLimiter,
   registerDailyLimiter,

--- a/backend/routes/itemRoutes.js
+++ b/backend/routes/itemRoutes.js
@@ -6,6 +6,8 @@ const { isAuthenticated, isAdmin } = require("../middleware/authMiddleware");
 const { recomputeCaseValues } = require("../utils/itemValue");
 const { publicCache, TTL } = require("../utils/httpCache");
 const itemCatalog = require("../utils/itemCatalog");
+const artProxy = require("../utils/artProxy");
+const { artLimiter } = require("../middleware/rateLimit");
 
 router.get("/", async (req, res) => {
   try {
@@ -14,6 +16,34 @@ router.get("/", async (req, res) => {
     res.json(items);
   } catch (err) {
     res.status(500).json({ message: err.message });
+  }
+});
+
+// the share card needs the pixels, not just the picture: steam's cdn serves item art
+// without a cors header, so a canvas that drew it straight could never be exported
+router.get("/art", isAuthenticated, artLimiter, async (req, res) => {
+  const target = artProxy.allow(req.query.url);
+  if (!target) return res.status(400).json({ message: "That image is not served from here" });
+
+  try {
+    const upstream = await fetch(target, { signal: AbortSignal.timeout(artProxy.TIMEOUT_MS) });
+    const type = upstream.headers.get("content-type") || "";
+    if (!upstream.ok || !type.startsWith("image/")) {
+      return res.status(502).json({ message: "That artwork could not be fetched" });
+    }
+    if (artProxy.tooBig(upstream.headers.get("content-length"))) {
+      return res.status(502).json({ message: "That artwork is too large" });
+    }
+
+    const body = Buffer.from(await upstream.arrayBuffer());
+    if (body.length > artProxy.MAX_BYTES) {
+      return res.status(502).json({ message: "That artwork is too large" });
+    }
+    res.set("Content-Type", type);
+    res.set("Cache-Control", `public, max-age=${artProxy.CACHE_SECONDS}, immutable`);
+    res.send(body);
+  } catch {
+    res.status(504).json({ message: "That artwork could not be fetched" });
   }
 });
 

--- a/backend/utils/artProxy.js
+++ b/backend/utils/artProxy.js
@@ -1,0 +1,35 @@
+// two thirds of the catalog is hosted on steam's cdn, which sends no cors header, so a
+// canvas that drew it could never be exported. our own bucket carries a policy and does.
+const HOSTS = new Set([
+  "kanicases.s3.amazonaws.com",
+  "kanicases.s3.us-east-1.amazonaws.com",
+  "community.akamai.steamstatic.com",
+  "community.cloudflare.steamstatic.com",
+  "steamcommunity-a.akamaihd.net",
+]);
+
+const MAX_BYTES = 2 * 1024 * 1024;
+const TIMEOUT_MS = 8000;
+const CACHE_SECONDS = 31536000;
+
+// an allowlist, not a blocklist: without one this endpoint fetches anything the box can
+// reach on a caller's behalf, the internal network included.
+function allow(raw) {
+  if (typeof raw !== "string" || !raw || raw.length > 2048) return null;
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:") return null;
+  if (!HOSTS.has(url.host)) return null;
+  return url.toString();
+}
+
+const tooBig = (length) => {
+  const size = Number(length);
+  return Number.isFinite(size) && size > MAX_BYTES;
+};
+
+module.exports = { HOSTS, MAX_BYTES, TIMEOUT_MS, CACHE_SECONDS, allow, tooBig };

--- a/src/components/fanCard/cardAssets.ts
+++ b/src/components/fanCard/cardAssets.ts
@@ -1,3 +1,5 @@
+import { getArt } from "../../services/items/ItemService";
+
 // the display faces are only ever drawn into a canvas, and canvas use does not pull a
 // @font-face down: they are requested here, the first time a card sheet opens.
 const FACES = [
@@ -18,14 +20,41 @@ export function loadCardFonts() {
   return fonts;
 }
 
-// crossOrigin is what keeps the canvas exportable. without the header on the bucket the
-// image fails outright, which the sheet reports rather than hand back an unsaveable card.
-export function loadCardArt(src: string) {
+// only our own bucket carries a cors policy. two thirds of the catalog sits on steam's
+// cdn, which does not, so that art has to arrive through the api instead.
+const OWN_BUCKET = /^kanicases\.s3[.-]/;
+
+const hostOf = (src: string) => {
+  try {
+    return new URL(src, window.location.href).host;
+  } catch {
+    return "";
+  }
+};
+
+export const needsProxy = (src: string) => !OWN_BUCKET.test(hostOf(src));
+
+function loadImage(src: string, cors: boolean) {
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image();
-    img.crossOrigin = "anonymous";
+    if (cors) img.crossOrigin = "anonymous";
     img.onload = () => resolve(img);
     img.onerror = () => reject(new Error("Could not load the character art"));
     img.src = src;
   });
+}
+
+// crossOrigin is what keeps the canvas exportable, and a blob from our own api is
+// same-origin, so neither route taints it.
+export async function loadCardArt(src: string) {
+  if (!needsProxy(src)) return loadImage(src, true);
+
+  const objectUrl = URL.createObjectURL(await getArt(src));
+  try {
+    const img = await loadImage(objectUrl, false);
+    await img.decode().catch(() => undefined);
+    return img;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
 }

--- a/src/components/fanCard/fanCard.test.ts
+++ b/src/components/fanCard/fanCard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { ALL_STYLES, PINNED, resolveStyle, stylesFor } from "./cardStyles";
 import { cardFromBoard, cardFromStanding, yearOf } from "./cardData";
 import { fileNameFor } from "./ShareCard/ShareCard.services";
+import { needsProxy } from "./cardAssets";
 import { FanBoard, FanRank } from "../../services/fandom/FandomService";
 
 const fan = {
@@ -98,5 +99,19 @@ describe("supporting bits", () => {
     expect(fileNameFor("Keine")).toBe("keine-top-fan.png");
     expect(fileNameFor("Yuuma Toutetsu")).toBe("yuuma-toutetsu-top-fan.png");
     expect(fileNameFor("???")).toBe("fan-top-fan.png");
+  });
+});
+
+describe("where the art has to come from", () => {
+  it("loads our own bucket straight, since that is the one with a cors policy", () => {
+    expect(needsProxy("https://kanicases.s3.amazonaws.com/touhou/Keine.png")).toBe(false);
+    expect(needsProxy("https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/10033.webp")).toBe(false);
+  });
+
+  it("sends everything else through the api, steam's cdn being two thirds of the catalog", () => {
+    expect(needsProxy("https://community.akamai.steamstatic.com/economy/image/abc/360fx360f")).toBe(true);
+    expect(needsProxy("https://example.com/x.png")).toBe(true);
+    expect(needsProxy("")).toBe(true);
+    expect(needsProxy("kanicases.s3.amazonaws.com/no-scheme.png")).toBe(true);
   });
 });

--- a/src/services/items/ItemService.ts
+++ b/src/services/items/ItemService.ts
@@ -1,0 +1,8 @@
+import api from "../api";
+
+// art on a host that sends no cors header has to come through us, or the canvas that
+// drew it cannot be exported
+export async function getArt(url: string): Promise<Blob> {
+  const res = await api.get("/items/art", { params: { url }, responseType: "blob" });
+  return res.data as Blob;
+}


### PR DESCRIPTION
**Problem.** The share card kept failing with "Could not load the character art". Two separate causes.

Most item art was never on our bucket. 805 of 1,246 items were hotlinked from `community.akamai.steamstatic.com`, which answers 200 with no `Access-Control-Allow-Origin`, so a canvas that drew one could not be exported. That accounts for the CS2 half of the catalog.

Then it failed again on `kanicases.s3.us-east-1.amazonaws.com`, which is ours and does send the header. I could not reproduce that one: curl returns the header for the exact object, and a fresh browser, a warm browser and a browser with a disk-cached plain copy of the same image all load it fine under `crossOrigin`. Rather than keep guessing at a cause I cannot see, the card no longer depends on the answer.

**Change.**

- Every card image is fetched through `GET /items/art` and drawn from a same-origin blob. No `crossOrigin`, no `Access-Control-Allow-Origin` on anyone's host, nothing to get right at request time.
- The proxy is allowlisted to the hosts item art lives on, needs a session, is rate limited per user, and sets `max-age=31536000, immutable`, so it is one fetch per person per character.
- `scripts/rehostItemArt.js` repoints stored art at our bucket from a manifest. Dry run by default, idempotent, one find and one bulkWrite per collection. Inventory copies are deliberately left alone: the catalog is what the app reads an image from, and a copy taken at drop time is already allowed to be stale.

**Already run against production.** 836 images copied onto `kanicases/cases/cs2/`, transcoded PNG to WebP at the same 360x360: 54.7 MB down to 12.4 MB, 77% smaller, mean 64 KB to 15 KB. Then 805 items, 46 case covers, 790 fan boards and 3 predictions repointed. `GET /items` now reports 1,246 of 1,246 on our own bucket and zero on Steam. Case pages get the 77% saving too.

**Tests.** 10 cases for the proxy: the allowlist takes the real hosts and rejects look-alike domains, `http`, `file:`, the metadata IP and localhost; the route serves an allowed image with the cache header, returns 400 without reaching upstream for anything else, needs a session, and refuses a non-image, an oversized body and a dead CDN. Backend 902 across 93 suites, frontend 138, e2e 26, build and lint clean.

Verified end to end in a browser on the real art: direct load blocked, proxied load 360x360, canvas export 113 KB. All six styles then rendered from a re-hosted CS2 image with a 1.15 MB PNG export.