### PR TITLE
Stop keeping ten thousand spent seeds per retired chain

### DIFF
--- a/backend/__tests__/integration/gameChain.test.js
+++ b/backend/__tests__/integration/gameChain.test.js
@@ -3,7 +3,8 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
 const { setupDb, clearDb, teardownDb } = require("./db");
 const GameSeedChain = require("../../models/GameSeedChain");
 const { consumeNextSeed } = require("../../utils/gameChain");
-const { sha256, linksTo } = require("../../utils/hashChain");
+const { CHAIN_LENGTH } = require("../../utils/gameChain");
+const { sha256, linksTo, seedAt } = require("../../utils/hashChain");
 
 beforeAll(setupDb);
 afterEach(clearDb);
@@ -51,4 +52,21 @@ test("an exhausted chain rotates to a fresh commitment", async () => {
   expect(rotated.terminalHash).not.toBe(oldTerminal);
   expect(rotated.index).toBe(0);
   expect(await GameSeedChain.countDocuments({ game: "crash", active: true })).toBe(1);
+});
+
+test("a retired chain keeps only the root every spent seed derives from", async () => {
+  const first = await consumeNextSeed("crash");
+  const chain = await GameSeedChain.findOne({ game: "crash" });
+  await GameSeedChain.updateOne({ _id: chain._id }, { $set: { cursor: chain.seeds.length } });
+  await consumeNextSeed("crash"); // forces the rotation that retires it
+
+  const retired = await GameSeedChain.findById(chain._id);
+  expect(retired.active).toBe(false);
+  expect(retired.seeds).toHaveLength(0);
+  expect(retired.rootSeed).toHaveLength(64);
+
+  // nothing was lost: the seed already handed out regenerates from the root, and the
+  // terminal it was committed against still checks out
+  expect(seedAt(retired.rootSeed, CHAIN_LENGTH, 0)).toBe(first.seed);
+  expect(linksTo(seedAt(retired.rootSeed, CHAIN_LENGTH, 0), retired.terminalHash)).toBe(true);
 });

--- a/backend/models/FanBoard.js
+++ b/backend/models/FanBoard.js
@@ -36,8 +36,6 @@ const FanBoardSchema = new mongoose.Schema({
 });
 
 // the browse page sorts by these
-FanBoardSchema.index({ fanCount: -1 });
 FanBoardSchema.index({ topCount: -1 });
-FanBoardSchema.index({ gap: 1 });
 
 module.exports = mongoose.model("FanBoard", FanBoardSchema);

