### PR TITLE
Expire rolls after thirty days

### DIFF
--- a/backend/__tests__/integration/rollRetention.test.js
+++ b/backend/__tests__/integration/rollRetention.test.js
@@ -1,0 +1,26 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const { setupDb, teardownDb } = require("./db");
+const Roll = require("../../models/Roll");
+
+beforeAll(setupDb);
+afterAll(teardownDb);
+
+// the rolls collection was 36% of a 512 MB budget and only ever grew. this is the one
+// thing keeping it bounded, and losing it would not fail anything else.
+test("rolls expire after thirty days", async () => {
+  await Roll.init(); // build the indexes mongoose declares
+  const indexes = await Roll.collection.indexes();
+  const ttl = indexes.find((i) => i.expireAfterSeconds !== undefined);
+
+  expect(ttl).toBeDefined();
+  expect(ttl.key).toEqual({ createdAt: 1 });
+  expect(ttl.expireAfterSeconds).toBe(30 * 24 * 60 * 60);
+});
+
+test("the lookups the fair page uses still have an index to stand on", async () => {
+  await Roll.init();
+  const names = (await Roll.collection.indexes()).map((i) => JSON.stringify(i.key));
+  expect(names).toContain(JSON.stringify({ rollId: 1 }));
+  expect(names).toContain(JSON.stringify({ userId: 1, createdAt: -1 }));
+});

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -1,5 +1,7 @@
 const mongoose = require("mongoose");
 
+const RETENTION_DAYS = 30;
+
 // one audit record per provably-fair draw. holds everything needed to verify the
 // outcome later: the seed reference, client seed, nonce, the raw roll, and for case
 // rolls the pinned case config version whose immutable range table maps the roll
@@ -32,5 +34,11 @@ const RollSchema = new mongoose.Schema(
 );
 
 RollSchema.index({ userId: 1, createdAt: -1 });
+// the audit trail is kept for thirty days and then expires itself. fairness does not
+// live here: the server seed is committed before the bet and revealed after, on the Seed
+// and on the Round, so an old draw stays provable to anyone who kept its seed and nonce.
+// this row is the convenience lookup, and one nobody has asked for in months of rolls is
+// not worth the free tier's whole storage budget.
+RollSchema.index({ createdAt: 1 }, { expireAfterSeconds: RETENTION_DAYS * 24 * 60 * 60 });
 
 module.exports = mongoose.model("Roll", RollSchema);

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -323,7 +323,7 @@
     "outcome": "Ergebnis",
     "previousSeedRevealedVerify": "Vorherige Seed offengelegt, prüf sie:",
     "roll": "Roll",
-    "rollNotFound": "Roll nicht gefunden",
+    "rollNotFound": "Roll nicht gefunden. Rolls werden 30 Tage lang aufbewahrt.",
     "rotateRevealServerSeed": "Server-Seed wechseln und offenlegen",
     "serverSeed": "Server-Seed",
     "serverSeedHash": "Hash des Server-Seeds",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -323,7 +323,7 @@
     "outcome": "Outcome",
     "previousSeedRevealedVerify": "Previous seed revealed, verify it:",
     "roll": "Roll",
-    "rollNotFound": "Roll not found",
+    "rollNotFound": "Roll not found. Rolls are kept for 30 days.",
     "rotateRevealServerSeed": "Rotate & reveal server seed",
     "serverSeed": "Server seed",
     "serverSeedHash": "Server seed hash",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -323,7 +323,7 @@
     "outcome": "Resultado",
     "previousSeedRevealedVerify": "Semilla anterior revelada, verifícala:",
     "roll": "Tirada",
-    "rollNotFound": "Tirada no encontrada",
+    "rollNotFound": "Tirada no encontrada. Las tiradas se guardan durante 30 días.",
     "rotateRevealServerSeed": "Rotar y revelar la semilla del servidor",
     "serverSeed": "Semilla del servidor",
     "serverSeedHash": "Hash de la semilla del servidor",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -323,7 +323,7 @@
     "outcome": "Résultat",
     "previousSeedRevealedVerify": "Seed précédente révélée, vérifiez-la :",
     "roll": "Tirage",
-    "rollNotFound": "Tirage introuvable",
+    "rollNotFound": "Tirage introuvable. Les tirages sont conservés 30 jours.",
     "rotateRevealServerSeed": "Changer et révéler la seed serveur",
     "serverSeed": "Seed serveur",
     "serverSeedHash": "Hash de la seed serveur",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -323,7 +323,7 @@
     "outcome": "Hasil",
     "previousSeedRevealedVerify": "Seed sebelumnya telah terungkap, verifikasi:",
     "roll": "Roll",
