### PR TITLE
Stop shipping the inventory array to answer small questions

### DIFF
--- a/backend/__tests__/integration/inventoryReads.test.js
+++ b/backend/__tests__/integration/inventoryReads.test.js
@@ -1,0 +1,111 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Case = require("../../models/Case");
+const { countsFor, holdingsFor, extrasFor } = require("../../utils/inventoryCounts");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const caseId = new mongoose.Types.ObjectId();
+const alpha = new mongoose.Types.ObjectId();
+const beta = new mongoose.Types.ObjectId();
+const gone = new mongoose.Types.ObjectId();
+
+const copies = (id, n, from = caseId) =>
+  Array.from({ length: n }, (_, i) => ({
+    _id: id,
+    uniqueId: `${id}-${i}`,
+    name: "x",
+    image: "x.png",
+    rarity: "1",
+    case: from,
+  }));
+
+async function makeUser(inventory) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    inventory,
+  });
+}
+
+describe("tallying an inventory without shipping it", () => {
+  it("counts every copy of every item", async () => {
+    const user = await makeUser([...copies(alpha, 7), ...copies(beta, 2)]);
+    const counts = await countsFor(user._id);
+
+    expect(counts.get(String(alpha))).toBe(7);
+    expect(counts.get(String(beta))).toBe(2);
+    expect(counts.get(String(gone))).toBeUndefined();
+    expect(counts.size).toBe(2);
+  });
+
+  it("scopes to the items asked for", async () => {
+    const user = await makeUser([...copies(alpha, 3), ...copies(beta, 4)]);
+    const counts = await countsFor(user._id, [alpha]);
+
+    expect(counts.get(String(alpha))).toBe(3);
+    expect(counts.has(String(beta))).toBe(false);
+  });
+
+  it("is empty for an empty inventory and for a user who does not exist", async () => {
+    expect((await countsFor((await makeUser([]))._id)).size).toBe(0);
+    expect((await countsFor(new mongoose.Types.ObjectId())).size).toBe(0);
+  });
+
+  it("hands back the copies themselves, capped", async () => {
+    const user = await makeUser(copies(alpha, 9));
+    const { countById, uniqueIdsById } = await holdingsFor(user._id, [alpha], 4);
+
+    expect(countById.get(String(alpha))).toBe(9);
+    expect(uniqueIdsById.get(String(alpha))).toHaveLength(4);
+  });
+
+  it("finds the copies a case no longer lists, with their snapshot", async () => {
+    const user = await makeUser([...copies(alpha, 2), ...copies(gone, 3)]);
+    const extras = await extrasFor(user._id, caseId, [alpha], 100);
+
+    expect(extras).toHaveLength(1);
+    expect(extras[0]._id).toBe(String(gone));
+    expect(extras[0].count).toBe(3);
+    expect(extras[0].snapshot.name).toBe("x");
+    expect(extras[0].uniqueIds).toHaveLength(3);
+  });
+
+  it("does not call a copy from another case an extra", async () => {
+    const other = new mongoose.Types.ObjectId();
+    const user = await makeUser(copies(gone, 3, other));
+    expect(await extrasFor(user._id, caseId, [alpha], 100)).toHaveLength(0);
+  });
+});
+
+describe("the inventory page", () => {
+  it("still answers for a visible user and hides a disabled one", async () => {
+    await Item.create({ _id: alpha, name: "Alpha", image: "a.png", rarity: "1", baseValue: 10, case: caseId });
+    await Case.create({ _id: caseId, name: "C", title: "C", image: "c.png", price: 1, items: [alpha] });
+
+    const user = await makeUser(copies(alpha, 5));
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].quantity).toBe(5);
+
+    await User.updateOne({ _id: user._id }, { $set: { disabled: true } });
+    expect((await request(app).get(`/users/inventory/${user._id}`)).status).toBe(404);
+  });
+});

--- a/backend/routes/collectionsRoutes.js
+++ b/backend/routes/collectionsRoutes.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const Case = require("../models/Case");
 const Item = require("../models/Item");
 const User = require("../models/User");