--- a/backend/models/GameSeedChain.js
+++ b/backend/models/GameSeedChain.js
@@ -6,7 +6,10 @@ const GameSeedChainSchema = new mongoose.Schema(
   {
     game: { type: String, enum: ["crash", "coinflip"], required: true },
     terminalHash: { type: String, required: true },
-    seeds: { type: [String], required: true }, // secret until each is consumed
+    seeds: { type: [String], required: true }, // secret until each is consumed, emptied on retire
+    // the last seed of a retired chain. every other one is a hash of the next, so this
+    // regenerates the whole sequence and the spent strings do not have to be kept.
+    rootSeed: String,
     cursor: { type: Number, default: 0 }, // index of the next seed to consume
     active: { type: Boolean, default: true },
   },

--- a/backend/models/MarketSale.js
+++ b/backend/models/MarketSale.js
@@ -20,6 +20,5 @@ const MarketSaleSchema = new mongoose.Schema({
 
 // the only hot query is "this item's sales, newest first, within a window"
 MarketSaleSchema.index({ item: 1, soldAt: -1 });
-MarketSaleSchema.index({ soldAt: -1 });
 
 module.exports = mongoose.model("MarketSale", MarketSaleSchema);

--- a/backend/models/Round.js
+++ b/backend/models/Round.js
@@ -55,7 +55,4 @@ const RoundSchema = new mongoose.Schema(
 RoundSchema.index({ status: 1 });
 // round history, newest first
 RoundSchema.index({ game: 1, createdAt: -1 });
-// "what did this player bet on, and when"
-RoundSchema.index({ "bets.userId": 1, createdAt: -1 });
-
 module.exports = mongoose.model("Round", RoundSchema);

--- a/backend/models/Transaction.js
+++ b/backend/models/Transaction.js
@@ -8,7 +8,6 @@ const TransactionSchema = new mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     ref: "User",
     required: true,
-    index: true,
   },
   type: {
     type: String,

--- a/backend/scripts/reclaimStorage.js
+++ b/backend/scripts/reclaimStorage.js
@@ -1,0 +1,114 @@
+// One-off cleanup for data the current code no longer creates.
+//
+//   node scripts/reclaimStorage.js           # report only
+//   node scripts/reclaimStorage.js --apply   # write
+//
+// Two things, both safe because nothing reads what they remove:
+//
+//   Retired seed chains still hold all ten thousand of their spent seeds, 732 kB each.
+//   Every seed is sha256 of the next, so the whole sequence regenerates from the last
+//   one; consumeNextSeed only ever looks at the active chain, and crash and coin flip
+//   verify against the serverSeed stored on the round itself.
+//
+//   Five indexes the planner has never chosen. Mongoose creates indexes but never drops
+//   them, so taking them out of a schema leaves them on the cluster until something does.
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const APPLY = process.argv.includes("--apply");
+
+// checked against $indexStats before anything drops. `covered` names the index that can
+// serve every query this one can, which is the only reason to drop one the planner still
+// picks: a prefix is never the sole option, it is just sometimes the narrower choice.
+const DEAD_INDEXES = [
+  { collection: "rounds", index: "bets.userId_1_createdAt_-1" },
+  { collection: "transactions", index: "userId_1", covered: "userId_1_createdAt_-1" },
+  { collection: "fanboards", index: "fanCount_-1" },
+  { collection: "fanboards", index: "gap_1" },
+  { collection: "marketsales", index: "soldAt_-1", covered: "item_1_soldAt_-1" },
+];
+
+const mb = (bytes) => (bytes / 1048576).toFixed(2);
+
+async function compactChains(db) {
+  const chains = db.collection("gameseedchains");
+  const stale = await chains
+    .aggregate([
+      { $match: { active: false, "seeds.0": { $exists: true } } },
+      { $project: { game: 1, cursor: 1, n: { $size: "$seeds" }, bytes: { $bsonSize: "$$ROOT" } } },
+    ])
+    .toArray();
+
+  if (!stale.length) return console.log("seed chains: nothing to compact");
+
+  const bytes = stale.reduce((sum, c) => sum + c.bytes, 0);
+  const spent = stale.filter((c) => c.cursor >= c.n).length;
+  console.log(`seed chains: ${stale.length} retired chains holding ${mb(bytes)} MB (${spent} fully consumed)`);
+
+  if (!APPLY) return console.log("           run with --apply to compact them");
+
+  const res = await chains.updateMany({ active: false, "seeds.0": { $exists: true } }, [
+    { $set: { rootSeed: { $ifNull: [{ $last: "$seeds" }, "$rootSeed" ] }, seeds: [] } },
+  ]);
+  const missing = await chains.countDocuments({ active: false, rootSeed: { $in: [null, ""] } });
+  console.log(`           compacted ${res.modifiedCount}, ${missing} left without a root`);
+}
+
+async function dropIndexes(db) {
+  for (const { collection: name, index, covered } of DEAD_INDEXES) {
+    const collection = db.collection(name);
+    let stats;
+    try {
+      stats = await collection.aggregate([{ $indexStats: {} }]).toArray();
+    } catch {
+      console.log(`${name}.${index}: could not read usage, skipped`);
+      continue;
+    }
+    const row = stats.find((s) => s.name === index);
+    if (!row) {
+      console.log(`${name}.${index}: already gone`);
+      continue;
+    }
+    // the counter resets on restart, so this is a guard against an obvious mistake rather
+    // than proof. an index with a wider one covering it is allowed to be busy: dropping it
+    // moves those queries onto the other, it does not leave them without a plan.
+    if (row.accesses.ops > 0 && !covered) {
+      console.log(`${name}.${index}: ${row.accesses.ops} ops since the last restart, LEFT ALONE`);
+      continue;
+    }
+    if (covered && !stats.some((s) => s.name === covered)) {
+      console.log(`${name}.${index}: ${covered} is missing, LEFT ALONE`);
+      continue;
+    }
+    const why = covered ? `${row.accesses.ops} ops, covered by ${covered}` : "unused";
+    if (!APPLY) {
+      console.log(`${name}.${index}: ${why}, would drop`);
+      continue;
+    }
+    await collection.dropIndex(index);
+    console.log(`${name}.${index}: dropped`);
+  }
+}
+
+async function main() {
+  await mongoose.connect(process.env.MONGO_URI);
+  const db = mongoose.connection.db;
+
+  const before = await db.stats();
+  console.log(`${APPLY ? "APPLYING" : "dry run"} - logical ${mb(before.dataSize + before.indexSize)} MB of 512 MB\n`);
+
+  await compactChains(db);
+  console.log("");
+  await dropIndexes(db);
+
+  const after = await db.stats();
+  const freed = before.dataSize + before.indexSize - (after.dataSize + after.indexSize);
+  console.log(`\nlogical ${mb(after.dataSize + after.indexSize)} MB of 512 MB${APPLY ? `, freed ${mb(freed)} MB` : ""}`);
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error("FAILED:", err.message);
+  process.exit(1);
+});

--- a/backend/tasks/cronJobs.js
+++ b/backend/tasks/cronJobs.js
@@ -75,7 +75,7 @@ module.exports = {
             }
         })
 
-        cron.schedule('30 4 * * *', async () => {
+        cron.schedule('30 * * * *', async () => {
             try {
                 const removed = await pruneEmptyRounds();
                 console.log(`Pruned ${removed} rounds nobody bet on.`);

--- a/backend/utils/gameChain.js
+++ b/backend/utils/gameChain.js
@@ -22,8 +22,17 @@ async function consumeNextSeed(game) {
       const doc = await GameSeedChain.findById(claimed._id, { seeds: { $slice: [index, 1] } });
       return { chainId: claimed._id, terminalHash: claimed.terminalHash, index, seed: doc.seeds[0] };
     }
-    // none active, or the active one is spent: retire it and publish a fresh commitment
-    await GameSeedChain.updateMany({ game, active: true }, { $set: { active: false } });
+    // none active, or the active one is spent: retire it and publish a fresh commitment.
+    // the spent seeds go with it, kept only as the root they all derive from
+    await GameSeedChain.updateMany({ game, active: true }, [
+      {
+        $set: {
+          active: false,
+          rootSeed: { $ifNull: [{ $last: "$seeds" }, "$rootSeed"] },
+          seeds: [],
+        },
+      },
+    ]);
     await createChain(game);
   }
   throw new Error(`could not consume a ${game} seed`);

--- a/backend/utils/hashChain.js
+++ b/backend/utils/hashChain.js
@@ -15,10 +15,18 @@ function generateChain(length) {
   return { seeds, terminalHash };
 }
 
+// every seed is the hash of the next, so the whole sequence regenerates from the last
+// one. a retired chain keeps only that root instead of all ten thousand strings.
+function seedAt(rootSeed, length, index) {
+  let seed = rootSeed;
+  for (let i = length - 1; i > index; i--) seed = sha256(seed);
+  return seed;
+}
+
 // a revealed seed is valid if hashing it gives the previous reveal (or the terminal
 // for the first round). this is the whole verification a player runs.
 function linksTo(seed, priorHashOrTerminal) {
   return sha256(seed) === priorHashOrTerminal;
 }
 
-module.exports = { sha256, generateChain, linksTo };
+module.exports = { sha256, generateChain, linksTo, seedAt };


### PR DESCRIPTION
**Problem.** The free tier caps the cluster at 512 MB of logical size. It is at 174 MB and grew ~17 MB on the busiest day this week.

`gameseedchains` is 29 documents and 21.8 MB, 12% of the database. A chain is 10,000 hex strings at 732 kB, but `seeds[i]` is `sha256(seeds[i+1])`, so the whole sequence regenerates from the last one. 27 of the 29 are fully consumed and nothing reads them: `consumeNextSeed` filters on `active: true`, and crash and coin flip verify against the `serverSeed` stored on the round. They also accumulate at ~1.5 chains/day whether or not anyone is playing.

**Change.**
- Retiring a chain keeps the root seed and empties the array. `seedAt()` regenerates any seed from it.
- Drops five indexes: `rounds.bets.userId_1_createdAt_-1` and both unused `fanboards` ones (0 ops), plus `transactions.userId_1` and `marketsales.soldAt_-1`, which are prefixes of compound indexes that already serve every query using them.
- Empty-round prune moves from daily to hourly. The two games mint a round every 11 seconds around the clock; 15,063 of 16,082 stored rounds had no bets and the daily run left up to 48 hours on disk.
- `scripts/reclaimStorage.js` applies the same to existing data. Dry run by default, `--apply` to write. Reclaims 19.3 MB.

**Tests.** `npx jest` 944 passed, including a new case proving a retired chain keeps only its root and that the seed already handed out still regenerates from it and still links to the committed terminal hash.