### PR TITLE
Only offer the share card to whoever leads the board

### DIFF
--- a/src/components/fanCard/cardData.ts
+++ b/src/components/fanCard/cardData.ts
@@ -23,6 +23,9 @@ export const cardFromBoard = (board: FanBoard, desc = ""): FanCardData | null =>
       }
     : null;
 
+// the cards come with the crown: a runner-up has nothing to share
+export const canShareCard = (fanRank?: FanRank | null) => fanRank?.rank === 1;
+
 // the profile works off the standing the sweep left on the player, which is why that
 // carries the runner-up count and the pin date
 export const cardFromStanding = (

--- a/src/components/fanCard/fanCard.test.ts
+++ b/src/components/fanCard/fanCard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { ALL_STYLES, PINNED, resolveStyle, stylesFor } from "./cardStyles";
-import { cardFromBoard, cardFromStanding, yearOf } from "./cardData";
+import { canShareCard, cardFromBoard, cardFromStanding, yearOf } from "./cardData";
 import { fileNameFor } from "./ShareCard/ShareCard.services";
 import { FanBoard, FanRank } from "../../services/fandom/FandomService";
 
@@ -83,6 +83,14 @@ describe("building the card", () => {
 
   it("has no card for a player who pinned nothing", () => {
     expect(cardFromStanding(null, "Konmaru", 48)).toBeNull();
+  });
+
+  it("only lets the board leader share", () => {
+    const lead = { name: "Keine", image: "k.png", rarity: "1", count: 490, rank: 1, fans: 5 };
+    expect(canShareCard(lead)).toBe(true);
+    expect(canShareCard({ ...lead, rank: 2, count: 4 })).toBe(false);
+    expect(canShareCard(null)).toBe(false);
+    expect(canShareCard(undefined)).toBe(false);
   });
 });
 

--- a/src/pages/Profile/UserInfo.tsx
+++ b/src/pages/Profile/UserInfo.tsx
@@ -10,7 +10,7 @@ import Avatar from "../../components/Avatar";
 import { User } from '../../components/Types'
 // the card renderer and its display faces are dead weight until someone opens the sheet
 const ShareCard = lazy(() => import("../../components/fanCard/ShareCard"));
-import { cardFromStanding } from "../../components/fanCard/cardData";
+import { canShareCard, cardFromStanding } from "../../components/fanCard/cardData";
 import i18n from "../../i18n";
 
 interface UserProps {
@@ -38,7 +38,7 @@ const UserInfo: React.FC<UserProps> = ({
   const [pickingAvatar, setPickingAvatar] = useState(false);
   const [sharing, setSharing] = useState(false);
   const card = useMemo(
-    () => cardFromStanding(fanRank, username, level, fixedItem?.description || ""),
+    () => (canShareCard(fanRank) ? cardFromStanding(fanRank, username, level, fixedItem?.description || "") : null),
     [fanRank, username, level, fixedItem]
   );
 


### PR DESCRIPTION
**Problem.** The profile built a fan card from any `fanRank`, so a player sitting at #2 or below saw the share button on their own profile. The board page already gated on `iHold`; the profile did not.

**Change.** Named the rule as `canShareCard` in `cardData.ts` and gated the profile's card on it. Since `card` feeds the button, the modal and `leadsABoard`, one condition closes all three. A runner-up still sees their standing and count, just no share button.

**Tests.** `npm run test:unit` 139 passed, including a new case over rank 1 / rank 2 / null. `npx eslint src --ext ts,tsx` 0 errors, `npm run build` clean.