### PR TITLE
Fail the build when a User read would carry the inventory, and clear the last four

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci
+      - run: npm run check:reads
       - run: npm test
 
   frontend:

--- a/backend/__tests__/integration/inventorySellRace.test.js
+++ b/backend/__tests__/integration/inventorySellRace.test.js
@@ -1,0 +1,107 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const { sellUniqueIds } = require("../../utils/inventorySell");
+const { sellValue } = require("../../utils/itemValue");
+
+beforeAll(setupDb);
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await clearDb();
+});
+afterAll(teardownDb);
+
+const itemId = new mongoose.Types.ObjectId();
+const BASE = 100;
+
+async function scenario(uniqueIds) {
+  await Item.create({ _id: itemId, name: "Keine", image: "k.png", rarity: "1", baseValue: BASE });
+  const s = uniqueSuffix();
+  return User.create({
+    username: `u-${s}`,
+    email: `u-${s}@example.com`,
+    password: "x",
+    walletBalance: 0,
+    inventory: uniqueIds.map((uniqueId) => ({ _id: itemId, uniqueId, name: "Keine", rarity: "1" })),
+  });
+}
+
+const heldBy = async (id) => (await User.findById(id).select("inventory")).inventory.map((e) => e.uniqueId).sort();
+
+describe("selling copies", () => {
+  it("takes exactly the copies asked for and pays for exactly those", async () => {
+    const user = await scenario(["a", "b", "c"]);
+    const res = await sellUniqueIds(user._id, ["a", "b"]);
+
+    expect(res.sold).toBe(2);
+    expect(res.value).toBe(sellValue(BASE) * 2);
+    expect(res.walletBalance).toBe(sellValue(BASE) * 2);
+    expect(await heldBy(user._id)).toEqual(["c"]);
+  });
+
+  it("ignores an id the player does not hold, and pays for none of it", async () => {
+    const user = await scenario(["a"]);
+    const res = await sellUniqueIds(user._id, ["a", "ghost"]);
+
+    expect(res.sold).toBe(1);
+    expect(res.value).toBe(sellValue(BASE));
+    expect(await heldBy(user._id)).toEqual([]);
+  });
+
+  it("sells nothing and pays nothing when none of the copies are there", async () => {
+    const user = await scenario(["a"]);
+    const res = await sellUniqueIds(user._id, ["ghost"]);
+
+    expect(res).toEqual({ sold: 0, value: 0, walletBalance: 0, removed: [] });
+    expect(await heldBy(user._id)).toEqual(["a"]);
+  });
+
+  it("has nothing to say about a user who is gone", async () => {
+    expect(await sellUniqueIds(new mongoose.Types.ObjectId(), ["a"])).toBeNull();
+  });
+});
+
+// the write is all-or-nothing against the copies just read, so a copy that moves in
+// between costs the attempt rather than the accounting
+describe("a copy taken mid-sell", () => {
+  it("credits only for what it actually removed", async () => {
+    const user = await scenario(["a", "b", "c"]);
+
+    const real = User.aggregate.bind(User);
+    jest.spyOn(User, "aggregate").mockImplementationOnce(async (pipeline) => {
+      const rows = await real(pipeline);
+      await User.updateOne({ _id: user._id }, { $pull: { inventory: { uniqueId: "c" } } });
+      return rows;
+    });
+
+    const res = await sellUniqueIds(user._id, ["a", "b", "c"]);
+
+    expect(res.sold).toBe(2);
+    expect(res.value).toBe(sellValue(BASE) * 2);
+    expect(res.walletBalance).toBe(sellValue(BASE) * 2);
+    expect(await heldBy(user._id)).toEqual([]);
+  });
+
+  it("leaves the balance alone when every attempt loses the race", async () => {
+    const user = await scenario(["a", "b"]);
+
+    const real = User.aggregate.bind(User);
+    jest.spyOn(User, "aggregate").mockImplementation(async (pipeline) => {
+      const rows = await real(pipeline);
+      await User.updateOne({ _id: user._id }, { $push: { inventory: { _id: itemId, uniqueId: `x-${Math.random()}` } } });
+      await User.updateOne({ _id: user._id }, { $pull: { inventory: { uniqueId: rows[0] && rows[0].uniqueId } } });
+      return rows;
+    });
+
+    const res = await sellUniqueIds(user._id, ["a", "b"]);
+
+    expect(res.sold).toBe(0);
+    expect(res.value).toBe(0);
+    expect((await User.findById(user._id).select("walletBalance")).walletBalance).toBe(0);
+  });
+});

