### PR TITLE
Count an alt outfit as the same character

### DIFF
--- a/backend/__tests__/integration/badges.test.js
+++ b/backend/__tests__/integration/badges.test.js
@@ -206,6 +206,48 @@ describe("collection badges", () => {
   const own = (items) =>
     items.map((it) => ({ _id: it._id, name: it.name, image: it.image, rarity: it.rarity }));
 
+  // a premium case sits on the same shelf but is not part of the roster to complete
+  async function makePremium(category, titles) {
+    const items = [];
+    for (const title of titles) {
+      items.push(await Item.create({ name: title, image: "i.png", rarity: "5", baseValue: 9000 }));
+    }
+    await Case.create({
+      title: `${category} Festival`, image: "c.png", price: 9000, category,
+      collectible: false, items: items.map((i) => i._id),
+    });
+    return items;
+  }
+
+  it("leaves a case marked uncollectible out of its category's set", async () => {
+    await makeCategory("Blue Archive", ["a", "b", "c", "d"]);
+    await makePremium("Blue Archive", ["alt-a", "alt-b"]);
+
+    const [set] = await badges.collectionSets();
+
+    expect(set.ids.size).toBe(4);
+  });
+
+  it("completes a collection without owning anything from the premium case", async () => {
+    const base = await makeCategory("Blue Archive", ["a", "b", "c", "d"]);
+    await makePremium("Blue Archive", ["alt-a", "alt-b"]);
+    const user = await makeUser({ inventory: own(base) });
+
+    expect(await badges.sweepCollections()).toBe(1);
+    const held = (await User.findById(user._id).select("badges").lean()).badges;
+    expect(held.map((b) => b.key)).toContain("collection:blue-archive");
+  });
+
+  it("counts a case that says nothing about being collectible", async () => {
+    await makeCategory("Touhou", ["a", "b"]);
+    await Case.create({ title: "Touhou C", image: "c.png", price: 60, category: "Touhou",
+      items: [(await Item.create({ name: "c", image: "i.png", rarity: "2", baseValue: 10 }))._id] });
+
+    const [set] = await badges.collectionSets();
+
+    expect(set.ids.size).toBe(3);
+  });
+
   it("groups a category across all of its cases", async () => {
     await makeCategory("Blue Archive", ["a", "b", "c", "d"]);
     const sets = await badges.collectionSets();

--- a/backend/__tests__/integration/fandom.test.js
+++ b/backend/__tests__/integration/fandom.test.js
@@ -308,3 +308,115 @@ describe("a drop of the pinned character", () => {
     expect((await FanBoard.findOne({ name: "Yuuma" }).lean()).topCount).toBe(5);
   });
 });
+
+// an alt outfit is a separate catalog row carrying the base character's name, so both
+// versions count as the same person on one board
+describe("alt outfits", () => {
+  const makeAlt = (name, character, rarity = "5") =>
+    Item.create({ name, character, image: `${name}.png`, rarity, baseValue: 100 });
+
+  it("counts a base copy and an alt copy as the same character", async () => {
+    const base = await makeItem("Hoshino", "5");
+    const alt = await makeAlt("Hoshino (Swimsuit)", "Hoshino");
+    await makeUser({ pinned: base, inventory: [...copies(base, 1), ...copies(alt, 1)] });
+
+    await fandom.rebuild();
+
+    const board = await FanBoard.findOne({ name: "Hoshino" }).lean();
+    expect(board.topCount).toBe(2);
+    expect(await FanBoard.findOne({ name: "Hoshino (Swimsuit)" }).lean()).toBeNull();
+  });
+
+  it("gives an alt no board of its own", async () => {
+    await makeItem("Hoshino", "5");
+    await makeAlt("Hoshino (Swimsuit)", "Hoshino");
+
+    const byName = await fandom.charactersByName();
+
+    expect(byName.has("Hoshino")).toBe(true);
+    expect(byName.has("Hoshino (Swimsuit)")).toBe(false);
+    expect(byName.get("Hoshino").ids.size).toBe(2);
+  });
+
+  it("keeps the base look on the board when the alt is a different picture", async () => {
+    const alt = await makeAlt("Hoshino (Swimsuit)", "Hoshino");
+    const base = await makeItem("Hoshino", "5");
+
+    const character = (await fandom.charactersByName(["Hoshino"])).get("Hoshino");
+
+    expect(character.image).toBe(base.image);
+    expect(character.ids.has(String(alt._id))).toBe(true);
+  });
+
+  it("puts someone who pinned the alt on the character's board", async () => {
+    const base = await makeItem("Hoshino", "5");
+    const alt = await makeAlt("Hoshino (Swimsuit)", "Hoshino");
+    const owner = await makeUser({ inventory: copies(alt, 3) });
+    const token = tokenFor(owner);
+
+    await request(app)
+      .put("/users/fixedItem")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ item: String(alt._id) })
+      .expect(200);
+
+    const after = await User.findById(owner._id).select("fixedItem").lean();
+    expect(after.fixedItem.name).toBe("Hoshino");
+    expect(after.fixedItem.variant).toBe("Hoshino (Swimsuit)");
+    expect(after.fixedItem.image).toBe(alt.image);
+
+    await fandom.rebuild();
+    const board = await FanBoard.findOne({ name: "Hoshino" }).lean();
+    expect(board.topCount).toBe(3);
+    expect(String(board.top.userId)).toBe(String(owner._id));
+    expect(base).toBeTruthy();
+  });
+
+  it("does not reset the tie-break clock when swapping between two outfits", async () => {
+    const base = await makeItem("Hoshino", "5");
+    const alt = await makeAlt("Hoshino (Swimsuit)", "Hoshino");
+    const owner = await makeUser({ pinned: base, inventory: copies(alt, 1) });
+    await User.updateOne({ _id: owner._id }, { $set: { fixedAt: new Date("2020-01-01") } });
+    const token = tokenFor(owner);
+
+    await request(app)
+      .put("/users/fixedItem")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ item: String(alt._id) })
+      .expect(200);
+
+    const after = await User.findById(owner._id).select("fixedAt").lean();
+    expect(after.fixedAt.toISOString()).toBe(new Date("2020-01-01").toISOString());
+  });
+
+  it("clears the outfit when the pin moves back to the base look", async () => {
+    const base = await makeItem("Hoshino", "5");
+    const alt = await makeAlt("Hoshino (Swimsuit)", "Hoshino");
+    const owner = await makeUser({ inventory: [...copies(alt, 1), ...copies(base, 1)] });
+    const token = tokenFor(owner);
+    const pin = (id) =>
+      request(app)
+        .put("/users/fixedItem")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ item: String(id) })
+        .expect(200);
+
+    await pin(alt._id);
+    expect((await User.findById(owner._id).lean()).fixedItem.variant).toBe("Hoshino (Swimsuit)");
+
+    await pin(base._id);
+    const after = await User.findById(owner._id).lean();
+    expect(after.fixedItem.variant).toBeUndefined();
+    expect(after.fixedItem.image).toBe(base.image);
+  });
+
+  it("leaves an ordinary item counting under its own name", async () => {
+    const plain = await makeItem("Cirno", "4");
+    await makeUser({ pinned: plain, inventory: copies(plain, 2) });
+
+    await fandom.rebuild();
+
+    const board = await FanBoard.findOne({ name: "Cirno" }).lean();
+    expect(board.topCount).toBe(2);
+  });
+});

