### PR TITLE
Fix what the live drop feed shows, and let upgrades into it

### DIFF
--- a/backend/__tests__/integration/upgradeLiveDrop.test.js
+++ b/backend/__tests__/integration/upgradeLiveDrop.test.js
@@ -1,0 +1,91 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const express = require("express");
+const request = require("supertest");
+const mongoose = require("mongoose");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { tokenFor, uniqueSuffix } = require("./helpers");
+// upgrade.js destructures rollFloat at load, so the module has to be replaced before it
+// is required rather than spied on afterwards
+jest.mock("../../utils/provablyFair", () => ({
+  ...jest.requireActual("../../utils/provablyFair"),
+  rollFloat: jest.fn(),
+}));
+const gamesRoutes = require("../../routes/gamesRoutes");
+const { rollFloat } = require("../../utils/provablyFair");
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Case = require("../../models/Case");
+
+// the feed only ever heard about case openings, so an upgrade that produced an item put
+// nothing in it. these pin the event down: it fires on a win, stays quiet on a loss, and
+// says where it came from, because the card shows the parent case either way.
+let emitted;
+const io = { emit: (event, payload) => emitted.push({ event, payload }), to: () => ({ emit: () => {} }) };
+
+const app = express();
+app.use(express.json());
+app.use("/games", gamesRoutes(io));
+
+beforeAll(setupDb);
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await clearDb();
+});
+afterAll(teardownDb);
+
+async function scenario() {
+  emitted = [];
+  const caseDoc = await Case.create({
+    title: `c-${uniqueSuffix()}`, image: "case.png", price: 100,
+  });
+  const target = await Item.create({
+    name: `t-${uniqueSuffix()}`, image: "t.png", rarity: "3", case: caseDoc._id, baseValue: 100,
+  });
+  const low = await Item.create({
+    name: `l-${uniqueSuffix()}`, image: "l.png", rarity: "1", case: caseDoc._id, baseValue: 40,
+  });
+  const user = await User.create({
+    username: `u-${uniqueSuffix()}`,
+    email: `u-${uniqueSuffix()}@e.com`,
+    password: "x",
+    profilePicture: "me.png",
+    inventory: ["a", "b", "c"].map((uniqueId) => ({
+      _id: low._id, name: low.name, image: low.image, rarity: "1", case: caseDoc._id, uniqueId,
+    })),
+  });
+  return { user, target, caseDoc };
+}
+
+const upgrade = (user, target) =>
+  request(app)
+    .post("/games/upgrade")
+    .set("Authorization", `Bearer ${tokenFor(user)}`)
+    .send({ selectedItemIds: ["a", "b", "c"], targetItemId: target._id.toString() });
+
+test("a won upgrade reaches the live drop feed", async () => {
+  const { user, target, caseDoc } = await scenario();
+  rollFloat.mockReturnValue(0); // always under the rate
+
+  const res = await upgrade(user, target);
+  expect(res.body.success).toBe(true);
+
+  const drop = emitted.find((e) => e.event === "caseOpened");
+  expect(drop).toBeDefined();
+  expect(drop.payload.winningItems).toHaveLength(1);
+  expect(String(drop.payload.winningItems[0]._id)).toBe(String(target._id));
+  expect(drop.payload.user.name).toBe(user.username);
+  // the flip side of the card shows the parent case, so it has to be the real one
+  expect(drop.payload.caseImage).toBe(caseDoc.image);
+  // and without this the drop reads as having come out of that case
+  expect(drop.payload.source).toBe("upgrade");
+});
+
+test("a lost upgrade puts nothing in the feed", async () => {
+  const { user, target } = await scenario();
+  rollFloat.mockReturnValue(0.999); // never under the rate
+
+  const res = await upgrade(user, target);
+  expect(res.body.success).toBe(false);
+  expect(emitted.filter((e) => e.event === "caseOpened")).toHaveLength(0);
+});

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -224,10 +224,28 @@ module.exports = (io) => {
   // Upgrade items
   router.post("/upgrade", isAuthenticated, async (req, res) => {
     const { selectedItemIds, targetItemId } = req.body;
-    const user = req.user._id;
+    const user = req.user;
 
+    const result = await upgradeItems(user._id, selectedItemIds, targetItemId);
 
-    const result = await upgradeItems(user, selectedItemIds, targetItemId);
+    // a won upgrade puts an item in someone's inventory exactly like an opening does, so
+    // it belongs in the same feed. `source` is what keeps it honest: the card shows the
+    // parent case, and without it the drop would read as having come out of one.
+    if (result.success && result.item) {
+      const parent = await Case.findById(result.item.case, { image: 1 }).lean();
+      io.emit("caseOpened", {
+        winningItems: [result.item],
+        user: {
+          name: user.username,
+          id: user._id,
+          profilePicture: user.profilePicture,
+          badge: badges.wornBadge(user),
+        },
+        caseImage: parent ? parent.image : null,
+        source: "upgrade",
+      });
+    }
+
     res.status(result.status).json(result);
   });
 

--- a/src/components/header/CaseOpenedNotification.test.tsx
+++ b/src/components/header/CaseOpenedNotification.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import CaseOpenedNotification from "./CaseOpenedNotification";
+import { BasicItem } from "../Types";
+
+const item = { name: "Yuuma", rarity: "3", image: "y.png", case: "c1" } as unknown as BasicItem;
+const user = { id: "u1", name: "tester", profilePicture: "p.png", badge: null };
+
+const draw = (props: Record<string, unknown> = {}) =>
+  render(
+    <MemoryRouter>
+      <CaseOpenedNotification item={item} caseImage="case.png" user={user} {...props} />
+    </MemoryRouter>
+  );
+
+describe("a card in the live drop feed", () => {
+  it("says how many more came out of the same opening", () => {
+    draw({ others: 4 });
+    expect(screen.getByText("+4")).toBeTruthy();
+  });
+
+  it("says nothing when the opening produced one item", () => {
+    draw();
+    expect(screen.queryByText(/^\+/)).toBeNull();
+  });
+
+  // the flip side shows the parent case, so an upgraded item would read as having
+  // dropped out of it
+  it("marks a drop that came from an upgrade", () => {
+    const { container } = draw({ source: "upgrade" });
+    expect(container.querySelector('[title="Won by upgrading"]')).toBeTruthy();
+  });
+
+  it("leaves an ordinary opening unmarked", () => {
+    const { container } = draw();
+    expect(container.querySelector('[title="Won by upgrading"]')).toBeNull();
+  });
+});

--- a/src/components/header/CaseOpenedNotification.tsx
+++ b/src/components/header/CaseOpenedNotification.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
+import { GiUpgrade } from "react-icons/gi";
 import Rarities from "../Rarities";
 import { Link } from "react-router-dom";
 import { BasicItem } from "../Types";
 import Badge from "../Badge";
 import { Badge as BadgeData } from "../../services/badges/BadgeService";
+import i18n from "../../i18n";
 
 interface CaseOpenedNotificationProps {
   user: {
@@ -14,11 +16,13 @@ interface CaseOpenedNotificationProps {
   };
   item: BasicItem;
   caseImage: string;
+  // undefined for an opening, which is what every drop in the feed used to be
+  source?: string;
 }
 
 
 const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
-  user, item, caseImage
+  user, item, caseImage, source
 }) => {
   const [isHovering, setIsHovering] = useState<boolean>(false);
 
@@ -47,6 +51,14 @@ const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
         transform: `${isHovering ? "rotateY(180deg)" : "rotateY(0deg)"}`,
       }}>
         <div className={`flex flex-col transition-all w-full items-center space-x-2 relative ${isHovering ? "opacity-0" : "opacity-100"}`}>