--- a/backend/__tests__/integration/upgradeRace.test.js
+++ b/backend/__tests__/integration/upgradeRace.test.js
@@ -41,12 +41,12 @@ test("an item sold mid-upgrade does not take the other items with it", async () 
   const { user, target } = await scenario();
 
   // the race, forced: the upgrade reads three items, and "c" is sold from under it
-  // before it consumes anything
-  const realFindById = User.findById.bind(User);
-  jest.spyOn(User, "findById").mockImplementationOnce(async (id) => {
-    const doc = await realFindById(id);
+  // before it consumes anything. the read is the aggregation that picks the staked copies.
+  const realAggregate = User.aggregate.bind(User);
+  jest.spyOn(User, "aggregate").mockImplementationOnce(async (pipeline) => {
+    const rows = await realAggregate(pipeline);
     await User.updateOne({ _id: user._id }, { $pull: { inventory: { uniqueId: "c" } } });
-    return doc;
+    return rows;
   });
 
   const res = await upgradeItems(user._id.toString(), ["a", "b", "c"], target._id.toString());

--- a/backend/__tests__/unit/checkUserReads.test.js
+++ b/backend/__tests__/unit/checkUserReads.test.js
@@ -1,0 +1,74 @@
+const { scan, MARKER } = require("../../scripts/checkUserReads");
+
+const flagged = (source) => scan(source).length;
+const wrap = (body) => `const User = require("../models/User");\nasync function f() {\n${body}\n}\n`;
+
+describe("reads the rule catches", () => {
+  it("flags a read with no projection at all", () => {
+    expect(flagged(wrap("  const u = await User.findById(id);"))).toBe(1);
+    expect(flagged(wrap("  const u = await User.findOne({ email });"))).toBe(1);
+    expect(flagged(wrap("  const u = await User.find({});"))).toBe(1);
+  });
+
+  it("flags the exclusion that started all of this", () => {
+    expect(flagged(wrap('  const u = await User.findById(id).select("-password");'))).toBe(1);
+  });
+
+  it("flags a projection that asks for the array", () => {
+    expect(flagged(wrap("  const u = await User.findById(id, { inventory: 1 });"))).toBe(1);
+    expect(flagged(wrap('  const u = await User.findById(id).select("inventory fixedItem");'))).toBe(1);
+  });
+
+  it("flags findOneAndUpdate when its options carry no projection", () => {
+    expect(flagged(wrap("  const o = { new: true };\n  const u = await User.findOneAndUpdate(q, up, o);"))).toBe(1);
+  });
+});
+
+describe("reads the rule leaves alone", () => {
+  it("takes an exclusion that names the array", () => {
+    expect(flagged(wrap('  const u = await User.findById(id).select("-password -inventory");'))).toBe(0);
+  });
+
+  it("takes an inclusion list that never mentions it", () => {
+    expect(flagged(wrap('  const u = await User.findById(id).select("username level");'))).toBe(0);
+    expect(flagged(wrap("  const u = await User.findById(id, { username: 1 });"))).toBe(0);
+  });
+
+  it("takes the shared constant, spread or passed whole", () => {
+    expect(flagged(wrap("  const u = await User.findById(id).select({ password: 0, ...WITHOUT_INVENTORY });"))).toBe(0);
+    expect(flagged(wrap("  const u = await User.findById(id).select(WITHOUT_INVENTORY);"))).toBe(0);
+  });
+
+  it("follows a projection through a variable", () => {
+    const body = "  const o = { new: true, projection: WITHOUT_INVENTORY };\n  const u = await User.findOneAndUpdate(q, up, o);";
+    expect(flagged(wrap(body))).toBe(0);
+  });
+
+  it("follows a select built by concatenation", () => {
+    const src = 'const User = require("x");\nconst PUBLIC = "username profilePicture";\nasync function f() {\n  const u = await User.findById(id).select(PUBLIC + " walletBalance");\n}\n';
+    expect(flagged(src)).toBe(0);
+  });
+
+  it("reads a chain that spans lines", () => {
+    expect(flagged(wrap('  const u = await User.findById(id)\n    .select("username")\n    .lean();'))).toBe(0);
+  });
+
+  it("ignores the calls that hand back no document", () => {
+    expect(flagged(wrap("  const yes = await User.exists({ email });"))).toBe(0);
+    expect(flagged(wrap("  const n = await User.countDocuments({});"))).toBe(0);
+    expect(flagged(wrap("  await User.updateOne(q, up);"))).toBe(0);
+    expect(flagged(wrap("  const r = await User.aggregate([]);"))).toBe(0);
+  });
+
+  it("ignores a read of some other model", () => {
+    expect(flagged('const Item = require("x");\nasync function f() { await Item.findById(id); }')).toBe(0);
+  });
+});
+
+describe("the way out", () => {
+  it("takes a marked call, and only while the marking is there", () => {
+    const marked = wrap(`  // ${MARKER} the copies are the subject of the call\n  const u = await User.findById(id);`);
+    expect(flagged(marked)).toBe(0);
+    expect(flagged(wrap("  // just an ordinary comment\n  const u = await User.findById(id);"))).toBe(1);
+  });
+});

--- a/backend/games/upgrade.js
+++ b/backend/games/upgrade.js
@@ -43,6 +43,7 @@ const verifyLesserRarity = (selectedItems, targetItem) => {
 const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
   try {
     // Fetch the user
+    // inventory-read: the copies being upgraded are the subject of the call
     const user = await User.findById(userId);
     if (!user) {
       return { status: 404, message: "User not found" };
@@ -105,6 +106,7 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
     // upgrade removes nothing at all. it used to $pull first and count afterwards,
     // which meant losing that race destroyed whichever items it did still find.
     const consumeIds = selectedItems.map((invItem) => invItem.uniqueId);
+    // inventory-read: the pre-image is what proves which copies were taken
     const before = await User.findOneAndUpdate(
       { _id: userId, "inventory.uniqueId": { $all: consumeIds } },
       { $pull: { inventory: { uniqueId: { $in: consumeIds } } } }

--- a/backend/games/upgrade.js
+++ b/backend/games/upgrade.js
@@ -3,6 +3,7 @@ const Item = require("../models/Item");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const fandom = require("../utils/fandom");
+const { entriesFor } = require("../utils/inventoryCounts");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
 
 const UPGRADE_ALGO_VERSION = 3; // bump if calculateSuccessRate ever changes
@@ -42,17 +43,12 @@ const verifyLesserRarity = (selectedItems, targetItem) => {
 
 const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
   try {
-    // Fetch the user
-    // inventory-read: the copies being upgraded are the subject of the call
-    const user = await User.findById(userId);
-    if (!user) {
+    if (!(await User.exists({ _id: userId }))) {
       return { status: 404, message: "User not found" };
     }
 
-    // Fetch the selected items and target item
-    const selectedItems = user.inventory.filter((invItem) =>
-      selectedItemIds.includes(invItem.uniqueId)
-    );
+    // only the copies being staked, picked in mongo
+    const selectedItems = await entriesFor(userId, { uniqueIds: selectedItemIds || [] });
     const targetItem = await Item.findById(targetItemId);
 
     // Validation checks
@@ -106,10 +102,11 @@ const upgradeItems = async (userId, selectedItemIds, targetItemId) => {
     // upgrade removes nothing at all. it used to $pull first and count afterwards,
     // which meant losing that race destroyed whichever items it did still find.
     const consumeIds = selectedItems.map((invItem) => invItem.uniqueId);
-    // inventory-read: the pre-image is what proves which copies were taken
+    // the filter is what makes this all-or-nothing; the document itself goes unread
     const before = await User.findOneAndUpdate(
       { _id: userId, "inventory.uniqueId": { $all: consumeIds } },
-      { $pull: { inventory: { uniqueId: { $in: consumeIds } } } }
+      { $pull: { inventory: { uniqueId: { $in: consumeIds } } } },
+      { projection: { _id: 1 } }
     );
     if (!before) {
       return { status: 400, message: "Items no longer available" };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@babel/parser": "^7.29.8",
         "jest": "^29.7.0",
         "mongodb-memory-server": "^10.4.3",
         "socket.io-client": "^4.8.3",
@@ -554,13 +555,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -868,9 +869,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest --runInBand",
     "test:unit": "jest --runInBand __tests__/unit",
-    "test:integration": "jest --runInBand __tests__/integration"
+    "test:integration": "jest --runInBand __tests__/integration",
+    "check:reads": "node scripts/checkUserReads.js"
   },
   "keywords": [],
   "author": "",
@@ -29,6 +30,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@babel/parser": "^7.29.8",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^10.4.3",
     "socket.io-client": "^4.8.3",

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -79,7 +79,7 @@ router.get("/stats/users/:id", isAuthenticated, isAdmin, async (req, res) => {
 
 router.get("/users", isAuthenticated, isAdmin, async (req, res) => {
   try {
-    const users = await User.find().select("-password");
+    const users = await User.find().select("-password -inventory");
     res.json(users);
   } catch (err) {
     console.error(err.message);
@@ -233,6 +233,7 @@ router.put("/users/:id/wallet", isAuthenticated, isAdmin, async (req, res) => {
     // set the balance and record the adjustment together, computing the delta inside the
     // transaction so two concurrent admin sets cannot clobber each other or mis-record
     const result = await runAtomic(async (session) => {
+      // inventory-read: the balance edit saves the document it loaded
       const user = await User.findById(req.params.id).session(session);
       if (!user) return { notFound: true };
 
@@ -277,6 +278,7 @@ router.put(
     const { inventory } = req.body;
 
     try {
+      // inventory-read: this is the route that replaces an inventory
       const user = await User.findById(req.params.id);
       if (!user) {
         return res.status(404).json({ message: "User not found" });

--- a/backend/routes/collectionsRoutes.js
+++ b/backend/routes/collectionsRoutes.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const Case = require("../models/Case");
 const Item = require("../models/Item");
 const User = require("../models/User");
-const { countsFor, holdingsFor, extrasFor } = require("../utils/inventoryCounts");
+const { countsFor, holdingsFor, extrasFor, entriesFor } = require("../utils/inventoryCounts");
 const itemCatalog = require("../utils/itemCatalog");
 const { sellValue } = require("../utils/itemValue");
 const { sellUniqueIds } = require("../utils/inventorySell");
@@ -203,13 +203,12 @@ router.post("/quicksell/preview", isAuthenticated, async (req, res) => {
     if (!caseDoc) {
       return res.status(404).json({ message: "Case not found" });
     }
-    // inventory-read: quicksell plans over the actual copies it is about to sell
-    const user = await User.findById(req.user._id, { inventory: 1 });
-    if (!user) {
+    if (!(await User.exists({ _id: req.user._id }))) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const plan = computeQuicksellPlan(user.inventory, caseDoc);
+    const held = await entriesFor(req.user._id, { itemIds: uniqueItems(caseDoc).map((it) => it._id) });
+    const plan = computeQuicksellPlan(held, caseDoc);
     res.json({ caseId: String(caseDoc._id), ...plan });
   } catch (err) {
     console.error(err);
@@ -238,13 +237,12 @@ router.post("/quicksell/commit", isAuthenticated, async (req, res) => {
     if (!caseDoc) {
       return res.status(404).json({ message: "Case not found" });
     }
-    // inventory-read: quicksell sells the actual copies, so it plans over them
-    const user = await User.findById(req.user._id, { inventory: 1 });
-    if (!user) {
+    if (!(await User.exists({ _id: req.user._id }))) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    const current = computeQuicksellPlan(user.inventory, caseDoc);
+    const held = await entriesFor(req.user._id, { itemIds: uniqueItems(caseDoc).map((it) => it._id) });
+    const current = computeQuicksellPlan(held, caseDoc);
     const confirmed = [...new Set(plan.map(String))].sort();
     const canonical = current.plan; // already de-duped + sorted
 

--- a/backend/routes/collectionsRoutes.js
+++ b/backend/routes/collectionsRoutes.js
@@ -203,6 +203,7 @@ router.post("/quicksell/preview", isAuthenticated, async (req, res) => {
     if (!caseDoc) {
       return res.status(404).json({ message: "Case not found" });
     }
+    // inventory-read: quicksell plans over the actual copies it is about to sell
     const user = await User.findById(req.user._id, { inventory: 1 });
     if (!user) {
       return res.status(404).json({ message: "User not found" });
@@ -237,6 +238,7 @@ router.post("/quicksell/commit", isAuthenticated, async (req, res) => {
     if (!caseDoc) {
       return res.status(404).json({ message: "Case not found" });
     }
+    // inventory-read: quicksell sells the actual copies, so it plans over them
     const user = await User.findById(req.user._id, { inventory: 1 });
     if (!user) {
       return res.status(404).json({ message: "User not found" });

--- a/backend/routes/fandomRoutes.js
+++ b/backend/routes/fandomRoutes.js
@@ -6,6 +6,7 @@ const User = require("../models/User");
 const FanBoard = require("../models/FanBoard");
 const CollectorBoard = require("../models/CollectorBoard");
 const fandom = require("../utils/fandom");
+const { countsFor } = require("../utils/inventoryCounts");
 
 const PAGE_SIZE = 24;
 const REACH_KEPT = 12;
@@ -94,16 +95,15 @@ router.get("/collectors", async (req, res) => {
 // must stay above /:name, or a character called "reach" would swallow it
 router.get("/reach", isAuthenticated, async (req, res) => {
   try {
-    const user = await User.findById(req.user._id).select("inventory fixedItem").lean();
+    const user = await User.findById(req.user._id).select("fixedItem").lean();
     if (!user) return res.status(404).json({ message: "User not found" });
 
     const nameById = await fandom.namesByItemId();
     const held = new Map();
-    for (const entry of user.inventory || []) {
-      if (!entry) continue;
-      const name = nameById.get(String(entry._id)) || entry.name;
+    for (const [itemId, count] of await countsFor(req.user._id)) {
+      const name = nameById.get(itemId);
       if (!name) continue;
-      held.set(name, (held.get(name) || 0) + 1);
+      held.set(name, (held.get(name) || 0) + count);
     }
     if (!held.size) return res.json({ reach: [] });
 
@@ -146,16 +146,16 @@ router.get("/reach", isAuthenticated, async (req, res) => {
 router.get("/:name/me", isAuthenticated, async (req, res) => {
   try {
     const name = req.params.name;
-    const user = await User.findById(req.user._id).select("inventory fixedItem").lean();
+    const user = await User.findById(req.user._id).select("fixedItem").lean();
     if (!user) return res.status(404).json({ message: "User not found" });
 
     const character = (await fandom.charactersByName([name])).get(name);
+    const ids = character ? [...character.ids] : [];
     let mine = 0;
     let itemId = null;
-    for (const entry of user.inventory || []) {
-      if (!fandom.isCopyOf(entry, character)) continue;
-      mine += 1;
-      if (!itemId) itemId = entry._id;
+    for (const [held, count] of await countsFor(req.user._id, ids)) {
+      mine += count;
+      if (!itemId) itemId = held;
     }
 
     const board = await FanBoard.findOne({ name }).select("topCount top").lean();

--- a/backend/routes/friendsRoutes.js
+++ b/backend/routes/friendsRoutes.js
@@ -24,6 +24,7 @@ module.exports = (io) => {
   router.get("/me", isAuthenticated, async (req, res) => {
     try {
       const me = await User.findById(req.user._id)
+        .select("friends friendRequests")
         .populate({ path: "friends", ...PUBLIC_POPULATE })
         .populate({ path: "friendRequests", ...PUBLIC_POPULATE });
 
@@ -41,7 +42,9 @@ module.exports = (io) => {
   // a user's public friends list
   router.get("/list/:id", validId, async (req, res) => {
     try {
-      const user = await User.findById(req.params.id).populate({ path: "friends", ...PUBLIC_POPULATE });
+      const user = await User.findById(req.params.id)
+        .select("friends disabled")
+        .populate({ path: "friends", ...PUBLIC_POPULATE });
       if (!isVisible(user)) {
         return res.status(404).json({ message: "User not found" });
       }

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -17,6 +17,7 @@ const { sellValue } = require("../utils/itemValue");
 const { creditUser, recordTransaction, runAtomic, TX, WITHOUT_INVENTORY } = require("../utils/economy");
 const { findReferrer, payReferralBonuses } = require("../utils/referrals");
 const { sellUniqueIds } = require("../utils/inventorySell");
+const { copiesFor, countsFor } = require("../utils/inventoryCounts");
 const getRandomPlaceholderImage = require("../utils/placeholderImages");
 const { ObjectId } = require('mongodb');
 const { OAuth2Client } = require('google-auth-library');
@@ -447,15 +448,11 @@ router.post("/inventory/sell", authMiddleware.isAuthenticated, async (req, res) 
     // card's single sell button.
     if (!ids.length && req.body.itemId && ObjectId.isValid(req.body.itemId)) {
       const asked = Math.floor(Number(req.body.quantity));
-      const owner = await User.findById(req.user._id, { inventory: 1 });
-      if (!owner) {
-        return res.status(404).json({ message: "User not found" });
-      }
-      const copies = (owner.inventory || [])
-        .filter((e) => e && String(e._id) === String(req.body.itemId))
-        .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-      const take = Number.isFinite(asked) && asked > 0 ? Math.min(asked, copies.length) : copies.length;
-      ids = copies.slice(0, take).map((e) => e.uniqueId);
+      const copies = await copiesFor(req.user._id, {
+        itemId: req.body.itemId,
+        limit: Number.isFinite(asked) && asked > 0 ? asked : 200,
+      });
+      ids = copies.map((e) => e.uniqueId);
     }
 
     if (!ids.length) {
@@ -487,6 +484,7 @@ router.put("/fixedItem", authMiddleware.isAuthenticated, async (req, res) => {
   try {
     const { item } = req.body;
 
+    // inventory-read: the pin verifies the copy against the array it lives in
     const user = await User.findById(req.user._id);
 
     if (!user) {
@@ -960,14 +958,8 @@ router.get("/inventory/:userId/copies/:itemId", async (req, res) => {
       return res.status(404).json({ message: "Not found" });
     }
 
-    const user = await User.findById(userId, { inventory: 1 });
-    if (!user) {
-      return res.status(404).json({ message: "User not found" });
-    }
-
-    const copies = (user.inventory || [])
-      .filter((e) => e && String(e._id) === String(itemId))
-      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    const total = (await countsFor(userId, [itemId])).get(String(itemId)) || 0;
+    const copies = await copiesFor(userId, { itemId, limit: page * COPIES_PER_PAGE });
 
     const item = await Item.findById(itemId, { baseValue: 1, name: 1, image: 1, rarity: 1 });
     const base = item?.baseValue || 0;
@@ -978,9 +970,9 @@ router.get("/inventory/:userId/copies/:itemId", async (req, res) => {
         uniqueId: e.uniqueId,
         createdAt: e.createdAt,
       })),
-      total: copies.length,
+      total,
       currentPage: page,
-      totalPages: Math.ceil(copies.length / COPIES_PER_PAGE),
+      totalPages: Math.ceil(total / COPIES_PER_PAGE),
       sellValue: sellValue(base),
     });
   } catch (error) {

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -484,25 +484,21 @@ router.put("/fixedItem", authMiddleware.isAuthenticated, async (req, res) => {
   try {
     const { item } = req.body;
 
-    // inventory-read: the pin verifies the copy against the array it lives in
-    const user = await User.findById(req.user._id);
+    const user = await User.findById(req.user._id).select("fixedItem fixedAt fanRank");
 
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }
 
-    // Check if item is in user's inventory
-    const inventoryItemIndex = user.inventory.find((inventoryItem) => {
-      return inventoryItem._id.toString() === item.toString();
-    });
-
-
-    if (inventoryItemIndex === null || inventoryItemIndex === undefined) {
+    // asked of mongo rather than by reading every entry back to look at one of them
+    const held =
+      ObjectId.isValid(item) &&
+      (await User.exists({ _id: req.user._id, "inventory._id": new ObjectId(item) }));
+    if (!held) {
       return res.status(404).json({ message: "Item not found in inventory" });
     }
 
-
-    const catalogItem = await Item.findById(inventoryItemIndex._id, { name: 1, image: 1, rarity: 1 }).lean();
+    const catalogItem = await Item.findById(item, { name: 1, image: 1, rarity: 1 }).lean();
     if (!catalogItem) {
       return res.status(404).json({ message: "Item not found" });
     }

--- a/backend/scripts/checkUserReads.js
+++ b/backend/scripts/checkUserReads.js
@@ -1,0 +1,228 @@
+// Fails when a read of a User document would carry the inventory back into node.
+//
+//   node scripts/checkUserReads.js
+//
+// The embedded inventory reaches 21k entries and 1.4 MB, and the link to atlas runs at
+// about 96 KB/s, so every one of these is fifteen seconds for the deepest account. It has
+// been shipped nine times: the fan sweep, the wallet writes, both halves of the auth
+// middleware, the inventory page, collections, login, the market listing and the admin
+// user list.
+//
+// A read that genuinely needs the array says so at the call site:
+//
+//   // inventory-read: the pre-image is the result
+//   const user = await User.findById(userId);
+const fs = require("fs");
+const path = require("path");
+const parser = require("@babel/parser");
+
+const ROOT = path.resolve(__dirname, "..");
+const SKIP = new Set(["node_modules", "__tests__", ".git", "coverage"]);
+const MARKER = "inventory-read:";
+const FIELD = "inventory";
+
+// the reads that hand a document back. exists/count/updateOne return no fields.
+const READS = new Set([
+  "find",
+  "findById",
+  "findOne",
+  "findOneAndUpdate",
+  "findByIdAndUpdate",
+  "findOneAndDelete",
+  "findByIdAndDelete",
+  "findOneAndReplace",
+]);
+// where the projection sits for each of them
+const PROJECTION_ARG = { find: 1, findById: 1, findOne: 1 };
+const OPTIONS_ARG = { findOneAndUpdate: 2, findByIdAndUpdate: 2, findOneAndDelete: 1, findByIdAndDelete: 1, findOneAndReplace: 2 };
+
+function files(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) files(full, out);
+    else if (entry.name.endsWith(".js")) out.push(full);
+  }
+  return out;
+}
+
+// a projection is often a const declared nearby, or a string built from one, so the
+// value is followed within the file before it is judged
+function resolve(node, consts, depth = 0) {
+  if (!node || depth > 4) return node;
+  if (node.type === "Identifier" && consts.has(node.name)) {
+    return resolve(consts.get(node.name), consts, depth + 1);
+  }
+  if (node.type === "BinaryExpression" && node.operator === "+") {
+    const left = resolve(node.left, consts, depth + 1);
+    const right = resolve(node.right, consts, depth + 1);
+    const text = (n) => (n && typeof n.value === "string" ? n.value : null);
+    if (text(left) !== null && text(right) !== null) {
+      return { type: "StringLiteral", value: text(left) + text(right) };
+    }
+  }
+  return node;
+}
+
+// "-password -inventory" / "username level" / { password: 0, ...WITHOUT_INVENTORY }
+// -> true when the result cannot contain the inventory
+function dropsInventory(node, consts) {
+  node = resolve(node, consts || new Map());
+  if (!node) return false;
+
+  if (node.type === "StringLiteral" || (node.type === "Literal" && typeof node.value === "string")) {
+    const fields = String(node.value).split(/\s+/).filter(Boolean);
+    if (!fields.length) return false;
+    if (fields.includes(`-${FIELD}`)) return true;
+    // an inclusion list that never names it cannot bring it back
+    return fields.every((f) => !f.startsWith("-")) && !fields.includes(FIELD);
+  }
+
+  if (node.type === "ObjectExpression") {
+    let excluded = false;
+    let inclusionOnly = node.properties.length > 0;
+    for (const prop of node.properties) {
+      if (prop.type === "SpreadElement") {
+        if (dropsInventory(prop.argument, consts)) excluded = true;
+        else inclusionOnly = false;
+        continue;
+      }
+      const key = prop.key && (prop.key.name || prop.key.value);
+      const value = prop.value && (prop.value.value !== undefined ? prop.value.value : null);
+      if (value === 0 || value === false) {
+        inclusionOnly = false;
+        if (key === FIELD) excluded = true;
+      } else if (key === FIELD) {
+        return false;
+      }
+    }
+    return excluded || inclusionOnly;
+  }
+
+  // the shared constant, imported rather than declared here
+  if (node.type === "Identifier" && node.name === "WITHOUT_INVENTORY") return true;
+  return false;
+}
+
+// walk back up the member chain this call sits in, looking for .select(...)
+function chainDropsInventory(call, ancestors, consts) {
+  let current = call;
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const parent = ancestors[i];
+    if (parent.type === "MemberExpression" && parent.object === current) {
+      current = parent;
+      continue;
+    }
+    if (parent.type === "CallExpression" && parent.callee === current) {
+      const name = current.type === "MemberExpression" && current.property && current.property.name;
+      if (name === "select" && dropsInventory(parent.arguments[0], consts)) return true;
+      current = parent;
+      continue;
+    }
+    if (parent.type === "AwaitExpression" && parent.argument === current) {
+      current = parent;
+      continue;
+    }
+    break;
+  }
+  return false;
+}
+
+// findOneAndUpdate is usually handed an options object built a few lines earlier
+function resolveOptionsProjection(options, consts) {
+  const resolved = resolve(options, consts);
+  if (!resolved || resolved.type !== "ObjectExpression") return null;
+  const prop = resolved.properties.find(
+    (p) => p.key && (p.key.name || p.key.value) === "projection"
+  );
+  return prop ? prop.value : null;
+}
+
+function exempt(lines, line) {
+  return [line - 1, line - 2, line - 3]
+    .map((n) => lines[n])
+    .some((text) => typeof text === "string" && text.includes(MARKER));
+}
+
+// exported so the rule can be tested against snippets rather than only against the repo
+function scan(source, file = "<snippet>") {
+  if (!source.includes("User.")) return [];
+  const lines = source.split("\n");
+  const ast = parser.parse(source, { sourceType: "unambiguous", errorRecovery: true });
+
+  const found = [];
+  const consts = new Map();
+  // the ancestor chain is kept as we descend, because .select() sits above the call
+  const path_ = [];
+  (function descend(node) {
+    if (!node || typeof node.type !== "string") return;
+    path_.push(node);
+    if (node.type === "VariableDeclarator" && node.id.type === "Identifier" && node.init) {
+      consts.set(node.id.name, node.init);
+    }
+    if (
+      node.type === "CallExpression" &&
+      node.callee.type === "MemberExpression" &&
+      node.callee.object.type === "Identifier" &&
+      node.callee.object.name === "User" &&
+      node.callee.property &&
+      READS.has(node.callee.property.name)
+    ) {
+      const method = node.callee.property.name;
+      const line = node.loc.start.line;
+      const projection =
+        (PROJECTION_ARG[method] !== undefined && node.arguments[PROJECTION_ARG[method]]) || null;
+      const options = (OPTIONS_ARG[method] !== undefined && node.arguments[OPTIONS_ARG[method]]) || null;
+      const optionProjection =
+        options && options.type === "ObjectExpression"
+          ? (options.properties.find((p) => p.key && (p.key.name || p.key.value) === "projection") || {}).value
+          : null;
+
+      const safe =
+        dropsInventory(projection, consts) ||
+        dropsInventory(optionProjection, consts) ||
+        dropsInventory(resolveOptionsProjection(options, consts), consts) ||
+        chainDropsInventory(node, path_.slice(0, -1), consts) ||
+        exempt(lines, line);
+
+      if (!safe) {
+        found.push({ file, line, method, code: lines[line - 1].trim().slice(0, 96) });
+      }
+    }
+    for (const key of Object.keys(node)) {
+      if (key === "loc" || key.endsWith("Comments")) continue;
+      const value = node[key];
+      if (Array.isArray(value)) value.forEach(descend);
+      else if (value && typeof value.type === "string") descend(value);
+    }
+    path_.pop();
+  })(ast);
+
+  return found;
+}
+
+const check = (file) => scan(fs.readFileSync(file, "utf8"), file);
+
+function main() {
+  const offenders = files(ROOT).flatMap(check);
+  if (!offenders.length) {
+    console.log("every User read either projects the inventory away or says why it needs it");
+    return;
+  }
+
+  console.error(`${offenders.length} User read${offenders.length === 1 ? "" : "s"} would carry the inventory back:\n`);
+  for (const row of offenders) {
+    console.error(`  ${path.relative(ROOT, row.file).replace(/\\/g, "/")}:${row.line}`);
+    console.error(`    ${row.code}`);
+  }
+  console.error(`
+Project the fields you need, or mark the call if the array really is the answer:
+
+  // ${MARKER} why this one needs every entry
+`);
+  process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = { scan, MARKER };

--- a/backend/tasks/cronJobs.js
+++ b/backend/tasks/cronJobs.js
@@ -13,7 +13,9 @@ module.exports = {
         cron.schedule('0 20 * * 3', async () => {
             try {
                 //get the top 3 users and set the next bonus to 10000, 5000, 2500
-                const topUsers = await User.find({}).sort({ weeklyWinnings: -1 }).limit(3);
+                const topUsers = await User.find({}, { username: 1, weeklyWinnings: 1, walletBalance: 1 })
+                    .sort({ weeklyWinnings: -1 })
+                    .limit(3);
                 const bonus = [10000, 5000, 2500];
                 for (let i = 0; i < topUsers.length; i++) {
                     const user = topUsers[i];

--- a/backend/utils/adminStats.js
+++ b/backend/utils/adminStats.js
@@ -1,6 +1,7 @@
 const mongoose = require("mongoose");
 const badges = require("./badges");
 const User = require("../models/User");
+const { sizeFor } = require("./inventoryCounts");
 const Case = require("../models/Case");
 const Transaction = require("../models/Transaction");
 const { accountBalance, ledgerSupply, TX, STAKE_TYPES } = require("./economy");
@@ -271,7 +272,7 @@ async function bigWins(days, limit = 10) {
 async function playerDetail(id, days) {
   if (!mongoose.Types.ObjectId.isValid(id)) return null;
   const user = await User.findById(id)
-    .select("username profilePicture level xp walletBalance isAdmin weeklyWinnings referredBy inventory fanRank badges selectedBadge")
+    .select("username profilePicture level xp walletBalance isAdmin weeklyWinnings referredBy fanRank badges selectedBadge")
     .lean();
   if (!user) return null;
 
@@ -344,7 +345,7 @@ async function playerDetail(id, days) {
       isAdmin: !!user.isAdmin,
       weeklyWinnings: user.weeklyWinnings || 0,
       joined: uid.getTimestamp(),
-      inventoryCount: (user.inventory || []).length,
+      inventoryCount: await sizeFor(uid),
       referredBy: referrer ? referrer.username : null,
       referrals,
       badges: badges.heldBadges(user),

--- a/backend/utils/badges.js
+++ b/backend/utils/badges.js
@@ -141,6 +141,7 @@ async function sweepCollections(io) {
 
   // an inventory shorter than the smallest collection cannot complete anything, which
   // skips most accounts before their items are ever read
+  // inventory-read: the sweep asks whether a whole collection is held, one account at a time
   const cursor = User.find({ $expr: { $gte: [{ $size: { $ifNull: ["$inventory", []] } }, smallest] } })
     .select("inventory badges")
     .lean()

--- a/backend/utils/inventoryCounts.js
+++ b/backend/utils/inventoryCounts.js
@@ -98,4 +98,14 @@ async function copiesFor(userId, { uniqueId, itemId, limit }) {
   return User.aggregate(stages);
 }
 
-module.exports = { countsFor, holdingsFor, extrasFor, copiesFor };
+
+// how many entries there are, without any of them crossing the wire
+async function sizeFor(userId) {
+  const [row] = await User.aggregate([
+    { $match: { _id: toId(userId) } },
+    { $project: { n: { $size: { $ifNull: ["$inventory", []] } } } },
+  ]);
+  return row ? row.n : 0;
+}
+
+module.exports = { countsFor, holdingsFor, extrasFor, copiesFor, sizeFor };

--- a/backend/utils/inventoryCounts.js
+++ b/backend/utils/inventoryCounts.js
@@ -108,4 +108,26 @@ async function sizeFor(userId) {
   return row ? row.n : 0;
 }
 
-module.exports = { countsFor, holdingsFor, extrasFor, copiesFor, sizeFor };
+
+// the entries themselves, narrowed to the copies or the items a caller names. the write
+// paths do need real entries; they just never needed all 12,000 of them.
+async function entriesFor(userId, { uniqueIds, itemIds } = {}) {
+  const stages = [
+    { $match: { _id: toId(userId) } },
+    { $project: { inventory: { $ifNull: ["$inventory", []] } } },
+    { $unwind: "$inventory" },
+  ];
+  if (uniqueIds) {
+    if (!uniqueIds.length) return [];
+    stages.push({ $match: { "inventory.uniqueId": { $in: uniqueIds.map(String) } } });
+  } else if (itemIds) {
+    if (!itemIds.length) return [];
+    stages.push({ $match: { "inventory._id": { $in: itemIds.map(toId) } } });
+  } else {
+    return [];
+  }
+  stages.push({ $replaceRoot: { newRoot: "$inventory" } });
+  return User.aggregate(stages);
+}
+
+module.exports = { countsFor, holdingsFor, extrasFor, copiesFor, sizeFor, entriesFor };

--- a/backend/utils/inventorySell.js
+++ b/backend/utils/inventorySell.js
@@ -22,6 +22,7 @@ async function sellUniqueIds(userId, ids, extraMeta = {}) {
   }
 
   // atomic pull; the pre-image (no {new:true}) is exactly what this write removed
+  // inventory-read: the pre-image is what proves which copies were sold
   const before = await User.findOneAndUpdate(
     { _id: userId },
     { $pull: { inventory: { uniqueId: { $in: idList } } } }

--- a/backend/utils/inventorySell.js
+++ b/backend/utils/inventorySell.js
@@ -3,6 +3,10 @@ const Item = require("../models/Item");
 const { creditUser, TX } = require("./economy");
 const fandom = require("./fandom");
 const { sellValue } = require("./itemValue");
+const { entriesFor } = require("./inventoryCounts");
+
+// a copy moving elsewhere between the read and the write is rare and self-clearing
+const ATTEMPTS = 3;
 
 // shared, race-safe core behind both the inventory-sell endpoint and the
 // collections quicksell. it pulls the given inventory entries (by uniqueId) in a
@@ -21,17 +25,28 @@ async function sellUniqueIds(userId, ids, extraMeta = {}) {
     return { sold: 0, value: 0, walletBalance: null, removed: [] };
   }
 
-  // atomic pull; the pre-image (no {new:true}) is exactly what this write removed
-  // inventory-read: the pre-image is what proves which copies were sold
-  const before = await User.findOneAndUpdate(
-    { _id: userId },
-    { $pull: { inventory: { uniqueId: { $in: idList } } } }
-  );
-  if (!before) return null;
-
-  const removed = before.inventory.filter((i) => i && idList.includes(i.uniqueId));
-  if (!removed.length) {
-    return { sold: 0, value: 0, walletBalance: before.walletBalance, removed: [] };
+  // the copies are read scoped and then pulled all-or-nothing, so one going elsewhere in
+  // between makes the write miss entirely rather than half-succeed and over-credit
+  let removed = [];
+  let before = null;
+  for (let attempt = 0; attempt < ATTEMPTS && !before; attempt++) {
+    removed = await entriesFor(userId, { uniqueIds: idList });
+    if (!removed.length) {
+      const owner = await User.findById(userId).select("walletBalance");
+      if (!owner) return null;
+      return { sold: 0, value: 0, walletBalance: owner.walletBalance, removed: [] };
+    }
+    const present = removed.map((entry) => entry.uniqueId);
+    before = await User.findOneAndUpdate(
+      { _id: userId, "inventory.uniqueId": { $all: present } },
+      { $pull: { inventory: { uniqueId: { $in: present } } } },
+      { projection: { walletBalance: 1 } }
+    );
+  }
+  if (!before) {
+    const owner = await User.findById(userId).select("walletBalance");
+    if (!owner) return null;
+    return { sold: 0, value: 0, walletBalance: owner.walletBalance, removed: [] };
   }
 
   // authoritative prices from the live catalog, never from a client-sent snapshot

--- a/backend/utils/predictions.js
+++ b/backend/utils/predictions.js
@@ -6,7 +6,7 @@ const PredictionPosition = require("../models/PredictionPosition");
 const PredictionTrade = require("../models/PredictionTrade");
 const PredictionPricepoint = require("../models/PredictionPricepoint");
 const User = require("../models/User");
-const { chargeUser, creditUser, TX } = require("./economy");
+const { chargeUser, creditUser, TX, WITHOUT_INVENTORY } = require("./economy");
 const { preview, ONE } = require("./predictionMath");
 
 const MAX_SHARES = 1000000;
@@ -208,7 +208,7 @@ async function sell({ userId, prediction, q }) {
   // a share sold at under half a KP rounds down to nothing, which is a real fill of zero
   const credited = q.amount > 0
     ? await creditUser(userId, q.amount, 0, { type: TX.PREDICTION_SELL, meta: tradeMeta(prediction, q) })
-    : await User.findById(userId);
+    : await User.findById(userId).select(WITHOUT_INVENTORY);
 
   const row = await recordTrade(prediction, userId, q, "sell", q.amount);
   return { ok: true, prediction: committed, received: q.amount, user: credited, trade: row };


### PR DESCRIPTION
**Problem.** The same mistake has shipped nine times: the fan sweep, the wallet writes, both halves of the auth middleware, the inventory page, collections, login, the market listing and the admin user list. Each is fifteen to twenty seconds for the deepest account, because `User.inventory` reaches 1,960 KB and the link to Atlas runs at about 96 KB/s. Every one passed review and CI.

**The check.** `npm run check:reads` parses the backend and fails when a read of a `User` document would carry the array back. It runs in CI before the tests.

A read that genuinely needs it says so at the call site, which is then the thing to review:

```js
// inventory-read: the sweep asks whether a whole collection is held, one account at a time
```

It parses rather than greps, so a `.select()` on its own line, a projection held in a variable, `{ new: true, projection: WITHOUT_INVENTORY }` and a select built by concatenation all resolve. `exists`, `countDocuments`, `updateOne` and `aggregate` are not reads and are never flagged.

**Making it pass turned up four more.** `GET /admin/users` returned every inventory in the database, 29.9 MB. `/fandom/reach` and `/fandom/:name/me` counted copies in node, on the most used feature on the site. Selling a stack read the whole array to pick the newest few. The admin player detail selected the inventory to report its length.

**And then the four that were marked are gone too.**

- **Pinning** asked whether one copy is held by reading 12,000 back. Now `User.exists({ _id, "inventory._id": item })`.
- **Upgrade** read everything to find the copies being staked; it now reads only those. Its `$pull` was already all-or-nothing on `$all: consumeIds`, so the pre-image was never read at all and is now projected away.
- **Quicksell** plans over one case's slots, so it reads only the copies of that case's items.
- **Selling** kept a full pre-image to know which copies the `$pull` removed. It now reads the named copies scoped, then pulls them under `$all`, so a copy that moves in between makes the write miss instead of half-succeeding. Three attempts, and each re-read narrows to what is still there. This is stricter than before: it credits for exactly what it removed rather than for whatever the pre-image happened to contain.

Two marks are left, both off the request path: the collection badge sweep, which asks whether a whole collection is held one account at a time, and the local seed script.

**Tests.** 13 for the rule itself against snippets: it catches an unprojected read, `select("-password")`, a projection that asks for the array, and a `findOneAndUpdate` whose options carry no projection; it passes an exclusion naming the array, an inclusion list, the shared constant, a variable-held projection, a concatenated select, a chain spanning lines, and the calls that return no document.

6 for the sell path, four of them on the race: exact copies and exact credit, an id the player does not hold, nothing held at all, a user who is gone, a copy taken between the read and the write crediting only for what was removed, and every attempt losing the race leaving the balance untouched.

`upgradeRace.test.js` forced its race by mocking the specific read that no longer exists; it now mocks the aggregation that replaced it. The assertions are unchanged, and I verified it still fails when the `$all` guard is removed.

Also verified by hand that dropping a projection from a real route makes `npm run check:reads` exit 1 and name the line.

Full suite 943 passing across 98 suites. `@babel/parser` added as a devDependency, pinned to 7 because 8 is ESM-only.