+const { countsFor, holdingsFor, extrasFor } = require("../utils/inventoryCounts");
 const { sellValue } = require("../utils/itemValue");
 const { sellUniqueIds } = require("../utils/inventorySell");
 const { isAuthenticated } = require("../middleware/authMiddleware");
@@ -30,18 +31,9 @@ function uniqueItems(caseDoc) {
 }
 
 // count owned copies and gather the uniqueIds per catalog item _id
-function indexInventory(inventory) {
-  const countById = new Map();
-  const uniqueIdsById = new Map();
-  for (const e of inventory || []) {
-    if (!e || !e._id) continue;
-    const id = String(e._id);
-    countById.set(id, (countById.get(id) || 0) + 1);
-    if (!uniqueIdsById.has(id)) uniqueIdsById.set(id, []);
-    uniqueIdsById.get(id).push(e.uniqueId);
-  }
-  return { countById, uniqueIdsById };
-}
+// no screen picks hundreds of copies one at a time, so the rest is pure payload
+const STACK_IDS = 500;
+
 
 // the canonical quicksell plan for a case: for every item in Case.items the viewer
 // owns more than one of (and that has a positive sell value), sell all but one. the
@@ -141,12 +133,12 @@ router.get("/summary", async (req, res) => {
     if (!isValidId(userId)) {
       return res.status(400).json({ message: "Invalid user id" });
     }
-    const user = await User.findById(userId, { inventory: 1 });
+    const user = await User.findById(userId).select("_id");
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const { countById } = indexInventory(user.inventory);
+    const countById = await countsFor(userId);
     const cases = await Case.find({}, { title: 1, image: 1, price: 1, items: 1, category: 1 })
       .populate("items", "rarity baseValue");
 
@@ -297,14 +289,14 @@ router.get("/:caseId", async (req, res) => {
     if (!caseDoc) {
       return res.status(404).json({ message: "Collection not found" });
     }
-    const user = await User.findById(userId, { inventory: 1 });
+    const user = await User.findById(userId).select("_id");
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const { countById, uniqueIdsById } = indexInventory(user.inventory);
     const items = uniqueItems(caseDoc);
     const caseItemIds = new Set(items.map((it) => String(it._id)));
+    const { countById, uniqueIdsById } = await holdingsFor(userId, [...caseItemIds], STACK_IDS);
     const stats = caseStats(caseDoc, countById);
 
     let rows = items.map((it) => {
@@ -363,16 +355,10 @@ router.get("/:caseId", async (req, res) => {
     const extraCounts = new Map();
     const extraUniqueIds = new Map();
     if (page === 1) {
-      for (const e of user.inventory || []) {
-        if (!e || !e._id) continue;
-        const id = String(e._id);
-        if (String(e.case) !== String(caseId) || caseItemIds.has(id)) continue;
-        extraCounts.set(id, (extraCounts.get(id) || 0) + 1);
-        if (!extraSnap.has(id)) {
-          extraSnap.set(id, { name: e.name, image: e.image, rarity: e.rarity });
-        }
-        if (!extraUniqueIds.has(id)) extraUniqueIds.set(id, []);
-        extraUniqueIds.get(id).push(e.uniqueId);
+      for (const extra of await extrasFor(userId, caseId, [...caseItemIds], STACK_IDS)) {
+        extraCounts.set(extra._id, extra.count);
+        extraSnap.set(extra._id, extra.snapshot);
+        extraUniqueIds.set(extra._id, extra.uniqueIds);
       }
     }
 

--- a/backend/routes/friendsRoutes.js
+++ b/backend/routes/friendsRoutes.js
@@ -93,7 +93,7 @@ module.exports = (io) => {
         return res.status(400).json({ message: "You can't add yourself" });
       }
 
-      const target = await User.findById(targetId);
+      const target = await User.findById(targetId).select("friends friendRequests disabled");
       if (!target) {
         return res.status(404).json({ message: "User not found" });
       }

--- a/backend/routes/giftRoutes.js
+++ b/backend/routes/giftRoutes.js
@@ -25,7 +25,7 @@ async function casesByCategory() {
 // the categories a player can choose between, each with the table it would spin and a
 // cover to show. the table is public on purpose: the odds are the pitch.
 async function state(userId) {
-  const user = await User.findById(userId);
+  const user = await User.findById(userId).select("giftStreak giftNextAt freeOpens level");
   if (!user) return null;
 
   const now = new Date();
@@ -157,7 +157,7 @@ router.get("/grants", isAuthenticated, async (req, res) => {
 router.post("/spin", isAuthenticated, async (req, res) => {
   try {
     const category = String(req.body?.category || "");
-    const user = await User.findById(req.user._id);
+    const user = await User.findById(req.user._id).select("giftStreak giftNextAt giftLastAt level freeOpens");
     if (!user) return res.status(404).json({ message: "User not found" });
 
     const now = new Date();

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -682,7 +682,7 @@ router.put(
     try {
       const { description } = req.body;
 
-      const user = await User.findById(req.user._id);
+      const user = await User.findById(req.user._id).select("fixedItem");
 
       if (!user) {
         return res.status(404).json({ message: "User not found" });
@@ -794,7 +794,8 @@ router.get("/inventory/:userId", async (req, res) => {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const user = await User.findById(userId);
+    // the visibility check needs a flag, not 12k inventory entries
+    const user = await User.findById(userId).select("disabled");
     if (!isVisible(user)) {
       return res.status(404).json({ message: "User not found" });
     }

--- a/backend/utils/inventoryCounts.js
+++ b/backend/utils/inventoryCounts.js
@@ -1,0 +1,81 @@
+const mongoose = require("mongoose");
+const User = require("../models/User");
+
+// how many of each item a player holds, tallied inside mongo. the embedded array reaches
+// 21k entries and 1.4 MB, and every caller here only ever wanted the counts.
+const toId = (id) => (id instanceof mongoose.Types.ObjectId ? id : new mongoose.Types.ObjectId(String(id)));
+
+function pipelineFor(userId, itemIds) {
+  const stages = [
+    { $match: { _id: toId(userId) } },
+    { $project: { inventory: { $ifNull: ["$inventory", []] } } },
+    { $unwind: "$inventory" },
+  ];
+  if (itemIds && itemIds.length) {
+    stages.push({ $match: { "inventory._id": { $in: itemIds.map(toId) } } });
+  }
+  return stages;
+}
+
+// itemId -> how many copies. an unheld item is simply absent.
+async function countsFor(userId, itemIds) {
+  const rows = await User.aggregate([
+    ...pipelineFor(userId, itemIds),
+    { $group: { _id: "$inventory._id", n: { $sum: 1 } } },
+  ]);
+  return new Map(rows.map((row) => [String(row._id), row.n]));
+}
+
+// the same tally plus the copies themselves, for the screens that sell one. capped
+// because no screen picks hundreds of copies by hand and the rest is pure payload.
+async function holdingsFor(userId, itemIds, cap) {
+  const rows = await User.aggregate([
+    ...pipelineFor(userId, itemIds),
+    { $group: { _id: "$inventory._id", n: { $sum: 1 }, uniqueIds: { $push: "$inventory.uniqueId" } } },
+    { $addFields: { uniqueIds: { $slice: ["$uniqueIds", cap || 500] } } },
+  ]);
+  const countById = new Map();
+  const uniqueIdsById = new Map();
+  for (const row of rows) {
+    const id = String(row._id);
+    countById.set(id, row.n);
+    uniqueIdsById.set(id, row.uniqueIds.filter(Boolean));
+  }
+  return { countById, uniqueIdsById };
+}
+
+
+// copies whose snapshot says they dropped from this case but which the case no longer
+// lists. the snapshot fields are the only record left of what they looked like.
+async function extrasFor(userId, caseId, excludeIds, cap) {
+  const rows = await User.aggregate([
+    { $match: { _id: toId(userId) } },
+    { $project: { inventory: { $ifNull: ["$inventory", []] } } },
+    { $unwind: "$inventory" },
+    {
+      $match: {
+        "inventory.case": toId(caseId),
+        "inventory._id": { $nin: (excludeIds || []).map(toId) },
+      },
+    },
+    {
+      $group: {
+        _id: "$inventory._id",
+        n: { $sum: 1 },
+        name: { $first: "$inventory.name" },
+        image: { $first: "$inventory.image" },
+        rarity: { $first: "$inventory.rarity" },
+        uniqueIds: { $push: "$inventory.uniqueId" },
+      },
+    },
+    { $addFields: { uniqueIds: { $slice: ["$uniqueIds", cap || 500] } } },
+  ]);
+  return rows.map((row) => ({
+    _id: String(row._id),
+    count: row.n,
+    snapshot: { name: row.name, image: row.image, rarity: row.rarity },
+    uniqueIds: row.uniqueIds.filter(Boolean),
+  }));
+}
+
+module.exports = { countsFor, holdingsFor, extrasFor };

--- a/backend/utils/missions.js
+++ b/backend/utils/missions.js
@@ -2,6 +2,7 @@ const mongoose = require("mongoose");
 const Transaction = require("../models/Transaction");
 const Battle = require("../models/Battle");
 const User = require("../models/User");
+const { countsFor } = require("./inventoryCounts");
 const Case = require("../models/Case");
 const MissionState = require("../models/MissionState");
 const { creditUser, runAtomic, TX, STAKE_TYPES } = require("./economy");
@@ -19,9 +20,8 @@ const ACTIVE = CATALOG.filter((m) => m.active !== false);
 // populate + drop null (deleted) refs so "complete" matches exactly what the
 // collections tab shows: a dangling item id is not a slot the album counts either.
 async function collectionsProgress(userId) {
-  const user = await User.findById(userId, { inventory: 1 });
-  if (!user) return { done: 0, total: 0 };
-  const owned = new Set((user.inventory || []).map((e) => String(e._id)));
+  const owned = new Set((await countsFor(userId)).keys());
+  if (!owned.size) return { done: 0, total: 0 };
   const cases = await Case.find({}, { items: 1 }).populate("items", "_id");
   let done = 0;
   let total = 0;


### PR DESCRIPTION
**Problem.** A player reported "it takes like 1 minute for my inventory to load". Measured against his account (1,368 KB, 12,457 entries), every page of `GET /users/inventory/:userId` took ~16s, and page 2 cost the same as page 1.

Broken down on production:

| | |
| --- | --- |
| `findById(userId)` — the visibility check | **14,774 ms** |
| the same check with a projection | 25 ms |
| count aggregation | 38 ms |
| the pipeline that builds the page | 63 ms |

So the endpoint's real work is about 100ms and the rest was one line reading 12,457 inventory entries to look at a boolean. Collections is the same shape: `findById(userId, { inventory: 1 })` took **14,359 ms** where tallying the same thing in mongo takes 67 ms. Sorting and paging felt slow because each one re-requests and pays the fixed cost again.

The embedded array is not the problem here. Mongo groups it in 38ms. The problem is that we keep shipping it to node.

**Change.**

- `utils/inventoryCounts.js`: `countsFor`, `holdingsFor` and `extrasFor` tally inside mongo, optionally scoped to a set of item ids, with the uniqueId lists capped.
- The collections summary, the album, the album's extras and the missions progress now use it instead of reading the array.
- Projections on the reads that never needed an inventory at all: the inventory page's visibility check, the pin description, the daily gift state and spin, and the friend-request target.

**Tests.** 7 new cases for the helpers: counting every copy, scoping to given items, an empty inventory and a missing user, the capped uniqueId list, extras with their snapshot, and a copy from another case not counting as an extra. Plus the inventory page still answering for a visible user and 404ing for a disabled one. Full suite 917 passing across 95 suites.

Two regressions the suite caught while writing this, both mine: scoping the album's holdings to the case's items dropped the extras, and projecting the gift spin dropped `freeOpens` so it created a second grant instead of topping up the first.