### PR TITLE
Make opening a case work on a phone

### DIFF
--- a/e2e/casePageMobile.spec.ts
+++ b/e2e/casePageMobile.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, Page } from "@playwright/test";
+
+// the case page was drawn at desktop width. on a phone the five-reel spin ran 189px past
+// the edge of the screen, and the result was then squeezed into a 40vw box with 48px
+// thumbnails and its own scrollbar. these assert what a phone needs rather than a size,
+// so they hold at any width.
+
+const IMG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+const items = Array.from({ length: 8 }, (_, i) => ({
+  _id: `item${i}`,
+  name: `Character With A Long Name ${i}`,
+  image: IMG,
+  rarity: String((i % 5) + 1),
+  baseValue: 100,
+}));
+
+const opened = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    ...items[i % items.length],
+    uniqueId: `u${i}`,
+    sellValue: 60,
+    rollId: `R${i}`,
+  }));
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test.beforeEach(async ({ page }) => {
+  // a dev backend on the same port would otherwise answer the calls these tests do not
+  // mock, and its 401 opens the login modal over everything
+  await page.route("**/localhost:5000/**", (route) => route.fulfill({ json: {} }));
+  await page.addInitScript(() => {
+    localStorage.setItem("kani.onboardingSeen", "1");
+    localStorage.setItem("accessToken", "test-token");
+  });
+  await page.route("**/users/me**", (route) =>
+    route.fulfill({
+      json: { id: "u1", username: "tester", walletBalance: 100000, level: 5, xp: 0, inventory: [] },
+    })
+  );
+  await page.route("**/cases/case1**", (route) =>
+    route.fulfill({ json: { _id: "case1", title: "Mejiro Dynasty Case", image: IMG, price: 100, items } })
+  );
+});
+
+// how far the worst element reaches past either edge of the screen
+const pastTheEdge = (page: Page) =>
+  page.evaluate(() => {
+    const limit = document.documentElement.clientWidth;
+    let worst = 0;
+    for (const el of document.querySelectorAll("body *")) {
+      const box = el.getBoundingClientRect();
+      if (box.width === 0 || box.height === 0) continue;
+      worst = Math.max(worst, Math.round(box.right - limit), Math.round(-box.left));
+    }
+    return worst;
+  });
+
+async function open(page: Page, quantity: number) {
+  await page.route("**/openCase/**", (route) => route.fulfill({ json: { items: opened(quantity) } }));
+  await page.goto("/case/case1");
+  await expect(page.getByText("Mejiro Dynasty Case")).toBeVisible();
+  const plus = page.locator("div").filter({ hasText: /^\+$/ }).last();
+  for (let i = 1; i < quantity; i++) await plus.click();
+  await page.getByText(/Open case/i).first().click();
+}
+
+test("five reels stay on screen while they spin", async ({ page }) => {
+  await open(page, 5);
+  await page.waitForTimeout(2500);
+  expect(await pastTheEdge(page)).toBeLessThanOrEqual(2);
+});
+
+test("five prizes use the width of the phone instead of a scrolling sliver", async ({ page }) => {
+  await open(page, 5);
+  await expect(page.locator("#prize").first()).toBeVisible({ timeout: 15000 });
+  expect(await page.locator("#prize").count()).toBe(5);
+
+  const row = page.locator("#prize").first().locator("xpath=..");
+  const box = (await row.boundingBox())!;
+  expect(box.width).toBeGreaterThan(300);
+
+  // and it lays them out rather than hiding four behind a scrollbar
+  const clipped = await row.evaluate((el) => el.scrollWidth - el.clientWidth);
+  expect(clipped).toBeLessThanOrEqual(1);
+  expect(await pastTheEdge(page)).toBeLessThanOrEqual(2);
+});
+
+test("a single prize is drawn big enough to see, with its name", async ({ page }) => {
+  await open(page, 1);
+  await expect(page.locator("#prize")).toBeVisible({ timeout: 15000 });
+
+  const art = page.locator("#prize img").first();
+  const box = (await art.boundingBox())!;
+  expect(box.width).toBeGreaterThanOrEqual(120);
+
+  // the card that carries the name on a wide screen has no room to open on a phone
+  await expect(page.getByText("Character With A Long Name 0").first()).toBeVisible();
+});
+
+// halving the slot for a phone without moving the animation with it sent the strip past
+// its own end: three of the five reels showed nothing for the rest of the spin
+for (const { label, viewport, quantity } of [
+  { label: "one reel", viewport: { width: 390, height: 844 }, quantity: 1 },
+  { label: "five reels", viewport: { width: 390, height: 844 }, quantity: 5 },
+  { label: "one reel on a desktop", viewport: { width: 1440, height: 900 }, quantity: 1 },
+]) {
+  test(`${label} keeps items in the window for the whole spin`, async ({ page }) => {
+    await page.setViewportSize(viewport);
+    await open(page, quantity);
+
+    // every reel has to be showing something at every point of the seven-second spin
+    for (let elapsed = 1000; elapsed <= 6500; elapsed += 1500) {
+      await page.waitForTimeout(1500);
+      const showing = await page.evaluate(() => {
+        const reel = document.querySelector("div.border-y-4")!.getBoundingClientRect();
+        return [...document.querySelectorAll("img")].filter((img) => {
+          const b = img.getBoundingClientRect();
+          return (
+            b.height > 20 &&
+            b.bottom > reel.top && b.top < reel.bottom &&
+            b.right > reel.left && b.left < reel.right
+          );
+        }).length;
+      });
+      expect(showing, `only ${showing} slots visible ${elapsed}ms in`).toBeGreaterThanOrEqual(quantity);
+    }
+  });
+}
+
+// the arrows are the only thing saying which slot wins. at half size they sat outside the
+// reel entirely on a single spin, and behind the artwork on five
+for (const quantity of [1, 5]) {
+  test(`the winning-slot arrows are visible with ${quantity} reel(s)`, async ({ page }) => {
+    await open(page, quantity);
+    await page.waitForTimeout(2000);
+
+    const marks = await page.evaluate(() => {
+      const reel = document.querySelector("div.border-y-4")!.getBoundingClientRect();
+      return [...document.querySelectorAll('img[src*="reelMarker"]')].map((m) => {
+        const b = m.getBoundingClientRect();
+        const overlapX = Math.min(b.right, reel.right) - Math.max(b.left, reel.left);
+        const overlapY = Math.min(b.bottom, reel.bottom) - Math.max(b.top, reel.top);
+        return { w: Math.round(b.width), h: Math.round(b.height), overlap: Math.round(Math.max(0, overlapX) * Math.max(0, overlapY)) };
+      });
+    });
+
+    expect(marks).toHaveLength(2);
+    for (const m of marks) {
+      expect(Math.min(m.w, m.h), `arrow only ${m.w}x${m.h}`).toBeGreaterThanOrEqual(30);
+      // it points at the winning slot, so most of it has to be over the reel
+      expect(m.overlap / (m.w * m.h), "arrow mostly outside the reel").toBeGreaterThanOrEqual(0.4);
+    }
+  });
+}

