### PR TITLE
Project the optional-auth read as well

### DIFF
--- a/backend/__tests__/integration/authInventory.test.js
+++ b/backend/__tests__/integration/authInventory.test.js
@@ -7,7 +7,7 @@ const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
 
 const User = require("../../models/User");
 const Item = require("../../models/Item");
-const { isAuthenticated } = require("../../middleware/authMiddleware");
+const { isAuthenticated, maybeAuthenticated } = require("../../middleware/authMiddleware");
 
 let app;
 
@@ -111,5 +111,43 @@ describe("routes that do need an inventory", () => {
     expect(res.body.username).toBe(user.username);
     const stored = await User.findById(user._id).select("inventory").lean();
     expect(stored.inventory).toHaveLength(4);
+  });
+});
+
+// the market pages read fine logged out, so this one runs on a public path and was the
+// half of the middleware the first pass missed
+describe("what maybeAuthenticated loads", () => {
+  it("leaves the inventory behind too", async () => {
+    const user = await makeUser({ inventory: stack(30), walletBalance: 77 });
+    const req = { header: () => `Bearer ${tokenFor(user)}` };
+    await maybeAuthenticated(req, {}, () => {});
+
+    expect(req.user.inventory).toBeUndefined();
+    expect(req.user.walletBalance).toBe(77);
+    expect(req.user.username).toBe(user.username);
+  });
+
+  it("still lets a guest and a bad token straight through", async () => {
+    const guest = { header: () => undefined };
+    let passed = 0;
+    await maybeAuthenticated(guest, {}, () => { passed += 1; });
+    expect(guest.user).toBeUndefined();
+
+    const bogus = { header: () => "Bearer not-a-token" };
+    await maybeAuthenticated(bogus, {}, () => { passed += 1; });
+    expect(bogus.user).toBeUndefined();
+    expect(passed).toBe(2);
+  });
+
+  it("does not attach a revoked or disabled account", async () => {
+    const revoked = await makeUser({ inventory: stack(3), tokenVersion: 5 });
+    const req = { header: () => `Bearer ${tokenFor(revoked)}` };
+    await maybeAuthenticated(req, {}, () => {});
+    expect(req.user).toBeUndefined();
+
+    const off = await makeUser({ inventory: stack(3), disabled: true });
+    const req2 = { header: () => `Bearer ${tokenFor(off)}` };
+    await maybeAuthenticated(req2, {}, () => {});
+    expect(req2.user).toBeUndefined();
   });
 });

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -61,7 +61,8 @@ const maybeAuthenticated = async (req, res, next) => {
 
   try {
     const decoded = jwt.verify(parts[1], process.env.JWT_SECRET);
-    const user = await User.findById(decoded.userId).select("-password");
+    // same reason as above: the prediction pages run this on every view
+    const user = await User.findById(decoded.userId).select({ password: 0, ...WITHOUT_INVENTORY });
     if (user && !user.disabled && (decoded.tokenVersion || 0) === (user.tokenVersion || 0)) {
       req.user = user;
     }


### PR DESCRIPTION
**Problem.** #232 projected `isAuthenticated` but left `maybeAuthenticated` in the same file untouched. It carries the identical `findById(...).select("-password")` and runs on `GET /predictions` and `GET /predictions/:slug`, both public pages a logged-in player hits on every view.

Confirmed on production after #232 deployed: the fixed path now returns the heaviest account (1,959.6 KB) in 29ms with the inventory absent, against 20,367ms before. The optional path was still paying the old cost.

**Change.** The same projection, same shared constant.

Nothing reads `req.user.inventory`, and the prediction routes only take `_id` off it, plus `username`, `profilePicture` and `level` for the trade card, all of which the projection keeps.

**Tests.** 3 new cases alongside the existing ones: the optional read drops the inventory but keeps the balance and username, a guest and a bad token still pass straight through, and a revoked or disabled account is still not attached. Full backend suite 910 passing across 94 suites.