### PR TITLE
Stop collection badges asking for deleted items

### DIFF
--- a/backend/__tests__/integration/badges.test.js
+++ b/backend/__tests__/integration/badges.test.js
@@ -10,6 +10,7 @@ const Notification = require("../../models/Notification");
 const Item = require("../../models/Item");
 const Case = require("../../models/Case");
 const badges = require("../../utils/badges");
+const itemCatalog = require("../../utils/itemCatalog");
 
 let app;
 
@@ -211,6 +212,22 @@ describe("collection badges", () => {
     expect(sets).toHaveLength(1);
     expect(sets[0]).toMatchObject({ slug: "blue-archive", label: "Blue Archive" });
     expect(sets[0].ids.size).toBe(4);
+  });
+
+  it("does not ask for an item that no longer exists", async () => {
+    const items = await makeCategory("Touhou", ["a", "b", "c", "d"]);
+    // the admin deleted an item but the case still lists its id: it can never drop and
+    // nobody can hold one, so a badge counting it would be impossible to earn
+    await Item.deleteOne({ _id: items[3]._id });
+    itemCatalog.invalidate();
+
+    const [set] = await badges.collectionSets();
+    expect(set.ids.size).toBe(3);
+    expect([...set.ids]).not.toContain(String(items[3]._id));
+
+    // and owning the three that are left is now the whole collection
+    await makeUser({ inventory: own(items.slice(0, 3)) });
+    expect(await badges.sweepCollections()).toBe(1);
   });
 
   it("awards only a whole collection, and keeps it afterwards", async () => {

--- a/backend/utils/badges.js
+++ b/backend/utils/badges.js
@@ -2,6 +2,7 @@ const User = require("../models/User");
 const MissionState = require("../models/MissionState");
 const Notification = require("../models/Notification");
 const Case = require("../models/Case");
+const itemCatalog = require("./itemCatalog");
 const { CATALOG } = require("./missionsCatalog");
 
 const TOP_FAN = "topFan";
@@ -118,8 +119,16 @@ async function sweepConnected(io) {
 
 // every case category and the item ids that make it whole. a category is complete only
 // when the player owns one of every distinct item across all of its cases.
+//
+// Case.items is raw admin input and can still name an item that has since been deleted.
+// those never drop and nobody can hold one, so counting them asks for a set that cannot
+// be completed: the touhou badge wanted 137 of the 134 that exist. only live items count.
 async function collectionSets() {
-  const cases = await Case.find({}, { category: 1, items: 1 }).lean();
+  const [cases, catalog] = await Promise.all([
+    Case.find({}, { category: 1, items: 1 }).lean(),
+    itemCatalog.all(),
+  ]);
+  const live = new Set(catalog.map((item) => String(item._id)));
   const byCategory = new Map();
   for (const one of cases) {
     const label = (one.category || "").trim();
@@ -127,7 +136,9 @@ async function collectionSets() {
     const slug = slugify(label);
     if (!slug) continue;
     if (!byCategory.has(slug)) byCategory.set(slug, { slug, label, ids: new Set() });
-    for (const id of one.items || []) byCategory.get(slug).ids.add(String(id));
+    for (const id of one.items || []) {
+      if (live.has(String(id))) byCategory.get(slug).ids.add(String(id));
+    }
   }
   return [...byCategory.values()].filter((c) => c.ids.size > 0);
 }


### PR DESCRIPTION
**Problem.** Two collection badges are impossible to earn.

| category | badge asks for | items that exist |
| --- | --- | --- |
| Touhou | 137 | **134** |
| Animals | 71 | **69** |

`collectionSets()` builds each set from raw `Case.items` ObjectIds with no existence check. Three ids in Lunatic Case and two in Cats Case have no `Item` document behind them, so they cannot drop and nobody can hold one. The collections page never disagreed because it uses `.populate("items", ...)`, which silently drops an id that resolves to nothing.

**Change.** `collectionSets()` now intersects `Case.items` with the live catalog, read through `itemCatalog` so it costs no extra query. Touhou becomes 134 and Animals 69, and both badges become earnable. The `{{count}}` in the badge description comes from the same place, so the displayed number corrects itself.

No case documents are touched: the dangling ids stay where they are and remain harmless to every other consumer, all of which populate.

**Tests.** `npx jest` 947 passed, with a new case that deletes an item a case still lists and asserts the set shrinks to the live three and that owning those three now completes the collection. Verified it fails without the fix (expected 3, received 4).