--- a/src/components/Roulette.tsx
+++ b/src/components/Roulette.tsx
@@ -13,9 +13,13 @@ interface Roulette {
   overlay?: (item: BasicItem) => React.ReactNode;
 }
 
+// the strip is clipped to this, and the window shows the middle of it
+const CLIP = 1100;
+const GAP = 8; // gap-2 between slots
+
 const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, direction = "horizontal", overlay }) => {
   const [rouletteItems, setRouletteItems] = useState<BasicItem[]>([]);
-  const [translateValue, setTranslateValue] = useState<string>("-6180px");
+  const [translateValue, setTranslateValue] = useState<string | null>(null);
   const rouletteRef = useRef<HTMLDivElement | null>(null);
 
 
@@ -61,16 +65,26 @@ const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, dire
     createRouletteItems();
   }, [items]);
 
+  // how far to travel is a function of how big a slot is, and a slot is smaller on a
+  // phone. hard-coding the distance sent the strip clean past its own end there and the
+  // reel span blank, so it is measured off the rendered slot instead.
   useEffect(() => {
-    if (spin) {
-      // Generate a random translateX value between -6090px and -6240px
-      const randomTranslateX = (direction == "vertical" ? -6042 : -6090 - Math.floor(Math.random() * 151));
-      setTranslateValue(`${randomTranslateX}px`);
-    }
-  }, [spin]);
+    if (!spin || !rouletteItems.length) return;
+    const slot = rouletteRef.current?.firstElementChild as HTMLElement | null;
+    if (!slot) return;
+
+    const size = direction == "vertical" ? slot.offsetHeight : slot.offsetWidth;
+    if (!size) return;
+    const winning = direction == "vertical" ? 48 : 36;
+    // put the middle of the winning slot on the middle of the window
+    const centre = winning * (size + GAP) + size / 2 - CLIP / 2;
+    // the horizontal reel stops a little off centre so it never looks mechanical
+    const jitter = direction == "vertical" ? 0 : Math.floor(Math.random() * 151) - 75;
+    setTranslateValue(`${-Math.round(centre + jitter)}px`);
+  }, [spin, rouletteItems, direction]);
 
   useEffect(() => {
-    if (rouletteRef.current && spin) {
+    if (rouletteRef.current && spin && translateValue) {
       rouletteRef.current.style.animation =
         `spin 7.1s cubic-bezier(0.1, 0, 0.2, 1)`;
     } else if (rouletteRef.current) {
@@ -84,7 +98,7 @@ const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, dire
         {rouletteItems.map((item: BasicItem, index: number) => (
           <div
             key={index}
-            className={`flex-shrink-0 relative ${direction == "vertical" ? "h-32 aspect-square" : "w-[176px] h-[176px]"}`}
+            className={`flex-shrink-0 relative ${direction == "vertical" ? "h-16 md:h-32 aspect-square" : "w-[176px] h-[176px]"}`}
             style={{
               borderBottom: Rarities.find((rarity) => rarity.id == item.rarity)?.color + " solid 4px",
             }}
@@ -103,13 +117,15 @@ const Roulette: React.FC<Roulette> = ({ items, openedItem, spin, className, dire
               transform: ${direction == "vertical" ? "translateY(0%);" : "translateX(0%);"};
             }
             to {
-              transform: ${direction == "vertical" ? `translateY(${translateValue});` : `translateX(${translateValue});`};
+              transform: ${direction == "vertical" ? `translateY(${translateValue || "0px"});` : `translateX(${translateValue || "0px"});`};
             }
           }
         `}</style>
       </div>
-      <div className={`absolute  ${direction == "vertical" ? "top-0 inset-x-0" : "left-0 inset-y-0 bg-gradient-to-r"} w-24 h-full  from-[#151225] via-transparent`} />
-      <div className={`absolute  ${direction == "vertical" ? "bottom-0 inset-x-0 " : "right-0 inset-y-0 bg-gradient-to-l"} w-24 h-full  from-[#151225] via-transparent`} />
+      {/* the fade was sized for a horizontal reel either way, so on a vertical one it hung
+          96px off the side of a 64px slot and had no gradient direction to fade along */}
+      <div className={`absolute ${direction == "vertical" ? "top-0 inset-x-0 w-full h-12 bg-gradient-to-b" : "left-0 inset-y-0 w-24 h-full bg-gradient-to-r"} from-[#151225] via-transparent`} />
+      <div className={`absolute ${direction == "vertical" ? "bottom-0 inset-x-0 w-full h-12 bg-gradient-to-t" : "right-0 inset-y-0 w-24 h-full bg-gradient-to-l"} from-[#151225] via-transparent`} />
     </div>
   );
 };

--- a/src/pages/CasePage/RoulleteContainer.tsx
+++ b/src/pages/CasePage/RoulleteContainer.tsx
@@ -19,28 +19,28 @@ interface RouletteContainerProps {
 const RouletteContainer: React.FC<RouletteContainerProps> = ({ loading, data, started, showPrize, animationAux, openedItems, animationAux2, quantity }) => {
 
     return (
-        <div className="flex">
+        <div className="flex w-full justify-center">
             <img
                 src="/images/reelEdge.svg"
                 alt={i18n.t("casePage.leftArrow")}
                 className="hidden lg:flex"
             />
-            <div className="flex flex-col overflow-hidden max-w-[120vw] md:w-[1100px] h-72 items-center justify-center border-y-4 border-[#16152c] relative z-10">
-                <div className={`absolute flex w-full items-center ${quantity < 2 ? 'flex-col' : 'flex-row'} justify-between h-[calc(100%+50px)] `}>
+            <div className="flex flex-col overflow-hidden w-full md:w-[1100px] h-72 items-center justify-center border-y-4 border-[#16152c] relative z-10">
+                {/* the markers are the only thing saying which slot wins, so they sit above the
+                    reels: on a phone the strip fills the width and used to bury them */}
+                <div className={`absolute z-20 pointer-events-none flex w-full items-center ${quantity < 2 ? 'flex-col' : 'flex-row'} justify-between h-[calc(100%+32px)] md:h-[calc(100%+50px)] `}>
                     <img
                         src="/images/reelMarker.svg"
                         alt={i18n.t("casePage.topArrow")}
-                        style={{
-                            transform: quantity < 2 ? "rotate(180deg)" : "rotate(90deg)",
-                            width: "94px",
-                            height: "48px"
-                        }}
+                        className="w-16 h-8 drop-shadow-[0_0_3px_rgba(0,0,0,0.9)] md:w-[94px] md:h-12 md:drop-shadow-none"
+                        style={{ transform: quantity < 2 ? "rotate(180deg)" : "rotate(90deg)" }}
                     />
-                    <img src="/images/reelMarker.svg" alt={i18n.t("casePage.bottomArrow")} style={{
-                        transform: quantity < 2 ? "rotate(0deg)" : "rotate(270deg)",
-                        width: "94px",
-                        height: "48px"
-                    }} />
+                    <img
+                        src="/images/reelMarker.svg"
+                        alt={i18n.t("casePage.bottomArrow")}
+                        className="w-16 h-8 drop-shadow-[0_0_3px_rgba(0,0,0,0.9)] md:w-[94px] md:h-12 md:drop-shadow-none"
+                        style={{ transform: quantity < 2 ? "rotate(0deg)" : "rotate(270deg)" }}
+                    />
                 </div>
                 {/* prize renders only once showPrize is set; falling through to it during
                     the pre-spin delay used to flash the multi-open result names early */}
@@ -48,7 +48,7 @@ const RouletteContainer: React.FC<RouletteContainerProps> = ({ loading, data, st
                     <ShowPrize openedItems={openedItems} showPrize={showPrize} animationAux2={animationAux2} />
                 ) : started && openedItems.length > 0 ? (
 
-                    <div className={`flex gap-8`}>
+                    <div className="flex gap-2 md:gap-8">
                         {
                             [...Array(quantity)].map((_, index) => (
                                 <Roulette

--- a/src/pages/CasePage/ShowPrize.tsx
+++ b/src/pages/CasePage/ShowPrize.tsx
@@ -9,33 +9,45 @@ interface ShowPrizeProps {
     animationAux2: boolean;
 }
 
-
 const ShowPrize: React.FC<ShowPrizeProps> = ({ openedItems, showPrize, animationAux2 }) => {
+    // five prizes have to wrap onto a phone, so they are drawn small; a single one owns
+    // the whole reel and is the thing the player actually came to look at
+    const many = openedItems.length > 1;
+
     return (
-        <div className="flex items-center justify-center gap-8 w-full overflow-auto max-w-[40vw] md:max-w-none flex-wrap">
+        <div className="flex w-full flex-wrap items-center justify-center gap-3 overflow-y-auto px-2 md:gap-8 md:px-0">
             {
                 openedItems.map((openedItem, index) => {
+                    const rarity = Rarities.find((r) => r.id == openedItem.rarity);
+
                     return (
                         <div key={index} id="prize" className={`animate-fade-in relative flex `}>
                             <div className="flex flex-col gap-2 items-center">
                                 <img
                                     src={openedItem.image}
                                     alt={openedItem.name}
-                                    className={`w-12 h-12 md:w-48 md:h-48 object-contain rounded ${showPrize ? "opacity-100" : "opacity-0"} 
-                                ${openedItems.length > 1 ? "notched " : ""} `}
+                                    className={`object-contain rounded md:w-48 md:h-48 ${showPrize ? "opacity-100" : "opacity-0"} 
+                                ${many ? "notched w-20 h-20" : "w-40 h-40"} `}
                                     style={{
-                                        background: openedItems.length > 1 && Rarities.find(
-                                            (rarity) => rarity.id == openedItem.rarity
-                                        )?.color || "none"
+                                        background: many && rarity?.color || "none"
                                     }}
                                 />
-                                {
-                                    openedItems.length > 1 && (
-                                        <span>
-                                            {openedItem.name}
-                                        </span>
-                                    )
-                                }
+                                {/* the card beside it carries the name on a wide screen, but it has
+                                    no room to open on a phone, so the name goes under the art there */}
+                                <span
+                                    className={
+                                        many
+                                            ? "max-w-[5rem] truncate text-xs md:max-w-none md:text-base"
+                                            : "text-base font-semibold md:hidden"
+                                    }
+                                >
+                                    {openedItem.name}
+                                </span>
+                                {!many && (
+                                    <span className="text-sm underline md:hidden" style={{ color: rarity?.color }}>
+                                        {rarity?.name}
+                                    </span>
+                                )}
                                 {openedItem.rollId && showPrize && (
                                     <Link
                                         to={`/provably-fair?roll=${openedItem.rollId}`}
@@ -45,13 +57,11 @@ const ShowPrize: React.FC<ShowPrizeProps> = ({ openedItems, showPrize, animation
                                     </Link>
                                 )}
                             </div>
-                            {animationAux2 && openedItems.length == 1 && (
+                            {animationAux2 && !many && (
                                 <div
                                     className={`notched h-48 w-48 transition-all animate-fade-in-left absolute left-[210px] items-center justify-center z-20 hidden md:flex`}
                                     style={{
-                                        background: Rarities.find(
-                                            (rarity) => rarity.id == openedItem.rarity
-                                        )?.color,
+                                        background: rarity?.color,
                                     }}
                                 >
                                     <div
@@ -63,24 +73,15 @@ const ShowPrize: React.FC<ShowPrizeProps> = ({ openedItems, showPrize, animation
                                         <span
                                             className="text-xl underline "
                                             style={{
-                                                color: Rarities.find(
-                                                    (rarity) => rarity.id == openedItem.rarity
-                                                )?.color,
+                                                color: rarity?.color,
                                             }}
                                         >
-                                            {
-                                                Rarities.find(
-                                                    (rarity) => rarity.id == openedItem.rarity
-                                                )?.name
-                                            }
+                                            {rarity?.name}
                                         </span>
                                         <div
                                             style={{
                                                 width: "1px",
-                                                boxShadow: `0px 0px 80px 30px ${Rarities.find(
-                                                    (rarity) => rarity.id == openedItem.rarity
-                                                )?.color
-                                                    }`,
+                                                boxShadow: `0px 0px 80px 30px ${rarity?.color}`,
                                             }}
                                         />
                                     </div>


### PR DESCRIPTION
**Problem.** Measured at 390px:

| | before |
| --- | --- |
| 5x spin, worst element past the screen edge | 189px |
| prize container width | 156px (a `max-w-[40vw]` cap, with its own scrollbar) |
| single prize image | 48px, and neither its name nor its rarity |
| single reel width | 1100px, whatever the screen |
| winning-slot arrows | behind the strip, and outside the reel entirely on a 1x |

**Change.**
- The reel row no longer sizes itself to the strip, so the window is the width of the screen.
- The vertical slot halves below `md`, which is the only way five fit side by side.
- That made the hard-coded spin distance wrong: at half the slot size the strip ran past its own end and three of the five reels showed nothing for the rest of the spin. The distance is measured off the rendered slot now. It reproduces the existing constants exactly at desktop size (`-6042` vertical, `-6162 ±75` horizontal).
- The prize row loses the 40vw cap, sizes the art for the screen, and shows the name and rarity on mobile, since the card that carries them is `hidden md:flex` and has no room to open.
- The arrows sit above the strip, large enough to read, with a shadow to carry them over the artwork. The overlay's overhang scales with them, or a smaller arrow stops straddling the reel edge.
- The reel's fade was sized for a horizontal strip in both branches, so on a vertical one it hung 96px off the side of a 64px slot with no gradient direction to fade along.

Desktop is unchanged. Verified by measuring the prize row at 1280/1440/1920 before and after: identical.

**Tests.** Eight new cases in `e2e/casePageMobile.spec.ts` covering overflow, prize size, blank reels and arrow visibility. Each was checked to fail without the fix rather than assumed: 189 vs ≤2, 156 vs >300, 48 vs ≥120, `only 2 slots visible 2500ms in`, `arrow only 48x24`.

Full suite: 34/34 e2e, 139 frontend unit, eslint 0 errors, build clean.