-    "rollNotFound": "Roll tidak ditemukan",
+    "rollNotFound": "Roll tidak ditemukan. Roll disimpan selama 30 hari.",
     "rotateRevealServerSeed": "Putar & ungkapkan seed server",
     "serverSeed": "Server seed",
     "serverSeedHash": "Server seed hash",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -323,7 +323,7 @@
     "outcome": "Risultato",
     "previousSeedRevealedVerify": "Seed precedente rivelato, verificalo:",
     "roll": "Roll",
-    "rollNotFound": "Roll non trovato",
+    "rollNotFound": "Roll non trovato. I roll vengono conservati per 30 giorni.",
     "rotateRevealServerSeed": "Ruota e rivela il seed del server",
     "serverSeed": "Seed del server",
     "serverSeedHash": "Hash del seed del server",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -323,7 +323,7 @@
     "outcome": "結果",
     "previousSeedRevealedVerify": "前のシードを公開しました。検証してください：",
     "roll": "ロール",
-    "rollNotFound": "ロールが見つかりません",
+    "rollNotFound": "ロールが見つかりません。ロールは30日間保存されます。",
     "rotateRevealServerSeed": "サーバーシードをローテーションして公開",
     "serverSeed": "サーバーシード",
     "serverSeedHash": "サーバーシードのハッシュ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -323,7 +323,7 @@
     "outcome": "결과",
     "previousSeedRevealedVerify": "이전 시드를 공개했습니다. 확인해 보세요:",
     "roll": "롤",
-    "rollNotFound": "롤을 찾을 수 없습니다",
+    "rollNotFound": "롤을 찾을 수 없습니다. 롤은 30일간 보관됩니다.",
     "rotateRevealServerSeed": "서버 시드 교체 및 공개",
     "serverSeed": "서버 시드",
     "serverSeedHash": "서버 시드 해시",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -323,7 +323,7 @@
     "outcome": "Resultado",
     "previousSeedRevealedVerify": "Seed anterior revelada, verifique:",
     "roll": "Roll",
-    "rollNotFound": "Roll não encontrado",
+    "rollNotFound": "Roll não encontrado. Os rolls são guardados por 30 dias.",
     "rotateRevealServerSeed": "Trocar e revelar a seed do servidor",
     "serverSeed": "Seed do servidor",
     "serverSeedHash": "Hash da seed do servidor",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -323,7 +323,7 @@
     "outcome": "Kết quả",
     "previousSeedRevealedVerify": "Seed trước đã được công khai, hãy kiểm chứng:",
     "roll": "Roll",
-    "rollNotFound": "Không tìm thấy roll",
+    "rollNotFound": "Không tìm thấy roll. Roll được lưu trong 30 ngày.",
     "rotateRevealServerSeed": "Đổi và công khai seed máy chủ",
     "serverSeed": "Seed máy chủ",
     "serverSeedHash": "Hash seed máy chủ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -323,7 +323,7 @@
     "outcome": "结果",
     "previousSeedRevealedVerify": "上一个种子已公开，请验证：",
     "roll": "Roll",
-    "rollNotFound": "未找到该 roll",
+    "rollNotFound": "未找到该 Roll。Roll 仅保留 30 天。",
     "rotateRevealServerSeed": "轮换并公开服务器种子",
     "serverSeed": "服务器种子",
     "serverSeedHash": "服务器种子哈希",


### PR DESCRIPTION
**Problem.** `rolls` is 61 MB of the free tier's 512 MB, 36% of the database, and the only collection that grows with no ceiling. Selling an item back leaves its roll behind, and the recovered coins buy another open that writes another row, so quicksell recycling multiplies it. A third of the collection is already older than 30 days.

**Change.** A TTL index on `Roll.createdAt` with a 30-day window. Mongo expires the rows itself, no cron and no script.

Safe because nothing derives a number from the collection. The only readers are three point lookups in `utils/rolls.js` (`findOne` by `rollId`, by `uniqueId`, and by `rollId` for game dispatch). An expired row means `/fair/roll/:id` returns 404 and `verifyRoll` returns `{ok: false}`, both already handled. The `fair.rollNotFound` string now says rolls are kept for 30 days, in all 11 locales, so a player pasting an old id learns why rather than assuming the roll was hidden.

Fairness is not affected. The commitment is the server seed hashed before the bet and revealed after, which lives on the `Seed` and on the `Round`. An old draw stays provable to anyone who kept its seed and nonce; the roll row is the convenience lookup.

The ledger deliberately gets no TTL: `missions.js` aggregates it from a fixed launch date, and `ledgerSupply()` and the house balance sum all of it with no date filter, so expiring rows would silently rewrite those figures with no backfill.

**Tests.** `npx jest` 946 passed, with a new case asserting the TTL index exists on `createdAt` at exactly 30 days and that the `rollId` and `userId+createdAt` lookups still have indexes. Frontend `npm run test:unit` 139 passed including locale key parity, `npx eslint` 0 errors, `npm run build` clean.