+          {source === "upgrade" && (
+            <span
+              className="absolute left-1 top-1 z-20 text-[#ECA823]"
+              title={i18n.t("upgrade.wonByUpgrading")}
+            >
+              <GiUpgrade className="text-sm" />
+            </span>
+          )}
           <img
             src={item.image}
             alt={item.name}

--- a/src/components/header/CaseOpenedNotification.tsx
+++ b/src/components/header/CaseOpenedNotification.tsx
@@ -18,11 +18,13 @@ interface CaseOpenedNotificationProps {
   caseImage: string;
   // undefined for an opening, which is what every drop in the feed used to be
   source?: string;
+  // how many more came out of the same opening, and are not drawn
+  others?: number;
 }
 
 
 const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
-  user, item, caseImage, source
+  user, item, caseImage, source, others = 0
 }) => {
   const [isHovering, setIsHovering] = useState<boolean>(false);
 
@@ -57,6 +59,14 @@ const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
               title={i18n.t("upgrade.wonByUpgrading")}
             >
               <GiUpgrade className="text-sm" />
+            </span>
+          )}
+          {others > 0 && (
+            <span
+              className="absolute right-1 top-1 z-20 rounded bg-[#1e1b38] px-1 text-[10px] font-bold text-[#c9c6de]"
+              title={i18n.t("common.andMoreFromThisOpening", { count: others })}
+            >
+              +{others}
             </span>
           )}
           <img

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -16,6 +16,7 @@ import { Badge } from "../../services/badges/BadgeService";
 interface CaseOpeningItem {
   id: string;
   caseImage: string;
+  source?: string;
   timestamp: number;
   user: {
     id: string;
@@ -37,6 +38,9 @@ interface ItemsQueue {
   id: string;
   items: BasicItem[];
   caseImages: string[];
+  // where the drop came from. absent means a case was opened, which is every drop the
+  // feed carried before the upgrade game started reporting its wins.
+  source?: string;
   user: {
     id: string;
     name: string;
@@ -91,6 +95,7 @@ const Header: React.FC<Header> = ({ onlineUsers, recentCaseOpenings, notificatio
           id: opening.id,
           items: opening.winningItems,
           caseImages: [opening.caseImage],
+          source: opening.source,
           user: opening.user,
         };
       });
@@ -148,6 +153,7 @@ const Header: React.FC<Header> = ({ onlineUsers, recentCaseOpenings, notificatio
                     key={opening.id}
                     item={opening.items[0]}
                     caseImage={opening.caseImages[0]}
+                    source={opening.source}
                     user={opening.user}
                   />
                 ))}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -12,6 +12,7 @@ import Sidebar from "./Sidebar";
 import { BasicItem } from "../Types";
 import i18n from "../../i18n";
 import { Badge } from "../../services/badges/BadgeService";
+import { bestDrop } from "./liveDrop";
 
 interface CaseOpeningItem {
   id: string;
@@ -148,15 +149,20 @@ const Header: React.FC<Header> = ({ onlineUsers, recentCaseOpenings, notificatio
 
             <div className="flex h-28 bg-[#141225] ">
               <div className="flex overflow-hidden justify-start transition-all">
-                {ItemsQueue.map((opening) => (
-                  <CaseOpenedNotification
-                    key={opening.id}
-                    item={opening.items[0]}
-                    caseImage={opening.caseImages[0]}
-                    source={opening.source}
-                    user={opening.user}
-                  />
-                ))}
+                {ItemsQueue.map((opening) => {
+                  const best = bestDrop(opening.items);
+                  if (!best) return null;
+                  return (
+                    <CaseOpenedNotification
+                      key={opening.id}
+                      item={best}
+                      others={opening.items.length - 1}
+                      caseImage={opening.caseImages[0]}
+                      source={opening.source}
+                      user={opening.user}
+                    />
+                  );
+                })}
 
               </div>
             </div>

--- a/src/components/header/liveDrop.test.ts
+++ b/src/components/header/liveDrop.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { bestDrop } from "./liveDrop";
+import { BasicItem } from "../Types";
+
+const item = (name: string, rarity: string) => ({ name, rarity, image: `${name}.png` }) as BasicItem;
+
+// the feed used to draw items[0], so a five-open threw away four items and usually showed
+// the dullest one. it draws the rarest now, with a count for the rest.
+describe("picking what a multi-open shows", () => {
+  it("takes the rarest of the batch", () => {
+    const items = [item("common", "1"), item("gold", "5"), item("blue", "2")];
+    expect(bestDrop(items)?.name).toBe("gold");
+  });
+
+  it("keeps the first rolled when two are equally rare", () => {
+    expect(bestDrop([item("first", "4"), item("second", "4")])?.name).toBe("first");
+  });
+
+  it("compares rarity as a number, not as text", () => {
+    // "10" sorts before "9" as a string, and the feed would show the wrong one
+    expect(bestDrop([item("nine", "9"), item("ten", "10")])?.name).toBe("ten");
+  });
+
+  it("handles a single item and an empty batch", () => {
+    expect(bestDrop([item("only", "3")])?.name).toBe("only");
+    expect(bestDrop([])).toBeUndefined();
+  });
+});

--- a/src/components/header/liveDrop.ts
+++ b/src/components/header/liveDrop.ts
@@ -1,0 +1,10 @@
+import { BasicItem } from "../Types";
+
+// 95% of openings are five at once, so showing every item would put five cards in a feed
+// that holds twenty and let one player fill it. one card per opening instead, carrying the
+// rarest pull, which is the part anyone reads the feed for. ties keep the first rolled.
+export const bestDrop = (items: BasicItem[]): BasicItem | undefined =>
+  (items || []).reduce<BasicItem | undefined>(
+    (best, item) => (!best || Number(item.rarity) > Number(best.rarity) ? item : best),
+    undefined
+  );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -878,6 +878,7 @@
     "selectedItem": "ausgewaehlter-gegenstand",
     "signInToPlay": "Zum Spielen anmelden",
     "upgradeFailed": "Verbesserung fehlgeschlagen",
-    "upgradeSuccess": "Verbesserung gelungen"
+    "upgradeSuccess": "Verbesserung gelungen",
+    "wonByUpgrading": "Durch Upgrade gewonnen"
   }
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Alle Seltenheiten",
+    "andMoreFromThisOpening": "und {{count}} weitere aus derselben Öffnung",
     "ascending": "Aufsteigend",
     "avatar": "Avatar",
     "balance": "Guthaben",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "All Rarities",
+    "andMoreFromThisOpening": "and {{count}} more from the same opening",
     "ascending": "Ascending",
     "avatar": "avatar",
     "balance": "Balance",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -878,6 +878,7 @@
     "selectedItem": "selected-item",
     "signInToPlay": "Sign in to play",
     "upgradeFailed": "Upgrade Failed",
-    "upgradeSuccess": "Upgrade Success"
+    "upgradeSuccess": "Upgrade Success",
+    "wonByUpgrading": "Won by upgrading"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Todas las rarezas",
+    "andMoreFromThisOpening": "y {{count}} más de la misma apertura",
     "ascending": "Ascendente",
     "avatar": "avatar",
     "balance": "Saldo",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -878,6 +878,7 @@
     "selectedItem": "objeto-seleccionado",
     "signInToPlay": "Inicia sesión para jugar",
     "upgradeFailed": "Mejora fallida",
-    "upgradeSuccess": "Mejora conseguida"
+    "upgradeSuccess": "Mejora conseguida",
+    "wonByUpgrading": "Conseguido con una mejora"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -878,6 +878,7 @@
     "selectedItem": "objet-selectionne",
     "signInToPlay": "Connectez-vous pour jouer",
     "upgradeFailed": "Amélioration échouée",
-    "upgradeSuccess": "Amélioration réussie"
+    "upgradeSuccess": "Amélioration réussie",
+    "wonByUpgrading": "Obtenu par amélioration"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Toutes les raretés",
+    "andMoreFromThisOpening": "et {{count}} autres de la même ouverture",
     "ascending": "Croissant",
     "avatar": "avatar",
     "balance": "Solde",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -878,6 +878,7 @@
     "selectedItem": "Item-terpilih",
     "signInToPlay": "Masuk untuk main",
     "upgradeFailed": "Upgrade gagal",
-    "upgradeSuccess": "Upgrade berhasil"
+    "upgradeSuccess": "Upgrade berhasil",
+    "wonByUpgrading": "Didapat dari upgrade"
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Semua Kelangkaan",
+    "andMoreFromThisOpening": "dan {{count}} lagi dari pembukaan yang sama",
     "ascending": "Naik",
     "avatar": "avatar",
     "balance": "Uang",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -878,6 +878,7 @@
     "selectedItem": "oggetto-selezionato",
     "signInToPlay": "Accedi per giocare",
     "upgradeFailed": "Miglioramento fallito",
-    "upgradeSuccess": "Miglioramento riuscito"
+    "upgradeSuccess": "Miglioramento riuscito",
+    "wonByUpgrading": "Ottenuto con un upgrade"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Tutte le rarità",
+    "andMoreFromThisOpening": "e altri {{count}} dalla stessa apertura",
     "ascending": "Crescente",
     "avatar": "avatar",
     "balance": "Saldo",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "すべてのレアリティ",
+    "andMoreFromThisOpening": "同じ開封からさらに{{count}}個",
     "ascending": "昇順",
     "avatar": "アバター",
     "balance": "残高",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -878,6 +878,7 @@
     "selectedItem": "selected-item",
     "signInToPlay": "ログインして遊ぶ",
     "upgradeFailed": "アップグレード失敗",
-    "upgradeSuccess": "アップグレード成功"
+    "upgradeSuccess": "アップグレード成功",
+    "wonByUpgrading": "アップグレードで獲得"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -878,6 +878,7 @@
     "selectedItem": "selected-item",
     "signInToPlay": "로그인하고 플레이",
     "upgradeFailed": "업그레이드 실패",
-    "upgradeSuccess": "업그레이드 성공"
+    "upgradeSuccess": "업그레이드 성공",
+    "wonByUpgrading": "업그레이드로 획득"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "모든 등급",
+    "andMoreFromThisOpening": "같은 개봉에서 {{count}}개 더",
     "ascending": "오름차순",
     "avatar": "아바타",
     "balance": "잔액",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Todas as raridades",
+    "andMoreFromThisOpening": "e mais {{count}} da mesma abertura",
     "ascending": "Crescente",
     "avatar": "avatar",
     "balance": "Saldo",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -878,6 +878,7 @@
     "selectedItem": "item-selecionado",
     "signInToPlay": "Entre para jogar",
     "upgradeFailed": "Melhoria falhou",
-    "upgradeSuccess": "Melhoria bem-sucedida"
+    "upgradeSuccess": "Melhoria bem-sucedida",
+    "wonByUpgrading": "Ganho no upgrade"
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "Mọi độ hiếm",
+    "andMoreFromThisOpening": "và {{count}} vật phẩm khác từ cùng lần mở",
     "ascending": "Tăng dần",
     "avatar": "ảnh đại diện",
     "balance": "Số dư",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -878,6 +878,7 @@
     "selectedItem": "selected-item",
     "signInToPlay": "Đăng nhập để chơi",
     "upgradeFailed": "Nâng cấp thất bại",
-    "upgradeSuccess": "Nâng cấp thành công"
+    "upgradeSuccess": "Nâng cấp thành công",
+    "wonByUpgrading": "Thắng từ nâng cấp"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -238,6 +238,7 @@
   },
   "common": {
     "allRarities": "全部稀有度",
+    "andMoreFromThisOpening": "以及同一次开箱的另外 {{count}} 件",
     "ascending": "升序",
     "avatar": "头像",
     "balance": "余额",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -878,6 +878,7 @@
     "selectedItem": "selected-item",
     "signInToPlay": "登录后游玩",
     "upgradeFailed": "升级失败",
-    "upgradeSuccess": "升级成功"
+    "upgradeSuccess": "升级成功",
+    "wonByUpgrading": "通过升级获得"
   }
 }


### PR DESCRIPTION
Two things wrong with the same feed.

**A multi-open showed one arbitrary item.** The header drew `winningItems[0]` and discarded the rest. That is nearly every card in the feed:

```
x1     660   4.7%
x5  12,976  93.2%
95.3% of all openings are multi-opens
```

Drawing all of them is the wrong fix: 66,399 cards for 13,921 openings, through a feed that holds twenty, and a single player opening five at a time would fill it. The card now carries the **rarest** pull with a `+4` for the rest, so one opening stays one card and the count stays honest.

**A won upgrade appeared nowhere**, though it puts an item in an inventory the same way an opening does. The upgrade route emits the same event on a win, and nothing on a loss.

It carries `source: "upgrade"` because the card's flip side shows the item's parent case: an upgraded item genuinely belongs to that case but did not come out of it, and unmarked the drop would read as an opening that never happened. The card shows a small upgrade mark, with a title translated into all 11 locales.

The emit sits before the response, matching `openCase`. That adds one `Case.findById` with an `{ image: 1 }` projection to the route: about 80 bytes for a single document, on a path used 1,113 times in the site's lifetime.

Known and left alone: the feed delays every drop by 7,500ms to match the case animation, but the upgrade wheel reveals at 8,000ms, so an upgrader sees their own win in the feed half a second early.

**Tests.** Two backend integration cases (fires on a win with the right item, user, case image and source; silent on a loss) and eight frontend cases covering the rarest-item pick, numeric rarity comparison, tie-breaking, and both card markers.

Backend 949 passing, frontend 147, eslint 0 errors, build clean, 34/34 e2e.