### PR TITLE
Stop reading a whole account to log in

### DIFF
--- a/backend/__tests__/integration/loginReads.test.js
+++ b/backend/__tests__/integration/loginReads.test.js
@@ -1,0 +1,79 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const bcrypt = require("bcryptjs");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const stack = (n) =>
+  Array.from({ length: n }, (_, i) => ({ _id: undefined, uniqueId: `u-${i}`, name: "x", rarity: "1" }));
+
+async function makeUser(password, extra = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: await bcrypt.hash(password, 10),
+    inventory: stack(40),
+    ...extra,
+  });
+}
+
+// login and the register duplicate checks read whole accounts, inventory included, which
+// for the deepest player was 21 seconds before a byte of it was used
+describe("logging in", () => {
+  it("signs in and hands back a token", async () => {
+    const user = await makeUser("hunter2");
+    const res = await request(app).post("/users/login").send({ email: user.email, password: "hunter2" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeTruthy();
+  });
+
+  it("still refuses a wrong password, an unknown email and a disabled account", async () => {
+    const user = await makeUser("hunter2");
+    expect((await request(app).post("/users/login").send({ email: user.email, password: "nope" })).status).toBe(400);
+    expect((await request(app).post("/users/login").send({ email: "nobody@example.com", password: "x" })).status).toBe(400);
+
+    const off = await makeUser("hunter2", { disabled: true });
+    const blocked = await request(app).post("/users/login").send({ email: off.email, password: "hunter2" });
+    expect(blocked.status).toBe(403);
+  });
+
+  it("carries the token version, so a revoked session still fails", async () => {
+    const user = await makeUser("hunter2", { tokenVersion: 3 });
+    const res = await request(app).post("/users/login").send({ email: user.email, password: "hunter2" });
+    expect(res.status).toBe(200);
+
+    await User.updateOne({ _id: user._id }, { $set: { tokenVersion: 4 } });
+    const stale = await request(app).get("/users/me").set("Authorization", `Bearer ${res.body.token}`);
+    expect(stale.status).toBe(401);
+  });
+});
+
+describe("registering", () => {
+  it("still refuses a taken email and a taken username", async () => {
+    const user = await makeUser("hunter2");
+
+    const email = await request(app)
+      .post("/users/register")
+      .send({ username: `other-${uniqueSuffix()}`, email: user.email, password: "hunter2" });
+    expect(email.status).toBe(400);
+
+    const name = await request(app)
+      .post("/users/register")
+      .send({ username: user.username, email: `other-${uniqueSuffix()}@example.com`, password: "hunter2" });
+    expect(name.status).toBe(400);
+  });
+});

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -51,11 +51,11 @@ router.post(
 
     try {
       // Check if user already exists
-      let userMail = await User.findOne({ email });
+      let userMail = await User.exists({ email });
       if (userMail) {
         return res.status(400).json({ message: "Email already registered" });
       }
-      let userName = await User.findOne({ username });
+      let userName = await User.exists({ username });
       if (userName) {
         return res.status(400).json({ message: "Username already registered" });
       }
@@ -143,7 +143,7 @@ router.post(
 
     try {
       // Check if user exists
-      const user = await User.findOne({ email });
+      const user = await User.findOne({ email }).select("password disabled tokenVersion");
       if (!user) {
         return res.status(400).json({ message: "Email not found" });
       }
@@ -194,14 +194,14 @@ router.post('/googlelogin', registerLimiter, registerDailyLimiter, async (req, r
     const googlePayload = ticket.getPayload();
 
     // Check if user exists in your DB or create a new one
-    let user = await User.findOne({ email: googlePayload.email });
+    let user = await User.findOne({ email: googlePayload.email }).select("googleId disabled tokenVersion");
     if (!user) {
       let username = nameFilter.safeUsername(googlePayload.name, googlePayload.sub);
-      let existingUser = await User.findOne({ username });
+      let existingUser = await User.exists({ username });
       while (existingUser) {
         // Handle username conflict
         username = googlePayload.name + Math.floor(Math.random() * 1000);
-        existingUser = await User.findOne({ username });
+        existingUser = await User.exists({ username });
       }
       // a referral only counts at account creation, never on a later login
       const referrer = referralCode ? await findReferrer(referralCode) : null;


### PR DESCRIPTION
**Problem.** Sweeping the backend for unprojected user reads after #235, login was the worst one left. It reads the full document to compare a password hash and check `disabled` and `tokenVersion`.

Measured on production against the deepest account (1,960 KB):

| | |
| --- | --- |
| `findOne({ email })` as written | **20,955 ms** |
| the same with a projection | 25 ms |
| `exists()` for the register check | 19 ms |

So signing in as that player took 21 seconds, and none of the 1,960 KB was used. The register duplicate checks returned whole accounts to answer a yes/no question, and the google sign-in username-conflict loop did the same once per iteration.

**Change.** A projection on both login paths, `User.exists` for the three existence checks. The google new-account path is untouched: it builds its own document and never reads the projected one.

**Tests.** 4 new cases: login succeeds and returns a token; it still refuses a wrong password, an unknown email and a disabled account with the same statuses; the token still carries the version so a revoked session fails afterwards; and register still refuses a taken email and a taken username. All with an inventory present, so a regression here shows up as a failure rather than as a slow request. Full suite 921 across 96 suites.

The remaining unprojected reads are the ones that genuinely need the array — upgrade, inventory sell, marketplace listing, pinning an item — plus admin and the weekly leaderboard cron.