### PR TITLE
Pick the copies to list inside mongo

### DIFF
--- a/backend/__tests__/integration/inventoryReads.test.js
+++ b/backend/__tests__/integration/inventoryReads.test.js
@@ -8,7 +8,7 @@ const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
 const User = require("../../models/User");
 const Item = require("../../models/Item");
 const Case = require("../../models/Case");
-const { countsFor, holdingsFor, extrasFor } = require("../../utils/inventoryCounts");
+const { countsFor, holdingsFor, extrasFor, copiesFor } = require("../../utils/inventoryCounts");
 
 let app;
 
@@ -107,5 +107,33 @@ describe("the inventory page", () => {
 
     await User.updateOne({ _id: user._id }, { $set: { disabled: true } });
     expect((await request(app).get(`/users/inventory/${user._id}`)).status).toBe(404);
+  });
+});
+
+describe("picking the copies a listing is about", () => {
+  it("finds one copy by its uniqueId", async () => {
+    const user = await makeUser(copies(alpha, 4));
+    const found = await copiesFor(user._id, { uniqueId: `${alpha}-2`, limit: 1 });
+
+    expect(found).toHaveLength(1);
+    expect(found[0].uniqueId).toBe(`${alpha}-2`);
+    expect(String(found[0]._id)).toBe(String(alpha));
+  });
+
+  it("takes the newest copies of an item, up to the number asked for", async () => {
+    const older = copies(alpha, 2).map((e, i) => ({ ...e, uniqueId: `old-${i}`, createdAt: new Date(2020, 0, 1) }));
+    const newer = copies(alpha, 3).map((e, i) => ({ ...e, uniqueId: `new-${i}`, createdAt: new Date(2026, 0, 1) }));
+    const user = await makeUser([...older, ...newer]);
+
+    const found = await copiesFor(user._id, { itemId: alpha, limit: 3 });
+    expect(found).toHaveLength(3);
+    expect(found.every((e) => e.uniqueId.startsWith("new-"))).toBe(true);
+  });
+
+  it("comes back empty for a copy that is not there, and asks for nothing without a target", async () => {
+    const user = await makeUser(copies(alpha, 2));
+    expect(await copiesFor(user._id, { uniqueId: "nope", limit: 1 })).toHaveLength(0);
+    expect(await copiesFor(user._id, { itemId: beta, limit: 5 })).toHaveLength(0);
+    expect(await copiesFor(user._id, {})).toHaveLength(0);
   });
 });

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
 
 const User = require("../models/User");
+const { copiesFor } = require("../utils/inventoryCounts");
 const Item = require("../models/Item");
 const Marketplace = require("../models/Marketplace");
 const MarketSale = require("../models/MarketSale");
@@ -118,7 +119,7 @@ module.exports = (io) => {
         return res.status(400).json({ message: "Invalid price" });
       }
 
-      const user = await User.findById(req.user._id);
+      const user = await User.findById(req.user._id).select("level");
       if (!user) {
         return res.status(404).json({ message: "User not found" });
       }
@@ -132,14 +133,13 @@ module.exports = (io) => {
       // the single-copy path and never a shortcut around it.
       let copies;
       if (uniqueId) {
-        const found = user.inventory.find((item) => item.uniqueId === uniqueId);
-        copies = found ? [found] : [];
+        copies = await copiesFor(user._id, { uniqueId, limit: 1 });
       } else if (req.body.itemId && isValidId(req.body.itemId)) {
         const asked = Math.floor(Number(req.body.quantity));
-        const owned = user.inventory
-          .filter((e) => e && String(e._id) === String(req.body.itemId))
-          .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-        copies = owned.slice(0, Number.isFinite(asked) && asked > 0 ? asked : 1);
+        copies = await copiesFor(user._id, {
+          itemId: req.body.itemId,
+          limit: Number.isFinite(asked) && asked > 0 ? asked : 1,
+        });
       } else {
         copies = [];
       }

--- a/backend/utils/inventoryCounts.js
+++ b/backend/utils/inventoryCounts.js
@@ -78,4 +78,24 @@ async function extrasFor(userId, caseId, excludeIds, cap) {
   }));
 }
 
-module.exports = { countsFor, holdingsFor, extrasFor };
+
+// the copies a listing is about, picked inside mongo. finding them in node meant reading
+// the whole array to take one entry out of it.
+async function copiesFor(userId, { uniqueId, itemId, limit }) {
+  const stages = [
+    { $match: { _id: toId(userId) } },
+    { $project: { inventory: { $ifNull: ["$inventory", []] } } },
+    { $unwind: "$inventory" },
+  ];
+  if (uniqueId) stages.push({ $match: { "inventory.uniqueId": String(uniqueId) } });
+  else if (itemId) stages.push({ $match: { "inventory._id": toId(itemId) } });
+  else return [];
+
+  // newest first, the order the route picked by hand
+  stages.push({ $sort: { "inventory.createdAt": -1 } });
+  stages.push({ $limit: Math.max(1, Math.min(Number(limit) || 1, 200)) });
+  stages.push({ $replaceRoot: { newRoot: "$inventory" } });
+  return User.aggregate(stages);
+}
+
+module.exports = { countsFor, holdingsFor, extrasFor, copiesFor };


### PR DESCRIPTION
**Problem.** Reported by the same player who has 12,457 items: "selling an item on the market takes around 15s".

`POST /marketplace` read the whole user document, then searched the inventory array in node for either one entry by `uniqueId` or the newest N of an item. For that account the read alone is about 15 seconds, and everything it wanted was one or two entries out of the array.

**Change.** `copiesFor` in `utils/inventoryCounts.js` matches, sorts newest-first and limits inside mongo, then `$replaceRoot`s to the entries. The route keeps the same two branches and the same ordering; it just no longer ships the array to find them. The level check is a projected read.

The limit is capped at 200, since the route lists each copy through the pull, the bid crossing and the publish on its own.

**Tests.** 3 new cases: one copy by uniqueId, the newest N of an item where older copies exist, and empty results for a missing copy, an unheld item and a call with no target. Existing market suites unchanged, 27 passing. Full suite 920 across 95 suites.