--- a/backend/models/Case.js
+++ b/backend/models/Case.js
@@ -15,6 +15,14 @@ const CaseSchema = new mongoose.Schema({
     type: String,
     default: "",
   },
+  // whether the case counts toward its category's collection badge. premium cases are
+  // alt outfits and joke items rather than new faces, so they are the shelf's top end
+  // without being part of the roster you are asked to complete. the case keeps its own
+  // sticker album either way. set explicitly, never derived from price: price moves.
+  collectible: {
+    type: Boolean,
+    default: true,
+  },
 
   items: [
     {

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -14,6 +14,12 @@ const ItemSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  // the character behind the item, when that is not the item's own name: an alt outfit is
+  // its own item but the same person, so both count toward one fan board. absent means the
+  // name is the character, which is true of everything but the alt sets.
+  character: {
+    type: String,
+  },
   baseValue: {
     type: Number,
     default: 0,

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -45,7 +45,11 @@ const UserSchema = new mongoose.Schema({
     },
   ],
   fixedItem: {
+    // the character, not the item: pinning an alt outfit makes you a fan of the person, so
+    // this holds the base name and every board lookup keeps working off the same index
     name: String,
+    // which outfit was pinned, when it was not the base one. display only
+    variant: String,
     image: String,
     rarity: String,
     description: String,

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -498,16 +498,21 @@ router.put("/fixedItem", authMiddleware.isAuthenticated, async (req, res) => {
       return res.status(404).json({ message: "Item not found in inventory" });
     }
 
-    const catalogItem = await Item.findById(item, { name: 1, image: 1, rarity: 1 }).lean();
+    const catalogItem = await Item.findById(item, { name: 1, character: 1, image: 1, rarity: 1 }).lean();
     if (!catalogItem) {
       return res.status(404).json({ message: "Item not found" });
     }
 
+    // pinning an alt outfit still makes you a fan of the character, so the board is theirs
+    // and swapping between two of their outfits is not a change of fandom
+    const character = catalogItem.character || catalogItem.name;
+
     // Update fixed item, keeping the same description
     const previousFandom = user.fixedItem && user.fixedItem.name;
-    const movedFandom = previousFandom !== catalogItem.name;
+    const movedFandom = previousFandom !== character;
     user.fixedItem = {
-      name: catalogItem.name,
+      name: character,
+      variant: catalogItem.character ? catalogItem.name : undefined,
       image: catalogItem.image,
       rarity: catalogItem.rarity,
       description: user.fixedItem.description,
@@ -525,7 +530,7 @@ router.put("/fixedItem", authMiddleware.isAuthenticated, async (req, res) => {
       // the board the player left and the one they joined are both wrong until recounted,
       // and the client reads them back straight away
       try {
-        await fandom.refreshCharacters([previousFandom, catalogItem.name]);
+        await fandom.refreshCharacters([previousFandom, character]);
       } catch (err) {
         console.error("fandom refresh:", err.message);
       }

--- a/backend/scripts/importCases.js
+++ b/backend/scripts/importCases.js
@@ -6,7 +6,9 @@
 //   idempotent: a case whose title already exists is skipped, so re-running is safe.
 //
 // spec shape: { "Millennium": { price: 45, cover: "<url>", category: "Blue Archive",
-//   items: [ { name, rarity: "1".."5", image: "<url>" }, ... ] }, ... }
+//   items: [ { name, rarity: "1".."5", image: "<url>", character? }, ... ] }, ... }
+//   character names the person behind an alt outfit, so both count on one fan board.
+//   collectible: false keeps a case off its category's collection badge.
 //   the title defaults to "<key> Case"; set def.title to override it.
 const mongoose = require("mongoose");
 require("dotenv").config();
@@ -49,10 +51,17 @@ async function main() {
       image: def.cover,
       price: def.price,
       category: def.category || "",
+      collectible: def.collectible !== false,
       items: [],
     });
     const items = await Item.insertMany(
-      def.items.map((i) => ({ name: i.name, image: i.image, rarity: String(i.rarity), case: c._id }))
+      def.items.map((i) => ({
+        name: i.name,
+        character: i.character && i.character !== i.name ? i.character : undefined,
+        image: i.image,
+        rarity: String(i.rarity),
+        case: c._id,
+      }))
     );
     await Case.updateOne({ _id: c._id }, { $set: { items: items.map((i) => i._id) } });
     await recomputeCaseValues(c._id); // baseValues + provably-fair range table

--- a/backend/utils/badges.js
+++ b/backend/utils/badges.js
@@ -118,19 +118,21 @@ async function sweepConnected(io) {
 }
 
 // every case category and the item ids that make it whole. a category is complete only
-// when the player owns one of every distinct item across all of its cases.
+// when the player owns one of every distinct item across all of its collectible cases;
+// a case marked `collectible: false` is on the shelf but out of the set.
 //
 // Case.items is raw admin input and can still name an item that has since been deleted.
 // those never drop and nobody can hold one, so counting them asks for a set that cannot
 // be completed: the touhou badge wanted 137 of the 134 that exist. only live items count.
 async function collectionSets() {
   const [cases, catalog] = await Promise.all([
-    Case.find({}, { category: 1, items: 1 }).lean(),
+    Case.find({}, { category: 1, items: 1, collectible: 1 }).lean(),
     itemCatalog.all(),
   ]);
   const live = new Set(catalog.map((item) => String(item._id)));
   const byCategory = new Map();
   for (const one of cases) {
+    if (one.collectible === false) continue;
     const label = (one.category || "").trim();
     if (!label) continue;
     const slug = slugify(label);

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -13,23 +13,30 @@ const RANKS_KEPT = 50;
 const NO_CONTEST = 999999;
 const COLLECTORS_KEPT = 100;
 
-// the same character can appear in more than one case, as separate item rows sharing a
-// name. the name is the character, so every id behind it counts toward the same board.
+// an item's character is its own name unless it is an alt outfit, which carries the base
+// name so both count as one person
+const characterOf = (item) => item.character || item.name;
+
+// the same character can appear in more than one case, and in more than one outfit, as
+// separate item rows. the character is the board, so every id behind it counts toward it.
 async function charactersByName(names) {
   const wanted = names && names.length ? new Set(names) : null;
-  const items = (await itemCatalog.all()).filter((item) => !wanted || wanted.has(item.name));
+  const items = (await itemCatalog.all()).filter((item) => !wanted || wanted.has(characterOf(item)));
   const byName = new Map();
   for (const item of items) {
-    let entry = byName.get(item.name);
+    const name = characterOf(item);
+    let entry = byName.get(name);
     if (!entry) {
-      entry = { name: item.name, ids: new Set(), image: item.image, rarity: item.rarity, caseId: item.case };
-      byName.set(item.name, entry);
+      entry = { name, ids: new Set(), image: null, rarity: null, caseId: null };
+      byName.set(name, entry);
     }
     entry.ids.add(String(item._id));
-    if (!entry.image) entry.image = item.image;
-    if (!entry.rarity) entry.rarity = item.rarity;
+    // the board wears the base look, so an alt never takes the portrait off the character
+    // it belongs to, whichever order the catalog came back in
+    if (!entry.image || !item.character) entry.image = item.image || entry.image;
+    if (!entry.rarity || !item.character) entry.rarity = item.rarity || entry.rarity;
     // the first case the character drops from is where the page sends anyone chasing them
-    if (!entry.caseId) entry.caseId = item.case;
+    if (!entry.caseId || !item.character) entry.caseId = item.case || entry.caseId;
   }
   return byName;
 }
@@ -101,8 +108,9 @@ async function countHoldings() {
     { $group: { _id: { user: "$_id", item: "$inventory._id" }, n: { $sum: 1 }, ...carry } },
     { $lookup: { from: "items", localField: "_id.item", foreignField: "_id", as: "catalog" } },
     { $unwind: "$catalog" },
-    // the same character can come from more than one case, so the name is the group
-    { $group: { _id: { user: "$_id.user", name: "$catalog.name" }, n: { $sum: "$n" }, ...carry } },
+    // one character can come from more than one case and wear more than one outfit, so the
+    // character is the group. no extra read: the join already had the catalog row
+    { $group: { _id: { user: "$_id.user", name: { $ifNull: ["$catalog.character", "$catalog.name"] } }, n: { $sum: "$n" }, ...carry } },
     {
       $group: {
         _id: "$_id.user",
@@ -397,9 +405,9 @@ async function touchInventory(userIds, itemIds) {
   if (!pinned.size) return { boards: 0 };
 
   const rows = await Item.find({ _id: { $in: items.map((id) => new mongoose.Types.ObjectId(id)) } })
-    .select("name")
+    .select("name character")
     .lean();
-  return refreshCharacters([...new Set(rows.map((row) => row.name).filter((name) => pinned.has(name)))]);
+  return refreshCharacters([...new Set(rows.map(characterOf).filter((name) => pinned.has(name)))]);
 }
 
 // a board recount must never be what fails the sale, upgrade or opening that moved

--- a/backend/utils/itemCatalog.js
+++ b/backend/utils/itemCatalog.js
@@ -76,13 +76,14 @@ async function find({ name, rarity, caseId } = {}) {
   });
 }
 
-// every catalog id mapped to the character behind it, rebuilt only when the cache turns over
+// every catalog id mapped to the character behind it, rebuilt only when the cache turns over.
+// an alt outfit is its own item but the same person, so it maps to the base character.
 let nameById = null;
 let nameByIdFor = -1;
 async function namesById() {
   const items = await all();
   if (!nameById || nameByIdFor !== generation) {
-    nameById = new Map(items.map((item) => [String(item._id), item.name]));
+    nameById = new Map(items.map((item) => [String(item._id), item.character || item.name]));
     nameByIdFor = generation;
   }
   return nameById;

--- a/src/pages/Home/groupCases.test.ts
+++ b/src/pages/Home/groupCases.test.ts
@@ -2,13 +2,44 @@ import { describe, it, expect } from "vitest";
 import { groupCasesByCategory, OTHER_CATEGORY } from "./groupCases";
 
 // objectid-like ids where string order is creation order
-const c = (_id: string, category?: string) => ({ _id, title: `case ${_id}`, category });
+const c = (_id: string, category?: string, price = 0) => ({ _id, title: `case ${_id}`, category, price });
 
 describe("groupCasesByCategory", () => {
-  it("groups by category with the newest case first inside each group", () => {
-    const groups = groupCasesByCategory([c("1", "Touhou"), c("3", "Touhou"), c("2", "Animals")]);
+  it("groups by category with the cheapest case first inside each group", () => {
+    const groups = groupCasesByCategory([
+      c("1", "Touhou", 8000),
+      c("3", "Touhou", 60),
+      c("2", "Animals", 40),
+    ]);
     const touhou = groups.find((g) => g.category === "Touhou");
     expect(touhou?.cases.map((x: any) => x._id)).toEqual(["3", "1"]);
+  });
+
+  it("puts a premium case behind every cheaper one even though it is the newest", () => {
+    const groups = groupCasesByCategory([
+      c("9", "Blue Archive", 10000),
+      c("1", "Blue Archive", 45),
+      c("2", "Blue Archive", 30),
+    ]);
+    expect(groups[0].cases.map((x: any) => [x._id, x.price])).toEqual([
+      ["2", 30],
+      ["1", 45],
+      ["9", 10000],
+    ]);
+  });
+
+  it("breaks a price tie with the newest case", () => {
+    const groups = groupCasesByCategory([c("1", "Touhou", 60), c("3", "Touhou", 60)]);
+    expect(groups[0].cases.map((x: any) => x._id)).toEqual(["3", "1"]);
+  });
+
+  it("still orders groups by their newest case, not their cheapest", () => {
+    const groups = groupCasesByCategory([
+      c("1", "Touhou", 10),
+      c("5", "Animals", 9000),
+      c("2", "Animals", 20),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["Animals", "Touhou"]);
   });
 
   it("orders groups by their newest case, newest group first", () => {

--- a/src/pages/Home/groupCases.ts
+++ b/src/pages/Home/groupCases.ts
@@ -7,8 +7,12 @@ export interface CaseGroup {
 
 export { OTHER_CATEGORY };
 
-// objectids embed creation time, so string order is creation order. newest first
-// inside a group, groups ordered by their newest case; no category -> "Other", last
+// objectids embed creation time, so string order is creation order
+const newest = (list: any[]) => list.reduce((a, b) => (a._id < b._id ? b : a))._id;
+
+// cheapest first inside a group, so a shelf reads from what a new player can afford up to
+// the premium end; groups are still ordered by their newest case, and no category ->
+// "Other", last
 export function groupCasesByCategory(cases: any[]): CaseGroup[] {
     const byCategory = new Map<string, any[]>();
     for (const c of cases || []) {
@@ -21,12 +25,13 @@ export function groupCasesByCategory(cases: any[]): CaseGroup[] {
 
     const groups = [...byCategory.entries()].map(([category, list]) => ({
         category,
-        cases: [...list].sort((a, b) => (a._id < b._id ? 1 : -1)),
+        newest: newest(list),
+        cases: [...list].sort(
+            (a, b) => (a.price || 0) - (b.price || 0) || (a._id < b._id ? 1 : -1)
+        ),
     }));
 
-    groups.sort((a, b) =>
-        compareCategories(a.category, b.category, () => (a.cases[0]._id < b.cases[0]._id ? 1 : -1))
-    );
+    groups.sort((a, b) => compareCategories(a.category, b.category, () => (a.newest < b.newest ? 1 : -1)));
 
-    return groups;
+    return groups.map(({ category, cases }) => ({ category, cases }));
 }


### PR DESCRIPTION
An alt outfit is a separate item but the same person. Holding one Hoshino and one Swimsuit Hoshino should make you a two-Hoshino fan, and today it makes you a fan of two unrelated characters with a board each.

## Change

`Item.character` names who is behind an item when that is not the item's own name. Absent means the name is the character, which is true of every item in the catalogue right now, so nothing changes until a set that uses it is imported.

- Fan boards group on the character instead of the item name.
- `fixedItem` stores the character rather than the pinned item's name, so its index and every board lookup keep working unchanged; the outfit is kept alongside for display. Swapping between two outfits of one character is not a change of fandom and does not reset the `fixedAt` tie-break.
- No extra reads: the sweep's `$lookup` already had the catalog row, so grouping on `character` instead of `name` costs nothing.

`Case.collectible` (default true) lets a premium case sit on its category's shelf and keep its own sticker album without being part of the roster the collection badge asks you to complete. Set per case, never derived from price: at any threshold it catches Steam-priced weapon cases that are ordinary roster cases, and a badge that resizes when someone reprices a case is the bug already fixed once by counting only live items.

Cases now list cheapest first inside a shelf, so a premium case cannot stand in front of the one a new player can afford. Shelf order itself is unchanged, still keyed on each category's newest case.

## Tests

`backend`: 959 pass. Seven new fan-board tests cover the base/alt merge, the board keeping the base portrait, pinning an alt, the tie-break clock, and clearing the outfit on re-pin; three new badge tests cover the flag and the untouched default. `frontend`: 153 unit pass, lint clean, build clean; four new ordering tests. Every new test was confirmed to fail without its change.