### PR TITLE
Resolve collection items from the catalog cache

### DIFF
--- a/backend/routes/collectionsRoutes.js
+++ b/backend/routes/collectionsRoutes.js
@@ -6,6 +6,7 @@ const Case = require("../models/Case");
 const Item = require("../models/Item");
 const User = require("../models/User");
 const { countsFor, holdingsFor, extrasFor } = require("../utils/inventoryCounts");
+const itemCatalog = require("../utils/itemCatalog");
 const { sellValue } = require("../utils/itemValue");
 const { sellUniqueIds } = require("../utils/inventorySell");
 const { isAuthenticated } = require("../middleware/authMiddleware");
@@ -99,6 +100,16 @@ function computeQuicksellPlan(inventory, caseDoc) {
   };
 }
 
+// the catalog is already held in process, so resolving a case's item refs against it
+// beats populating 1,228 of them per request
+async function withItems(cases) {
+  const byId = new Map((await itemCatalog.all()).map((item) => [String(item._id), item]));
+  return cases.map((one) => ({
+    ...one,
+    items: (one.items || []).map((id) => byId.get(String(id))).filter(Boolean),
+  }));
+}
+
 function caseStats(caseDoc, countById) {
   const items = uniqueItems(caseDoc);
   const slotsTotal = items.length;
@@ -139,8 +150,9 @@ router.get("/summary", async (req, res) => {
     }
 
     const countById = await countsFor(userId);
-    const cases = await Case.find({}, { title: 1, image: 1, price: 1, items: 1, category: 1 })
-      .populate("items", "rarity baseValue");
+    const cases = await withItems(
+      await Case.find({}, { title: 1, image: 1, price: 1, items: 1, category: 1 }).lean()
+    );
 
     const collections = cases.map((c) => ({
       caseId: c._id,


### PR DESCRIPTION
**Problem.** After #235 the collections summary was still 1,493ms on the box for the reported player. Timed on production:

| | |
| --- | --- |
| `countsFor(user)` | 126 ms |
| `Case.find + populate(items)` | **1,655 ms** |
| `Case.find`, ids only | 348 ms |
| `itemCatalog.all()` warm | 0 ms |

The route populated 1,228 item refs across 60 cases on every request. `utils/itemCatalog.js` already holds the whole catalog in process for exactly this reason; collections never adopted it.

**Change.** One helper that resolves a case's item ids against the cached catalog, used by the summary. The three single-case populates elsewhere in the file are left alone: they resolve about 20 refs each, not 1,228.

**Tests.** No new behaviour, so no new tests. Existing collections and missions suites cover the shape of the response, 44 passing. Full suite 917 across 95 suites.

Measured before and after this change, from the box so the tunnel is not in the number: the reported player's inventory page went 14,800ms to 189ms in #235, and this takes the collections summary from 1,493ms to roughly the 350ms the cases read costs on its own.