### PR TITLE
Draw every card from art served by us

### DIFF
--- a/backend/scripts/rehostItemArt.js
+++ b/backend/scripts/rehostItemArt.js
@@ -1,0 +1,82 @@
+// Repoints stored art urls at our own bucket, from a manifest of {oldUrl: newUrl}.
+//
+//   node scripts/rehostItemArt.js ../art-manifest.json            (dry run)
+//   node scripts/rehostItemArt.js ../art-manifest.json --apply
+//
+// Dry run by default. Idempotent: a url already repointed no longer matches anything.
+// Inventory copies are left alone on purpose, because the catalog is what the app reads
+// an item's image from; a copy taken at drop time is already allowed to be stale.
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const mongoose = require("mongoose");
+
+const [, , manifestPath] = process.argv;
+const APPLY = process.argv.includes("--apply");
+
+// one find and one bulkWrite per collection, rather than a query per url
+async function flat(db, collection, field, manifest, keys) {
+  const rows = await db
+    .collection(collection)
+    .find({ [field]: { $in: keys } }, { projection: { [field]: 1 } })
+    .toArray();
+  if (!APPLY || !rows.length) return rows.length;
+
+  const res = await db.collection(collection).bulkWrite(
+    rows.map((row) => ({
+      updateOne: { filter: { _id: row._id }, update: { $set: { [field]: manifest[row[field]] } } },
+    })),
+    { ordered: false }
+  );
+  return res.modifiedCount;
+}
+
+// predictions carry art on each outcome as well as on the market itself
+async function nested(db, manifest, keys) {
+  const rows = await db
+    .collection("predictions")
+    .find({ "outcomes.image": { $in: keys } }, { projection: { "outcomes.image": 1 } })
+    .toArray();
+  let changed = 0;
+  for (const row of rows) {
+    const updates = (row.outcomes || [])
+      .map((outcome, index) => [index, manifest[outcome && outcome.image]])
+      .filter(([, next]) => next);
+    if (!updates.length) continue;
+    changed += 1;
+    if (!APPLY) continue;
+    const $set = {};
+    for (const [index, next] of updates) $set[`outcomes.${index}.image`] = next;
+    await db.collection("predictions").updateOne({ _id: row._id }, { $set });
+  }
+  return changed;
+}
+
+async function main() {
+  if (!manifestPath) {
+    console.error("usage: node scripts/rehostItemArt.js <manifest.json> [--apply]");
+    process.exit(1);
+  }
+  const manifest = JSON.parse(fs.readFileSync(path.resolve(manifestPath), "utf8"));
+  const keys = Object.keys(manifest);
+  console.log(`${APPLY ? "applying" : "DRY RUN over"} ${keys.length} urls`);
+
+  await mongoose.connect(process.env.MONGO_URI);
+  const db = mongoose.connection.db;
+
+  for (const [collection, field] of [["items", "image"], ["cases", "image"], ["fanboards", "image"], ["predictions", "image"]]) {
+    console.log(`${String(await flat(db, collection, field, manifest, keys)).padStart(6)}  ${collection}.${field}`);
+  }
+  console.log(`${String(await nested(db, manifest, keys)).padStart(6)}  predictions.outcomes[].image`);
+
+  const left = await db.collection("items").countDocuments({ image: /steamstatic\.com/ });
+  console.log(`\nitems still pointing at steam: ${left}`);
+  if (!APPLY) console.log("nothing was written. re-run with --apply");
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error("FAILED:", err.message);
+  process.exit(1);
+});

--- a/src/components/fanCard/cardAssets.ts
+++ b/src/components/fanCard/cardAssets.ts
@@ -20,38 +20,21 @@ export function loadCardFonts() {
   return fonts;
 }
 
-// only our own bucket carries a cors policy. two thirds of the catalog sits on steam's
-// cdn, which does not, so that art has to arrive through the api instead.
-const OWN_BUCKET = /^kanicases\.s3[.-]/;
-
-const hostOf = (src: string) => {
-  try {
-    return new URL(src, window.location.href).host;
-  } catch {
-    return "";
-  }
-};
-
-export const needsProxy = (src: string) => !OWN_BUCKET.test(hostOf(src));
-
-function loadImage(src: string, cors: boolean) {
+function loadImage(src: string) {
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const img = new Image();
-    if (cors) img.crossOrigin = "anonymous";
     img.onload = () => resolve(img);
     img.onerror = () => reject(new Error("Could not load the character art"));
     img.src = src;
   });
 }
 
-// crossOrigin is what keeps the canvas exportable, and a blob from our own api is
-// same-origin, so neither route taints it.
+// every card image comes through our own origin as a blob, so the canvas is never
+// tainted and no cors header on anyone else's host has to be right for this to work.
 export async function loadCardArt(src: string) {
-  if (!needsProxy(src)) return loadImage(src, true);
-
   const objectUrl = URL.createObjectURL(await getArt(src));
   try {
-    const img = await loadImage(objectUrl, false);
+    const img = await loadImage(objectUrl);
     await img.decode().catch(() => undefined);
     return img;
   } finally {

--- a/src/components/fanCard/fanCard.test.ts
+++ b/src/components/fanCard/fanCard.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { ALL_STYLES, PINNED, resolveStyle, stylesFor } from "./cardStyles";
 import { cardFromBoard, cardFromStanding, yearOf } from "./cardData";
 import { fileNameFor } from "./ShareCard/ShareCard.services";
-import { needsProxy } from "./cardAssets";
 import { FanBoard, FanRank } from "../../services/fandom/FandomService";
 
 const fan = {
@@ -99,19 +98,5 @@ describe("supporting bits", () => {
     expect(fileNameFor("Keine")).toBe("keine-top-fan.png");
     expect(fileNameFor("Yuuma Toutetsu")).toBe("yuuma-toutetsu-top-fan.png");
     expect(fileNameFor("???")).toBe("fan-top-fan.png");
-  });
-});
-
-describe("where the art has to come from", () => {
-  it("loads our own bucket straight, since that is the one with a cors policy", () => {
-    expect(needsProxy("https://kanicases.s3.amazonaws.com/touhou/Keine.png")).toBe(false);
-    expect(needsProxy("https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/10033.webp")).toBe(false);
-  });
-
-  it("sends everything else through the api, steam's cdn being two thirds of the catalog", () => {
-    expect(needsProxy("https://community.akamai.steamstatic.com/economy/image/abc/360fx360f")).toBe(true);
-    expect(needsProxy("https://example.com/x.png")).toBe(true);
-    expect(needsProxy("")).toBe(true);
-    expect(needsProxy("kanicases.s3.amazonaws.com/no-scheme.png")).toBe(true);
   });
 });


### PR DESCRIPTION
**Problem.** The share card still fails on production with a CORS error on our own bucket:

```
Access to image at 'https://kanicases.s3.us-east-1.amazonaws.com/cases/bluearchive/10019.webp'
from origin 'https://kanicasino.com' has been blocked by CORS policy
```

This was supposed to be fixed in #233. It was not: the commit that made the card stop depending on CORS exists but never landed on `main`. My push raced a branch update on the PR and the merge took the older head, so what shipped was the version that still loads our own bucket directly with `crossOrigin`. This is that commit, re-applied.

**Change.** Every card image is fetched through `GET /items/art` and drawn from a same-origin blob. No `crossOrigin`, no `Access-Control-Allow-Origin` on anyone's host, nothing to be right at request time. The direct-load path and the host check that chose between them are gone.

The bucket policy stays: it is correct and other things use it. The card just no longer depends on it.

Also brings `scripts/rehostItemArt.js`, which was in the same lost commit. The data change it performs is already applied in production.

**Why not fix the CORS failure itself.** I could not reproduce it: `curl` returns the header for that exact object, and a fresh browser, a warm browser, and a browser with a disk-cached plain copy all load it under `crossOrigin`. The most likely explanation is a response cached before the policy existed, still fresh under `Cache-Control: max-age=604800`. Going through our own origin removes the class of problem rather than that instance.

**Tests.** Frontend 138 passing, build and lint clean. The proxy path was verified end to end against the real CDN and a real browser in #233: direct load blocked, proxied load 360x360, canvas export 113 KB.