### PR TITLE
feat(discord): a read-only bot, and account linking

### DIFF
--- a/backend/__tests__/integration/discordBot.test.js
+++ b/backend/__tests__/integration/discordBot.test.js
@@ -1,0 +1,304 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+process.env.DISCORD_BOT_SECRET = "bot-secret-for-tests";
+process.env.SITE_URL = "https://kanicasino.com";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const DiscordLink = require("../../models/DiscordLink");
+const FanBoard = require("../../models/FanBoard");
+
+const SECRET = process.env.DISCORD_BOT_SECRET;
+const DISCORD_EPOCH = 1420070400000;
+const GUILD = "907336089797267496";
+const OTHER_GUILD = "111111111111111111";
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+// discord ids carry their own creation time, which is what the age check reads
+const snowflakeFor = (date) => String(BigInt(date.getTime() - DISCORD_EPOCH) << 22n);
+const daysAgo = (days) => new Date(Date.now() - days * 86400000);
+const oldEnough = () => snowflakeFor(daysAgo(400));
+
+async function makeUser(overrides = {}) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    ...overrides,
+  });
+}
+
+const bot = (req) => req.set("x-bot-secret", SECRET);
+const auth = (req, user) => req.set("Authorization", `Bearer ${tokenFor(user)}`);
+const startLink = (discordId) =>
+  bot(request(app).post("/discord/link/start")).send({ discordId, discordName: "someone" });
+const completeLink = (user, code) =>
+  auth(request(app).post("/discord/link/complete"), user).send({ code });
+
+// the whole flow, since most tests need an account already linked
+async function linkUser(user, discordId, guilds = []) {
+  const started = await startLink(discordId);
+  await completeLink(user, started.body.code);
+  if (guilds.length) await User.updateOne({ _id: user._id }, { $set: { discordGuilds: guilds } });
+  return started.body.code;
+}
+
+describe("discord bot routes", () => {
+  describe("the bot secret", () => {
+    it("refuses a caller with no secret", async () => {
+      const res = await request(app).post("/discord/link/start").send({ discordId: oldEnough() });
+      expect(res.status).toBe(403);
+    });
+
+    it("refuses a caller with the wrong secret", async () => {
+      const res = await request(app)
+        .post("/discord/link/start")
+        .set("x-bot-secret", "not-the-secret-at-all")
+        .send({ discordId: oldEnough() });
+      expect(res.status).toBe(403);
+    });
+
+    // the site api key ships in the frontend bundle, so anyone could mint a link code
+    // for someone else's discord id if that were the only gate
+    it("guards showcase, topfan and the leaderboard too", async () => {
+      const paths = [
+        `/discord/showcase/${oldEnough()}`,
+        `/discord/topfan/Hoshino?guild=${GUILD}`,
+        `/discord/leaderboard?guild=${GUILD}`,
+      ];
+      for (const path of paths) {
+        expect((await request(app).get(path)).status).toBe(403);
+      }
+    });
+  });
+
+  describe("linking", () => {
+    it("turns a code into a link once the site session claims it", async () => {
+      const user = await makeUser();
+      const discordId = oldEnough();
+
+      const started = await startLink(discordId);
+      expect(started.status).toBe(200);
+      expect(started.body.code).toMatch(/^[A-Z2-9]{8}$/);
+      expect(started.body.url).toContain(started.body.code);
+
+      const done = await completeLink(user, started.body.code);
+      expect(done.status).toBe(200);
+      expect(done.body.username).toBe(user.username);
+
+      const stored = await User.findById(user._id).select("discordId").lean();
+      expect(stored.discordId).toBe(discordId);
+      // the code is spent, not left lying around
+      expect(await DiscordLink.countDocuments({ code: started.body.code })).toBe(0);
+    });
+
+    it("turns away a discord account created in the last 30 days", async () => {
+      const res = await startLink(snowflakeFor(daysAgo(3)));
+      expect(res.status).toBe(403);
+      expect(await DiscordLink.countDocuments()).toBe(0);
+    });
+
+    it("says who holds a discord id rather than minting another code", async () => {
+      const user = await makeUser();
+      const discordId = oldEnough();
+      await linkUser(user, discordId);
+
+      const again = await startLink(discordId);
+      expect(again.body.alreadyLinked).toBe(true);
+      expect(again.body.username).toBe(user.username);
+      expect(again.body.code).toBeUndefined();
+    });
+
+    it("will not let a second account claim a discord id already linked", async () => {
+      const first = await makeUser();
+      const second = await makeUser();
+      const discordId = oldEnough();
+
+      const started = await startLink(discordId);
+      await completeLink(first, started.body.code);
+
+      // a code that was captured before it was redeemed is worthless afterwards
+      const res = await completeLink(second, started.body.code);
+      expect(res.status).toBe(404);
+      const stored = await User.findById(second._id).select("discordId").lean();
+      expect(stored.discordId).toBeUndefined();
+    });
+
+    it("will not let one account link twice", async () => {
+      const user = await makeUser();
+      await linkUser(user, oldEnough());
+
+      const started = await startLink(snowflakeFor(daysAgo(500)));
+      const res = await completeLink(user, started.body.code);
+      expect(res.status).toBe(409);
+    });
+
+    it("refuses an expired code", async () => {
+      const user = await makeUser();
+      const started = await startLink(oldEnough());
+      await DiscordLink.updateOne({ code: started.body.code }, { $set: { expiresAt: daysAgo(1) } });
+
+      const res = await completeLink(user, started.body.code);
+      expect(res.status).toBe(404);
+    });
+
+    it("needs a session: a code alone links nothing", async () => {
+      const started = await startLink(oldEnough());
+      const res = await request(app).post("/discord/link/complete").send({ code: started.body.code });
+      expect(res.status).toBe(401);
+    });
+
+    it("unlinks, and leaves the discord id free to link again", async () => {
+      const user = await makeUser();
+      const discordId = oldEnough();
+      await linkUser(user, discordId, [GUILD]);
+
+      expect((await auth(request(app).delete("/discord/link"), user)).status).toBe(200);
+      const stored = await User.findById(user._id).select("discordId discordGuilds").lean();
+      expect(stored.discordId).toBeUndefined();
+      expect(stored.discordGuilds).toBeUndefined();
+
+      const other = await makeUser();
+      const started = await startLink(discordId);
+      expect((await completeLink(other, started.body.code)).status).toBe(200);
+    });
+  });
+
+  describe("showcase", () => {
+    it("hands back the card, and never the inventory", async () => {
+      const user = await makeUser({
+        level: 12,
+        fixedItem: { name: "Hoshino", variant: "Swimsuit", rarity: "5" },
+        fanRank: { name: "Hoshino", count: 9, rank: 1, fans: 4, second: 5 },
+        collectionRank: { distinct: 30, total: 210, rank: 2 },
+        inventory: [{ name: "Hoshino", rarity: "5" }],
+      });
+      const discordId = oldEnough();
+      await linkUser(user, discordId);
+
+      const res = await bot(request(app).get(`/discord/showcase/${discordId}`));
+      expect(res.status).toBe(200);
+      expect(res.body.username).toBe(user.username);
+      expect(res.body.pinned).toMatchObject({ name: "Hoshino", variant: "Swimsuit" });
+      expect(res.body.fanRank).toMatchObject({ rank: 1, count: 9 });
+      expect(res.body.collection).toMatchObject({ distinct: 30 });
+      expect(res.body.inventory).toBeUndefined();
+    });
+
+    it("404s for a discord user with no account", async () => {
+      const res = await bot(request(app).get(`/discord/showcase/${oldEnough()}`));
+      expect(res.status).toBe(404);
+    });
+
+    it("hides a disabled account", async () => {
+      const user = await makeUser();
+      const discordId = oldEnough();
+      await linkUser(user, discordId);
+      await User.updateOne({ _id: user._id }, { $set: { disabled: true } });
+
+      expect((await bot(request(app).get(`/discord/showcase/${discordId}`))).status).toBe(404);
+    });
+  });
+
+  describe("server boards", () => {
+    async function seedBoard(rows) {
+      await FanBoard.create({
+        name: "Hoshino",
+        image: "hoshino.webp",
+        rarity: "5",
+        fanCount: rows.length,
+        topCount: rows.length ? rows[0].count : 0,
+        top: rows[0] || null,
+        ranks: rows,
+      });
+    }
+
+    it("shows only the players who use the bot in this server", async () => {
+      const here = await makeUser({ level: 5 });
+      const elsewhere = await makeUser({ level: 9 });
+      await linkUser(here, oldEnough(), [GUILD]);
+      await linkUser(elsewhere, snowflakeFor(daysAgo(500)), [OTHER_GUILD]);
+
+      await seedBoard([
+        { userId: elsewhere._id, username: elsewhere.username, count: 40 },
+        { userId: here._id, username: here.username, count: 6 },
+      ]);
+
+      const res = await bot(request(app).get(`/discord/topfan/Hoshino?guild=${GUILD}`));
+      expect(res.status).toBe(200);
+      expect(res.body.ranks.map((row) => row.username)).toEqual([here.username]);
+      // the worldwide leader still shows, because the gap is the reason to keep playing
+      expect(res.body.global).toBe(40);
+    });
+
+    it("finds a character whatever the caller capitalised", async () => {
+      await seedBoard([]);
+      const res = await bot(request(app).get(`/discord/topfan/hOsHiNo?guild=${GUILD}`));
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe("Hoshino");
+    });
+
+    it("404s on a character that has no board", async () => {
+      const res = await bot(request(app).get(`/discord/topfan/Nobody?guild=${GUILD}`));
+      expect(res.status).toBe(404);
+    });
+
+    it("ranks this server's players by level, and leaves other servers out", async () => {
+      const top = await makeUser({ level: 30 });
+      const low = await makeUser({ level: 2 });
+      const elsewhere = await makeUser({ level: 99 });
+      await linkUser(top, oldEnough(), [GUILD]);
+      await linkUser(low, snowflakeFor(daysAgo(500)), [GUILD]);
+      await linkUser(elsewhere, snowflakeFor(daysAgo(600)), [OTHER_GUILD]);
+
+      const res = await bot(request(app).get(`/discord/leaderboard?guild=${GUILD}`));
+      expect(res.status).toBe(200);
+      expect(res.body.players.map((row) => row.username)).toEqual([top.username, low.username]);
+    });
+
+    it("needs a guild", async () => {
+      expect((await bot(request(app).get("/discord/leaderboard"))).status).toBe(400);
+      expect((await bot(request(app).get("/discord/topfan/Hoshino"))).status).toBe(400);
+    });
+  });
+
+  describe("being seen in a server", () => {
+    it("records the server once, however many commands are run", async () => {
+      const user = await makeUser();
+      const discordId = oldEnough();
+      await linkUser(user, discordId);
+
+      for (let i = 0; i < 3; i += 1) {
+        await bot(request(app).post("/discord/seen")).send({ discordId, guildId: GUILD });
+      }
+      const stored = await User.findById(user._id).select("discordGuilds").lean();
+      expect(stored.discordGuilds).toEqual([GUILD]);
+    });
+
+    it("caps the array, so it cannot grow without bound", async () => {
+      const user = await makeUser();
+      const discordId = oldEnough();
+      await linkUser(user, discordId);
+
+      for (let i = 0; i < 30; i += 1) {
+        await bot(request(app).post("/discord/seen")).send({ discordId, guildId: `guild-${i}` });
+      }
+      const stored = await User.findById(user._id).select("discordGuilds").lean();
+      expect(stored.discordGuilds).toHaveLength(25);
+      // the cap keeps the most recent, so a player who moved on still shows where they play
+      expect(stored.discordGuilds).toContain("guild-29");
+      expect(stored.discordGuilds).not.toContain("guild-0");
+    });
+  });
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -17,6 +17,7 @@ const caseRoutes = require("../../routes/caseRoutes");
 const itemRoutes = require("../../routes/itemRoutes");
 const fandomRoutes = require("../../routes/fandomRoutes");
 const predictionRoutes = require("../../routes/predictionRoutes");
+const discordRoutes = require("../../routes/discordRoutes");
 
 // no-op socket.io stand-in
 const io = { emit: () => {}, to: () => ({ emit: () => {} }) };
@@ -41,6 +42,7 @@ function makeApp() {
   app.use("/items", itemRoutes);
   app.use("/fandom", fandomRoutes);
   app.use("/predictions", predictionRoutes(io));
+  app.use("/discord", discordRoutes);
   return app;
 }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -94,6 +94,7 @@ const giftRoutes = require("./routes/giftRoutes");
 const emailRoutes = require("./routes/emailRoutes");
 const fandomRoutes = require("./routes/fandomRoutes");
 const predictionRoutes = require("./routes/predictionRoutes")(io);
+const discordRoutes = require("./routes/discordRoutes");
 
 // Connect to MongoDB
 mongoose
@@ -167,6 +168,7 @@ app.use("/rewards", rewardRoutes);
 app.use("/gift", giftRoutes);
 app.use("/fandom", fandomRoutes);
 app.use("/predictions", predictionRoutes);
+app.use("/discord", discordRoutes);
 
 // settle whatever the last shutdown interrupted before dealing anyone in again: a live
 // crash or coin flip round holds real stakes, and until this runs they are unaccounted.

--- a/backend/models/DiscordLink.js
+++ b/backend/models/DiscordLink.js
@@ -1,0 +1,18 @@
+const mongoose = require("mongoose");
+
+// a pending link between a discord account and whichever site account claims the code.
+// short-lived by design: mongo expires the row, so nothing here needs sweeping.
+const DiscordLinkSchema = new mongoose.Schema({
+  code: { type: String, required: true, unique: true, index: true },
+  discordId: { type: String, required: true },
+  discordName: String,
+  createdAt: { type: Date, default: Date.now },
+  expiresAt: { type: Date, required: true },
+});
+
+// mongo drops the row the moment it expires, so a stale code can never be redeemed
+DiscordLinkSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+// one pending code per discord account, so spamming /link cannot pile up rows
+DiscordLinkSchema.index({ discordId: 1 }, { unique: true });
+
+module.exports = mongoose.model("DiscordLink", DiscordLinkSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -192,6 +192,15 @@ const UserSchema = new mongoose.Schema({
   emailSuppressedReason: String,
   emailSuppressedAt: Date,
 
+  // the linked discord account. set only by the bot's link flow, which needs a logged-in
+  // session on the site, so a discord id can never claim an account on its own.
+  discordId: String,
+  discordName: String,
+  discordLinkedAt: Date,
+  // the servers this player has actually used the bot in, which is what a per-server board
+  // counts. it holds who plays, not who is a member, so no privileged intent is needed.
+  discordGuilds: [String],
+
   // the daily gift. one spin every 24h; the streak tilts the odds toward the rarer
   // slots and resets the moment a calendar day is missed.
   giftNextAt: Date,
@@ -218,5 +227,7 @@ UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });
 UserSchema.index({ referredBy: 1 }, { sparse: true });
 UserSchema.index({ weeklyWinnings: -1 }); // leaderboard, ranking window, weekly cron
 UserSchema.index({ "fixedItem.name": 1 }, { sparse: true }); // fan board recount on pin
+UserSchema.index({ discordId: 1 }, { unique: true, sparse: true }); // bot lookups, one account per discord user
+UserSchema.index({ discordGuilds: 1 }, { sparse: true }); // per-server boards
 
 module.exports = User = mongoose.model("User", UserSchema);

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -1,0 +1,309 @@
+const express = require("express");
+const crypto = require("crypto");
+const router = express.Router();
+
+const User = require("../models/User");
+const DiscordLink = require("../models/DiscordLink");
+const FanBoard = require("../models/FanBoard");
+const { isAuthenticated } = require("../middleware/authMiddleware");
+const { visible } = require("../utils/visibility");
+const badges = require("../utils/badges");
+
+// how long a link code stays redeemable. long enough to switch to a browser and log in,
+// short enough that a code read off someone else's screen is worthless by the time it lands.
+const LINK_TTL_MS = 15 * 60 * 1000;
+// a discord account younger than this cannot link. the snowflake carries its creation
+// time, so throwaway alts farming the bonus are turned away without a lookup.
+const MIN_ACCOUNT_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const DISCORD_EPOCH = 1420070400000;
+// how many rows a server board hands back, which is also what caps every query below
+const BOARD_ROWS = 15;
+// a player is only ever counted in this many servers, so the array cannot grow unbounded
+const MAX_GUILDS = 25;
+
+// the only fields the bot is ever given. the inventory is never one of them: it reaches
+// 21k entries, and everything these cards show is already summarised on the document.
+const CARD_FIELDS = {
+  username: 1,
+  level: 1,
+  xp: 1,
+  profilePicture: 1,
+  fixedItem: 1,
+  fanRank: 1,
+  collectionRank: 1,
+  badges: 1,
+  selectedBadge: 1,
+  discordId: 1,
+  discordName: 1,
+};
+
+// no ambiguous glyphs: this gets read off a phone screen and typed back
+const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const makeCode = () =>
+  Array.from(crypto.randomBytes(8), (byte) => ALPHABET[byte % ALPHABET.length]).join("");
+
+const snowflakeDate = (id) => {
+  if (!/^\d{5,25}$/.test(String(id || ""))) return null;
+  return new Date(Number(BigInt(id) >> 22n) + DISCORD_EPOCH);
+};
+
+// the bot is the only caller. the site api key ships inside the frontend bundle, so it
+// cannot be what guards a route that mints link codes for an arbitrary discord id.
+const botOnly = (req, res, next) => {
+  const expected = process.env.DISCORD_BOT_SECRET;
+  if (!expected) return res.status(503).json({ message: "Discord bot is not configured" });
+  const given = req.headers["x-bot-secret"];
+  if (typeof given !== "string" || given.length !== expected.length) {
+    return res.status(403).json({ message: "Forbidden" });
+  }
+  if (!crypto.timingSafeEqual(Buffer.from(given), Buffer.from(expected))) {
+    return res.status(403).json({ message: "Forbidden" });
+  }
+  next();
+};
+
+const publicCard = (user) => ({
+  userId: user._id,
+  username: user.username,
+  level: user.level || 0,
+  xp: user.xp || 0,
+  profilePicture: user.profilePicture || null,
+  discordName: user.discordName || null,
+  pinned:
+    user.fixedItem && user.fixedItem.name
+      ? {
+          name: user.fixedItem.name,
+          variant: user.fixedItem.variant || null,
+          image: user.fixedItem.image || null,
+          rarity: user.fixedItem.rarity || null,
+        }
+      : null,
+  fanRank:
+    user.fanRank && user.fanRank.name
+      ? {
+          name: user.fanRank.name,
+          count: user.fanRank.count || 0,
+          rank: user.fanRank.rank || null,
+          fans: user.fanRank.fans || 0,
+          second: user.fanRank.second || 0,
+        }
+      : null,
+  collection: user.collectionRank
+    ? {
+        distinct: user.collectionRank.distinct || 0,
+        total: user.collectionRank.total || 0,
+        rank: user.collectionRank.rank || null,
+      }
+    : null,
+  badge: badges.wornBadge(user) || null,
+});
+
+// a linked player running a command here is what puts them on this server's boards. it is
+// who plays rather than who is a member, so the bot never needs the guild member list.
+router.post("/seen", botOnly, async (req, res) => {
+  try {
+    const discordId = String((req.body && req.body.discordId) || "");
+    const guildId = String((req.body && req.body.guildId) || "");
+    if (!discordId || !guildId) return res.status(400).json({ message: "Missing discordId or guildId" });
+
+    await User.updateOne(
+      { discordId, discordGuilds: { $ne: guildId } },
+      // push rather than addToSet because only push can cap the array, and the $ne in the
+      // filter is what makes the two equivalent here
+      { $push: { discordGuilds: { $each: [guildId], $slice: -MAX_GUILDS } } }
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("discord seen:", err.message);
+    res.status(500).json({ message: "Could not record the server" });
+  }
+});
+
+router.post("/link/start", botOnly, async (req, res) => {
+  try {
+    const discordId = String((req.body && req.body.discordId) || "");
+    const discordName = String((req.body && req.body.discordName) || "").slice(0, 64);
+    if (!/^\d{5,25}$/.test(discordId)) return res.status(400).json({ message: "Missing discordId" });
+
+    const born = snowflakeDate(discordId);
+    if (!born || Date.now() - born.getTime() < MIN_ACCOUNT_AGE_MS) {
+      return res.status(403).json({ message: "This Discord account is too new to link" });
+    }
+
+    const existing = await User.findOne({ discordId }, { username: 1 }).lean();
+    if (existing) return res.json({ alreadyLinked: true, username: existing.username });
+
+    const code = makeCode();
+    const expiresAt = new Date(Date.now() + LINK_TTL_MS);
+    await DiscordLink.findOneAndUpdate(
+      { discordId },
+      { $set: { code, discordName, expiresAt, createdAt: new Date() } },
+      { upsert: true }
+    );
+
+    const site = (process.env.SITE_URL || "https://kanicasino.com").replace(/\/$/, "");
+    res.json({ code, url: site + "/link/discord?code=" + code, expiresAt });
+  } catch (err) {
+    console.error("discord link start:", err.message);
+    res.status(500).json({ message: "Could not start the link" });
+  }
+});
+
+// redeemed from the site, by whoever is logged in there. that session is the proof of
+// which account is being linked, which is why the bot cannot do this half on its own.
+router.post("/link/complete", isAuthenticated, async (req, res) => {
+  try {
+    const code = String((req.body && req.body.code) || "").trim().toUpperCase();
+    if (!code) return res.status(400).json({ message: "Missing code" });
+
+    const pending = await DiscordLink.findOne({ code }).lean();
+    if (!pending || pending.expiresAt <= new Date()) {
+      return res.status(404).json({ message: "That code has expired. Run /link again in Discord." });
+    }
+
+    const taken = await User.findOne({ discordId: pending.discordId }, { username: 1 }).lean();
+    if (taken) {
+      await DiscordLink.deleteOne({ code });
+      return res.status(409).json({ message: "That Discord account is already linked to " + taken.username + "." });
+    }
+
+    const mine = await User.findById(req.user._id, { discordId: 1, username: 1 }).lean();
+    if (!mine) return res.status(404).json({ message: "User not found" });
+    if (mine.discordId) {
+      return res.status(409).json({ message: "This account is already linked to a Discord user." });
+    }
+
+    const done = await User.updateOne(
+      { _id: req.user._id, discordId: { $exists: false } },
+      { $set: { discordId: pending.discordId, discordName: pending.discordName, discordLinkedAt: new Date() } }
+    );
+    if (!done.modifiedCount) return res.status(409).json({ message: "This account is already linked." });
+    await DiscordLink.deleteOne({ code });
+
+    res.json({ username: mine.username, discordName: pending.discordName || null });
+  } catch (err) {
+    // the unique index is the real guard against two accounts racing for one discord id
+    if (err && err.code === 11000) {
+      return res.status(409).json({ message: "That Discord account is already linked." });
+    }
+    console.error("discord link complete:", err.message);
+    res.status(500).json({ message: "Could not finish the link" });
+  }
+});
+
+router.delete("/link", isAuthenticated, async (req, res) => {
+  try {
+    await User.updateOne(
+      { _id: req.user._id },
+      { $unset: { discordId: "", discordName: "", discordLinkedAt: "", discordGuilds: "" } }
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("discord unlink:", err.message);
+    res.status(500).json({ message: "Could not unlink" });
+  }
+});
+
+// whether the logged-in player has a discord account attached, for the profile page
+router.get("/link/me", isAuthenticated, async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id, { discordName: 1, discordId: 1, discordLinkedAt: 1 }).lean();
+    if (!user) return res.status(404).json({ message: "User not found" });
+    res.json({
+      linked: !!user.discordId,
+      discordName: user.discordName || null,
+      linkedAt: user.discordLinkedAt || null,
+    });
+  } catch (err) {
+    console.error("discord link me:", err.message);
+    res.status(500).json({ message: "Could not read your link" });
+  }
+});
+
+router.get("/showcase/:discordId", botOnly, async (req, res) => {
+  try {
+    const user = await User.findOne(visible({ discordId: String(req.params.discordId) }), CARD_FIELDS).lean();
+    if (!user) return res.status(404).json({ message: "Not linked" });
+    res.json(publicCard(user));
+  } catch (err) {
+    console.error("discord showcase:", err.message);
+    res.status(500).json({ message: "Could not load that player" });
+  }
+});
+
+// one board, narrowed to the players who use the bot in this server. the board document
+// already carries its top rows, so this reads one small document and one id lookup.
+router.get("/topfan/:name", botOnly, async (req, res) => {
+  try {
+    const guildId = String(req.query.guild || "");
+    if (!guildId) return res.status(400).json({ message: "Missing guild" });
+
+    const escaped = String(req.params.name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const board = await FanBoard.findOne(
+      { name: new RegExp("^" + escaped + "$", "i") },
+      { name: 1, image: 1, rarity: 1, ranks: 1, fanCount: 1, topCount: 1 }
+    ).lean();
+    if (!board) return res.status(404).json({ message: "No such character" });
+
+    const rows = board.ranks || [];
+    const card = {
+      name: board.name,
+      image: board.image,
+      rarity: board.rarity,
+      global: board.topCount || 0,
+      fanCount: board.fanCount || 0,
+    };
+    if (!rows.length) return res.json({ ...card, ranks: [] });
+
+    // capped by RANKS_KEPT on the board, so this $in stays bounded whatever the playerbase does
+    const here = await User.find(
+      visible({ _id: { $in: rows.map((row) => row.userId) }, discordGuilds: guildId }),
+      { _id: 1, discordName: 1 }
+    ).lean();
+    const mine = new Map(here.map((row) => [String(row._id), row.discordName || null]));
+
+    res.json({
+      ...card,
+      ranks: rows
+        .filter((row) => mine.has(String(row.userId)))
+        .slice(0, BOARD_ROWS)
+        .map((row) => ({
+          userId: row.userId,
+          username: row.username,
+          level: row.level || 0,
+          count: row.count || 0,
+          discordName: mine.get(String(row.userId)),
+        })),
+    });
+  } catch (err) {
+    console.error("discord topfan:", err.message);
+    res.status(500).json({ message: "Could not load that board" });
+  }
+});
+
+// who in this server is worth beating. sorted on fields the fandom sweep already
+// materialised, so nothing here counts an inventory.
+router.get("/leaderboard", botOnly, async (req, res) => {
+  try {
+    const guildId = String(req.query.guild || "");
+    if (!guildId) return res.status(400).json({ message: "Missing guild" });
+    const sort = String(req.query.sort || "level");
+
+    const order =
+      sort === "collection"
+        ? { "collectionRank.distinct": -1, "collectionRank.total": -1 }
+        : { level: -1, xp: -1 };
+
+    const rows = await User.find(visible({ discordGuilds: guildId }), CARD_FIELDS)
+      .sort(order)
+      .limit(BOARD_ROWS)
+      .lean();
+
+    res.json({ sort, players: rows.map(publicCard) });
+  } catch (err) {
+    console.error("discord leaderboard:", err.message);
+    res.status(500).json({ message: "Could not load the leaderboard" });
+  }
+});
+
+module.exports = router;

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,15 @@
+# from the discord developer portal, Bot tab
+DISCORD_BOT_TOKEN=
+# the application id, same tab as the client id
+DISCORD_CLIENT_ID=
+
+# shared with backend/.env. the bot is the only thing that may call /discord/*,
+# and the site api key cannot be that guard because it ships in the frontend bundle.
+DISCORD_BOT_SECRET=
+
+# the site api key, because the whole api sits behind it
+API_KEY=
+
+# the backend, on this box
+API_BASE_URL=http://127.0.0.1:5001
+SITE_URL=https://kanicasino.com

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,59 @@
+# KaniCasino Discord bot
+
+Read-only. It shows what a player has and where they stand; opening cases, spending and
+everything else stays on the site. That split is deliberate: the bot is how people find
+KaniCasino, not a second place to play it.
+
+## Commands
+
+| | |
+| --- | --- |
+| `/link` | attach a Discord user to a site account, once |
+| `/showcase [player]` | pinned character, level, fan rank, collection |
+| `/topfan <character>` | who in this server collects that character hardest |
+| `/leaderboard [sort]` | the players in this server, by level or collection |
+| `/help` | what this is |
+
+## Setup
+
+```
+cd bot
+npm install
+cp .env.example .env      # fill it in
+node src/register.js <guildId>   # a test server, instant
+npm start
+```
+
+`node src/register.js` with no argument registers globally, which can take up to an hour to
+propagate. Only rerun it when a command's name, description or options change.
+
+`DISCORD_BOT_SECRET` must match the one in `backend/.env`. Everything under `/discord/*`
+checks it, because the site API key ships inside the frontend bundle and guards nothing.
+
+## How linking works
+
+`/link` asks the backend for a short code and answers privately with a URL. Opening that
+URL while logged in on the site attaches the Discord account to whichever account holds
+that session. The bot never sees a password and cannot link an account on its own: the
+website session is the proof of who is being linked.
+
+Codes last 15 minutes and Mongo expires the row itself. A Discord account created in the
+last 30 days is refused, which costs nothing to check because the snowflake carries its
+own creation time.
+
+## Server boards
+
+A player joins a server's board by running a command there, not by being a member. So the
+bot never needs the member list, never asks for a privileged intent, and a board shows the
+people who actually play rather than everyone in the channel.
+
+## What it costs
+
+Every endpoint the bot calls projects the inventory away and is bounded:
+
+- `/showcase` is one document, read by an indexed `discordId`.
+- `/topfan` is one fan board document plus an `$in` capped at the 50 rows that board keeps.
+- `/leaderboard` is an indexed lookup on `discordGuilds`, limited to 15.
+
+Nothing here counts an inventory, and nothing runs on a timer. Commands are also rate
+limited per user in the bot's own memory, so spam is a map lookup rather than a query.

--- a/bot/package-lock.json
+++ b/bot/package-lock.json
@@ -1,0 +1,327 @@
+{
+  "name": "kanicasino-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kanicasino-bot",
+      "version": "1.0.0",
+      "dependencies": {
+        "discord.js": "^14.16.3",
+        "dotenv": "^16.4.5"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.50",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.53",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+      "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.1.tgz",
+      "integrity": "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kanicasino-bot",
+  "version": "1.0.0",
+  "description": "Discord bot for KaniCasino",
+  "main": "src/index.js",
+  "private": true,
+  "scripts": {
+    "start": "node src/index.js",
+    "register": "node src/register.js"
+  },
+  "dependencies": {
+    "discord.js": "^14.16.3",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/bot/src/api.js
+++ b/bot/src/api.js
@@ -1,0 +1,57 @@
+const BASE = (process.env.API_BASE_URL || "http://127.0.0.1:5001").replace(/\/$/, "");
+
+// every call carries both keys: the site key, because the whole api sits behind it, and
+// the bot secret, because the site key ships in the frontend bundle and guards nothing.
+const headers = () => ({
+  "Content-Type": "application/json",
+  "x-api-key": process.env.API_KEY || "",
+  "x-bot-secret": process.env.DISCORD_BOT_SECRET || "",
+});
+
+// the backend is on the same box, so a slow call means it is in trouble rather than far away
+const TIMEOUT_MS = 8000;
+
+class ApiError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function call(method, path, body) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(BASE + path, {
+      method,
+      headers: headers(),
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await res.text();
+    const data = text ? JSON.parse(text) : {};
+    if (!res.ok) throw new ApiError(res.status, data.message || "Request failed");
+    return data;
+  } catch (err) {
+    if (err.name === "AbortError") throw new ApiError(504, "The site did not answer in time");
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const get = (path) => call("GET", path);
+const post = (path, body) => call("POST", path, body);
+
+module.exports = {
+  ApiError,
+  linkStart: (discordId, discordName) => post("/discord/link/start", { discordId, discordName }),
+  showcase: (discordId) => get(`/discord/showcase/${encodeURIComponent(discordId)}`),
+  topFan: (name, guildId) =>
+    get(`/discord/topfan/${encodeURIComponent(name)}?guild=${encodeURIComponent(guildId)}`),
+  leaderboard: (guildId, sort) =>
+    get(`/discord/leaderboard?guild=${encodeURIComponent(guildId)}&sort=${encodeURIComponent(sort)}`),
+  // fired and forgotten: being on a server board is not worth failing a command over
+  seen: (discordId, guildId) =>
+    post("/discord/seen", { discordId, guildId }).catch(() => {}),
+};

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -1,0 +1,122 @@
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
+const api = require("./api");
+const { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE } = require("./embeds");
+
+// rejected in the bot's own memory, before any http call. spamming a command costs a map
+// lookup here rather than a query on a link that carries about 100 KB/s.
+const COOLDOWN_MS = 5000;
+const lastUsed = new Map();
+
+function onCooldown(userId, name) {
+  const key = `${userId}:${name}`;
+  const now = Date.now();
+  const previous = lastUsed.get(key) || 0;
+  if (now - previous < COOLDOWN_MS) return Math.ceil((COOLDOWN_MS - (now - previous)) / 1000);
+  lastUsed.set(key, now);
+  return 0;
+}
+
+// the map would otherwise hold a row per user per command forever
+setInterval(() => {
+  const cutoff = Date.now() - COOLDOWN_MS * 4;
+  for (const [key, at] of lastUsed) if (at < cutoff) lastUsed.delete(key);
+}, 60000).unref();
+
+const NOT_LINKED = `No KaniCasino account is linked to that Discord user yet. Run \`/link\` to attach one.`;
+
+const commands = [
+  {
+    data: new SlashCommandBuilder()
+      .setName("link")
+      .setDescription("Attach your KaniCasino account to this Discord user"),
+    async run(interaction) {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      const link = await api.linkStart(interaction.user.id, interaction.user.username);
+      if (link.alreadyLinked) {
+        await interaction.editReply({
+          embeds: [noticeEmbed(`You are already linked to **${link.username}**.`)],
+        });
+        return;
+      }
+      await interaction.editReply({ embeds: [linkEmbed(link)] });
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName("showcase")
+      .setDescription("Show a player's pinned character and standing")
+      .addUserOption((option) =>
+        option.setName("player").setDescription("Whose card to show. Defaults to you.")
+      ),
+    async run(interaction) {
+      await interaction.deferReply();
+      const target = interaction.options.getUser("player") || interaction.user;
+      const card = await api.showcase(target.id);
+      await interaction.editReply({ embeds: [showcaseEmbed(card)] });
+    },
+    notFound: (interaction) => {
+      const target = interaction.options.getUser("player");
+      return target ? `**${target.username}** has not linked a KaniCasino account.` : NOT_LINKED;
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName("topfan")
+      .setDescription("Who in this server collects a character hardest")
+      .addStringOption((option) =>
+        option.setName("character").setDescription("The character to rank").setRequired(true)
+      ),
+    async run(interaction) {
+      await interaction.deferReply();
+      const name = interaction.options.getString("character");
+      const board = await api.topFan(name, interaction.guildId);
+      await interaction.editReply({ embeds: [topFanEmbed(board, interaction.guild.name)] });
+    },
+    notFound: (interaction) =>
+      `No character called **${interaction.options.getString("character")}**. Browse them at ${SITE}/fandom`,
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName("leaderboard")
+      .setDescription("The KaniCasino players in this server")
+      .addStringOption((option) =>
+        option
+          .setName("sort")
+          .setDescription("What to rank by")
+          .addChoices(
+            { name: "Level", value: "level" },
+            { name: "Collection", value: "collection" }
+          )
+      ),
+    async run(interaction) {
+      await interaction.deferReply();
+      const sort = interaction.options.getString("sort") || "level";
+      const payload = await api.leaderboard(interaction.guildId, sort);
+      await interaction.editReply({ embeds: [leaderboardEmbed(payload, interaction.guild.name)] });
+    },
+  },
+  {
+    data: new SlashCommandBuilder().setName("help").setDescription("What this bot is"),
+    async run(interaction) {
+      await interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [
+          noticeEmbed(
+            [
+              `**KaniCasino** is a fake-coin casino where you open cases, collect characters and fight for their fan boards.`,
+              "",
+              "`/link` attach your account, once",
+              "`/showcase` your pinned character and standing",
+              "`/topfan` who in this server collects a character hardest",
+              "`/leaderboard` the players in this server",
+              "",
+              `Everything else, and every case, is at ${SITE}`,
+            ].join("\n")
+          ),
+        ],
+      });
+    },
+  },
+];
+
+module.exports = { commands, onCooldown };

--- a/bot/src/embeds.js
+++ b/bot/src/embeds.js
@@ -1,0 +1,138 @@
+const { EmbedBuilder } = require("discord.js");
+
+const SITE = (process.env.SITE_URL || "https://kanicasino.com").replace(/\/$/, "");
+
+// the same five the site paints items with, so a card in discord reads as the same object
+const RARITY = {
+  "1": 0x4b69ff,
+  "2": 0x8847ff,
+  "3": 0xd32ce6,
+  "4": 0xeb4b4b,
+  "5": 0xffff6e,
+};
+const NEUTRAL = 0xf0287a;
+
+const colorOf = (rarity) => RARITY[String(rarity)] || NEUTRAL;
+const num = (value) => Number(value || 0).toLocaleString("en-US");
+const medal = (index) => ["1.", "2.", "3."][index] || `${index + 1}.`;
+
+const profileUrl = (userId) => `${SITE}/profile/${userId}`;
+const boardUrl = (name) => `${SITE}/fandom/${encodeURIComponent(name)}`;
+
+function showcaseEmbed(card) {
+  const embed = new EmbedBuilder()
+    .setColor(colorOf(card.pinned && card.pinned.rarity))
+    .setTitle(card.username)
+    .setURL(profileUrl(card.userId))
+    .setFooter({ text: "kanicasino.com" });
+
+  if (card.profilePicture) embed.setThumbnail(card.profilePicture);
+
+  const lines = [`Level ${num(card.level)}`];
+  if (card.badge && card.badge.label) lines.push(card.badge.label);
+  embed.setDescription(lines.join("  ·  "));
+
+  if (card.pinned) {
+    const worn = card.pinned.variant ? `${card.pinned.name} (${card.pinned.variant})` : card.pinned.name;
+    embed.addFields({ name: "Pinned", value: `[${worn}](${boardUrl(card.pinned.name)})`, inline: true });
+    if (card.pinned.image) embed.setImage(card.pinned.image);
+  }
+
+  if (card.fanRank) {
+    const standing =
+      card.fanRank.rank === 1
+        ? `**#1** of ${num(card.fanRank.fans)} fans`
+        : `#${card.fanRank.rank} of ${num(card.fanRank.fans)} fans`;
+    embed.addFields({
+      name: "Fan rank",
+      value: `${standing}\n${num(card.fanRank.count)} copies`,
+      inline: true,
+    });
+  }
+
+  if (card.collection && card.collection.distinct) {
+    embed.addFields({
+      name: "Collection",
+      value: `${num(card.collection.distinct)} characters\n${num(card.collection.total)} items`,
+      inline: true,
+    });
+  }
+
+  return embed;
+}
+
+function topFanEmbed(board, guildName) {
+  const embed = new EmbedBuilder()
+    .setColor(colorOf(board.rarity))
+    .setTitle(`Top ${board.name} fan in ${guildName}`)
+    .setURL(boardUrl(board.name))
+    .setFooter({ text: "kanicasino.com" });
+
+  if (board.image) embed.setThumbnail(board.image);
+
+  if (!board.ranks.length) {
+    embed.setDescription(
+      `Nobody here has pinned **${board.name}** yet. The board is open.\n[Take it](${boardUrl(board.name)})`
+    );
+    return embed;
+  }
+
+  embed.setDescription(
+    board.ranks
+      .map((row, index) => `${medal(index)} **${row.username}** — ${num(row.count)}`)
+      .join("\n")
+  );
+  // the server's leader is rarely the site's, and the gap is the reason to keep opening
+  embed.addFields({
+    name: "Worldwide leader",
+    value: `${num(board.global)} copies, across ${num(board.fanCount)} fans`,
+  });
+  return embed;
+}
+
+function leaderboardEmbed(payload, guildName) {
+  const byCollection = payload.sort === "collection";
+  const embed = new EmbedBuilder()
+    .setColor(NEUTRAL)
+    .setTitle(byCollection ? `Biggest collections in ${guildName}` : `Highest levels in ${guildName}`)
+    .setURL(SITE)
+    .setFooter({ text: "kanicasino.com" });
+
+  if (!payload.players.length) {
+    embed.setDescription("Nobody here has linked an account yet. Run `/link` to be the first.");
+    return embed;
+  }
+
+  embed.setDescription(
+    payload.players
+      .map((card, index) => {
+        const stat = byCollection
+          ? `${num(card.collection && card.collection.distinct)} characters`
+          : `level ${num(card.level)}`;
+        const pin = card.pinned ? ` · ${card.pinned.name}` : "";
+        return `${medal(index)} **${card.username}** — ${stat}${pin}`;
+      })
+      .join("\n")
+  );
+  return embed;
+}
+
+function linkEmbed(link) {
+  return new EmbedBuilder()
+    .setColor(NEUTRAL)
+    .setTitle("Link your KaniCasino account")
+    .setDescription(
+      [
+        "Open this link while logged in on the site, and your Discord account is attached:",
+        `**[Link my account](${link.url})**`,
+        "",
+        "Only you can see this message, and the link works for 15 minutes.",
+        "No account yet? Sign up on that page first, then the same link finishes the job.",
+      ].join("\n")
+    )
+    .setFooter({ text: "kanicasino.com" });
+}
+
+const noticeEmbed = (text) => new EmbedBuilder().setColor(NEUTRAL).setDescription(text);
+
+module.exports = { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE };

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -1,0 +1,62 @@
+require("dotenv").config();
+
+const { Client, Events, GatewayIntentBits, MessageFlags } = require("discord.js");
+const api = require("./api");
+const { noticeEmbed } = require("./embeds");
+const { commands, onCooldown } = require("./commands");
+
+const REQUIRED = ["DISCORD_BOT_TOKEN", "DISCORD_BOT_SECRET", "API_KEY"];
+const missing = REQUIRED.filter((key) => !process.env[key]);
+if (missing.length) {
+  console.error("bot: missing env", missing.join(", "));
+  process.exit(1);
+}
+
+// Guilds is the only intent this needs. slash commands arrive as interactions, so nothing
+// here reads messages or member lists, and no privileged intent has to be requested.
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+const byName = new Map(commands.map((command) => [command.data.name, command]));
+
+const reply = async (interaction, text) => {
+  const payload = { embeds: [noticeEmbed(text)], flags: MessageFlags.Ephemeral };
+  if (interaction.deferred || interaction.replied) {
+    await interaction.editReply({ embeds: payload.embeds }).catch(() => {});
+  } else {
+    await interaction.reply(payload).catch(() => {});
+  }
+};
+
+client.on(Events.InteractionCreate, async (interaction) => {
+  if (!interaction.isChatInputCommand()) return;
+  const command = byName.get(interaction.commandName);
+  if (!command) return;
+
+  if (!interaction.guildId && interaction.commandName !== "link") {
+    return reply(interaction, "This one only works inside a server.");
+  }
+
+  const wait = onCooldown(interaction.user.id, interaction.commandName);
+  if (wait) return reply(interaction, `Give it ${wait}s.`);
+
+  try {
+    // before the command, not after: otherwise a player's first /leaderboard in a server
+    // is the one that does not list them. it no-ops for anyone who has not linked.
+    if (interaction.guildId) await api.seen(interaction.user.id, interaction.guildId);
+    await command.run(interaction);
+  } catch (err) {
+    if (err.status === 404 && command.notFound) return reply(interaction, command.notFound(interaction));
+    if (err.status === 403 || err.status === 409) return reply(interaction, err.message);
+    console.error(`bot ${interaction.commandName}:`, err.message);
+    reply(interaction, "The site did not answer. Try again in a moment.");
+  }
+});
+
+client.once(Events.ClientReady, (ready) => {
+  console.log(`bot: online as ${ready.user.tag} in ${ready.guilds.cache.size} servers`);
+});
+
+client.on(Events.Error, (err) => console.error("bot client:", err.message));
+process.on("unhandledRejection", (err) => console.error("bot unhandled:", err && err.message));
+
+client.login(process.env.DISCORD_BOT_TOKEN);

--- a/bot/src/register.js
+++ b/bot/src/register.js
@@ -1,0 +1,29 @@
+require("dotenv").config();
+
+const { REST, Routes } = require("discord.js");
+const { commands } = require("./commands");
+
+// run after changing a command's name, description or options: discord caches the
+// definitions. an argument scopes it to one guild, which lands instantly instead of hourly.
+const guildId = process.argv[2];
+
+(async () => {
+  const token = process.env.DISCORD_BOT_TOKEN;
+  const clientId = process.env.DISCORD_CLIENT_ID;
+  if (!token || !clientId) {
+    console.error("register: DISCORD_BOT_TOKEN and DISCORD_CLIENT_ID are both required");
+    process.exit(1);
+  }
+
+  const rest = new REST().setToken(token);
+  const body = commands.map((command) => command.data.toJSON());
+  const route = guildId
+    ? Routes.applicationGuildCommands(clientId, guildId)
+    : Routes.applicationCommands(clientId);
+
+  const done = await rest.put(route, { body });
+  console.log(`register: ${done.length} commands ${guildId ? `in ${guildId}` : "globally"}`);
+})().catch((err) => {
+  console.error("register:", err.message);
+  process.exit(1);
+});

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -25,6 +25,7 @@ import ReferralRedirect from "./pages/Affiliates/ReferralRedirect";
 import Backoffice from "./pages/Backoffice/Backoffice";
 import Predictions from "./pages/Predictions/Predictions";
 import PredictionMarket from "./pages/Predictions/Market";
+import LinkDiscord from "./pages/Discord/LinkDiscord";
 
 const defaultRoutes = (
   <>
@@ -54,6 +55,7 @@ const defaultRoutes = (
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
     <Route path="/unsubscribe" element={<Unsubscribe />} />
     <Route path="/gift" element={<Gift />} />
+    <Route path="/link/discord" element={<LinkDiscord />} />
   </>
 );
 

--- a/src/components/OnboardingModal.test.tsx
+++ b/src/components/OnboardingModal.test.tsx
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import OnboardingModal from "./OnboardingModal";
+
+// the tour reads the route to know when to stay out of the way
+const at = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <OnboardingModal />
+    </MemoryRouter>
+  );
 
 describe("OnboardingModal", () => {
   beforeEach(() => {
@@ -8,28 +17,40 @@ describe("OnboardingModal", () => {
   });
 
   it("shows on a first visit", () => {
-    render(<OnboardingModal />);
+    at("/");
     expect(screen.getByText("Welcome to KaniCasino!")).toBeInTheDocument();
     expect(screen.getByText("Start with free coins")).toBeInTheDocument();
   });
 
   it("does not show again once seen", () => {
     localStorage.setItem("kani.onboardingSeen", "1");
-    const { container } = render(<OnboardingModal />);
+    const { container } = at("/");
     expect(container).toBeEmptyDOMElement();
   });
 
   it("dismissing it marks it as seen", () => {
-    render(<OnboardingModal />);
+    at("/");
     fireEvent.click(screen.getByText("Got it, let's play!"));
     expect(screen.queryByText("Welcome to KaniCasino!")).toBeNull();
     expect(localStorage.getItem("kani.onboardingSeen")).toBe("1");
   });
 
   it("closing with the X also marks it as seen", () => {
-    render(<OnboardingModal />);
+    at("/");
     fireEvent.click(screen.getByLabelText("close modal"));
     expect(screen.queryByText("Welcome to KaniCasino!")).toBeNull();
     expect(localStorage.getItem("kani.onboardingSeen")).toBe("1");
+  });
+
+  // it used to open on top of the login panel there and swallow every click, which left
+  // a visitor arriving from the discord bot unable to finish linking
+  it("stays out of the way of the discord link flow", () => {
+    const { container } = at("/link/discord?code=ABCD2345");
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("still shows once that visitor reaches the site", () => {
+    at("/");
+    expect(screen.getByText("Welcome to KaniCasino!")).toBeInTheDocument();
   });
 });

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 import { AiOutlineClockCircle } from "react-icons/ai";
 import Modal from "./Modal";
 import MainButton from "./MainButton";
@@ -25,6 +26,7 @@ const steps = () => [
 ];
 
 const OnboardingModal = () => {
+  const { pathname } = useLocation();
   // storage can be blocked; then the tour shows every visit, which is harmless
   const [open, setOpen] = useState<boolean>(() => {
     try {
@@ -43,7 +45,9 @@ const OnboardingModal = () => {
     setOpen(false);
   };
 
-  if (!open) return null;
+  // a visitor arriving from the discord bot is mid-task, and this would cover the panel
+  // they came to use. the tour waits until they reach the site proper.
+  if (!open || pathname.startsWith("/link/")) return null;
 
   return (
     <Modal open={open} setOpen={dismiss} width="520px">

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -300,6 +300,16 @@
     "rollDice": "Würfeln",
     "winChance": "Gewinnchance"
   },
+  "discord": {
+    "failed": "Dieser Link hat nicht funktioniert",
+    "keepPlaying": "Öffne eine Kiste, wenn du schon hier bist",
+    "linked": "Discord verknüpft",
+    "linkedBody": "{{name}} ist jetzt mit deinem Konto verknüpft. Geh zurück zu Discord und probier /showcase.",
+    "linking": "Dein Konto wird verknüpft",
+    "needLogin": "Melde dich an, um die Verknüpfung abzuschließen",
+    "needLoginBody": "Melde dich an oder erstelle ein Konto, dann wird dein Discord-Benutzer sofort verknüpft.",
+    "tryAgain": "Führe /link in Discord erneut aus, um einen neuen Code zu bekommen."
+  },
   "fair": {
     "autoVerifySupportedFor": "Automatische Prüfung möglich für Kisten-, Plinko-, Blackjack-, Würfel-, Minen- und Hilo-Rolls",
     "busted": "geplatzt",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -300,6 +300,16 @@
     "rollDice": "Roll Dice",
     "winChance": "Win Chance"
   },
+  "discord": {
+    "failed": "That link did not work",
+    "keepPlaying": "Open a case while you are here",
+    "linked": "Discord linked",
+    "linkedBody": "{{name}} is now attached to your account. Head back to Discord and try /showcase.",
+    "linking": "Linking your account",
+    "needLogin": "Log in to finish linking",
+    "needLoginBody": "Sign in or create an account, and your Discord user gets attached straight away.",
+    "tryAgain": "Run /link in Discord again for a fresh code."
+  },
   "fair": {
     "autoVerifySupportedFor": "Auto-verify supported for case, plinko, blackjack, dice, mines and hilo rolls",
     "busted": "busted",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -300,6 +300,16 @@
     "rollDice": "Tirar los dados",
     "winChance": "Probabilidad de ganar"
   },
+  "discord": {
+    "failed": "Ese enlace no funcionó",
+    "keepPlaying": "Abre una caja ya que estás aquí",
+    "linked": "Discord vinculado",
+    "linkedBody": "{{name}} ya está vinculado a tu cuenta. Vuelve a Discord y prueba /showcase.",
+    "linking": "Vinculando tu cuenta",
+    "needLogin": "Inicia sesión para terminar de vincular",
+    "needLoginBody": "Inicia sesión o crea una cuenta y tu usuario de Discord se vinculará al instante.",
+    "tryAgain": "Usa /link en Discord otra vez para conseguir un código nuevo."
+  },
   "fair": {
     "autoVerifySupportedFor": "Verificación automática disponible para tiradas de caja, plinko, blackjack, dados, minas e hilo",
     "busted": "reventó",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -300,6 +300,16 @@
     "rollDice": "Lancer les dés",
     "winChance": "Chance de gagner"
   },
+  "discord": {
+    "failed": "Ce lien n'a pas fonctionné",
+    "keepPlaying": "Ouvre une caisse tant que tu es là",
+    "linked": "Discord associé",
+    "linkedBody": "{{name}} est maintenant associé à ton compte. Retourne sur Discord et essaie /showcase.",
+    "linking": "Association de ton compte",
+    "needLogin": "Connecte-toi pour terminer l'association",
+    "needLoginBody": "Connecte-toi ou crée un compte, et ton utilisateur Discord sera associé aussitôt.",
+    "tryAgain": "Relance /link sur Discord pour obtenir un nouveau code."
+  },
   "fair": {
     "autoVerifySupportedFor": "Vérification automatique disponible pour les tirages de caisse, plinko, blackjack, dés, mines et hilo",
     "busted": "perdu",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -300,6 +300,16 @@
     "rollDice": "Lempar Dadu",
     "winChance": "Kesempatan menang"
   },
+  "discord": {
+    "failed": "Tautan itu tidak berhasil",
+    "keepPlaying": "Buka satu case selagi di sini",
+    "linked": "Discord tertaut",
+    "linkedBody": "{{name}} sekarang tertaut ke akunmu. Kembali ke Discord dan coba /showcase.",
+    "linking": "Menautkan akunmu",
+    "needLogin": "Masuk untuk menyelesaikan penautan",
+    "needLoginBody": "Masuk atau buat akun, dan pengguna Discord-mu langsung tertaut.",
+    "tryAgain": "Jalankan /link lagi di Discord untuk kode baru."
+  },
   "fair": {
     "autoVerifySupportedFor": "Verifikasi otomatis didukung untuk permainan case, plinko, blackjack, dadu, mines, dan hilo rolls.",
     "busted": "Gagal",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -300,6 +300,16 @@
     "rollDice": "Lancia i dadi",
     "winChance": "Probabilità di vincita"
   },
+  "discord": {
+    "failed": "Quel link non ha funzionato",
+    "keepPlaying": "Apri una cassa già che ci sei",
+    "linked": "Discord collegato",
+    "linkedBody": "{{name}} ora è collegato al tuo account. Torna su Discord e prova /showcase.",
+    "linking": "Collegamento del tuo account",
+    "needLogin": "Accedi per completare il collegamento",
+    "needLoginBody": "Accedi o crea un account e il tuo utente Discord verrà collegato subito.",
+    "tryAgain": "Usa di nuovo /link su Discord per un codice nuovo."
+  },
   "fair": {
     "autoVerifySupportedFor": "Verifica automatica disponibile per i roll di cassa, plinko, blackjack, dadi, mine e hilo",
     "busted": "saltato",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -300,6 +300,16 @@
     "rollDice": "ダイスを振る",
     "winChance": "勝率"
   },
+  "discord": {
+    "failed": "このリンクは使えませんでした",
+    "keepPlaying": "せっかくなのでケースを開けてみる",
+    "linked": "Discord を連携しました",
+    "linkedBody": "{{name}} がアカウントに連携されました。Discord に戻って /showcase を試してみてください。",
+    "linking": "アカウントを連携しています",
+    "needLogin": "ログインして連携を完了してください",
+    "needLoginBody": "ログインするかアカウントを作成すると、Discord アカウントがすぐに連携されます。",
+    "tryAgain": "Discord でもう一度 /link を実行して、新しいコードを取得してください。"
+  },
   "fair": {
     "autoVerifySupportedFor": "ケース、プリンコ、ブラックジャック、ダイス、マインズ、HiLo のロールは自動検証に対応しています",
     "busted": "バースト",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -300,6 +300,16 @@
     "rollDice": "주사위 굴리기",
     "winChance": "승리 확률"
   },
+  "discord": {
+    "failed": "이 링크는 작동하지 않았습니다",
+    "keepPlaying": "온 김에 케이스 하나 열어보기",
+    "linked": "Discord 연결 완료",
+    "linkedBody": "{{name}}이(가) 계정에 연결되었습니다. Discord로 돌아가 /showcase를 사용해 보세요.",
+    "linking": "계정을 연결하는 중",
+    "needLogin": "로그인하고 연결을 마치세요",
+    "needLoginBody": "로그인하거나 계정을 만들면 Discord 계정이 바로 연결됩니다.",
+    "tryAgain": "Discord에서 /link를 다시 실행해 새 코드를 받으세요."
+  },
   "fair": {
     "autoVerifySupportedFor": "케이스, 플린코, 블랙잭, 주사위, 마인즈, HiLo 롤은 자동 검증을 지원합니다",
     "busted": "실패",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -300,6 +300,16 @@
     "rollDice": "Rolar dados",
     "winChance": "Chance de ganhar"
   },
+  "discord": {
+    "failed": "Esse link não funcionou",
+    "keepPlaying": "Abra uma caixa já que está por aqui",
+    "linked": "Discord vinculado",
+    "linkedBody": "{{name}} agora está vinculado à sua conta. Volte ao Discord e tente /showcase.",
+    "linking": "Vinculando sua conta",
+    "needLogin": "Entre para concluir a vinculação",
+    "needLoginBody": "Faça login ou crie uma conta, e seu usuário do Discord será vinculado na hora.",
+    "tryAgain": "Use /link no Discord de novo para obter um código novo."
+  },
   "fair": {
     "autoVerifySupportedFor": "Verificação automática disponível para rolls de caixa, plinko, blackjack, dados, minas e hilo",
     "busted": "estourou",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -300,6 +300,16 @@
     "rollDice": "Gieo xúc xắc",
     "winChance": "Tỉ lệ thắng"
   },
+  "discord": {
+    "failed": "Liên kết đó không hoạt động",
+    "keepPlaying": "Mở một hòm đi, tiện thể",
+    "linked": "Đã liên kết Discord",
+    "linkedBody": "{{name}} đã được liên kết với tài khoản của bạn. Quay lại Discord và thử /showcase.",
+    "linking": "Đang liên kết tài khoản của bạn",
+    "needLogin": "Đăng nhập để hoàn tất liên kết",
+    "needLoginBody": "Đăng nhập hoặc tạo tài khoản, và người dùng Discord của bạn sẽ được liên kết ngay.",
+    "tryAgain": "Chạy lại /link trong Discord để lấy mã mới."
+  },
   "fair": {
     "autoVerifySupportedFor": "Hỗ trợ kiểm chứng tự động cho roll của hòm, plinko, blackjack, xúc xắc, dò mìn và hilo",
     "busted": "nổ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -300,6 +300,16 @@
     "rollDice": "掷骰子",
     "winChance": "获胜概率"
   },
+  "discord": {
+    "failed": "该链接无法使用",
+    "keepPlaying": "来都来了，开个箱吧",
+    "linked": "Discord 已关联",
+    "linkedBody": "{{name}} 已关联到你的账号。回到 Discord 试试 /showcase。",
+    "linking": "正在关联你的账号",
+    "needLogin": "登录后完成关联",
+    "needLoginBody": "登录或注册账号，你的 Discord 用户就会立即关联。",
+    "tryAgain": "在 Discord 中重新运行 /link 获取新的验证码。"
+  },
   "fair": {
     "autoVerifySupportedFor": "开箱、Plinko、21点、骰子、扫雷和 HiLo 的 roll 支持自动验证",
     "busted": "爆掉",

--- a/src/pages/Discord/LinkDiscord.tsx
+++ b/src/pages/Discord/LinkDiscord.tsx
@@ -1,0 +1,82 @@
+import { useContext, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Link } from "react-router-dom";
+import UserContext from "../../UserContext";
+import i18n from "../../i18n";
+import {
+    completeDiscordLink,
+    setPendingDiscordCode,
+    takePendingDiscordCode,
+} from "../../services/discord/DiscordLinkService";
+
+type State = "working" | "needLogin" | "done" | "failed";
+
+// landing point of the bot's /link url. the site session is what says which account is
+// being linked, so a visitor who is not logged in yet signs in first and lands back here.
+const LinkDiscord = () => {
+    const [params] = useSearchParams();
+    const { isLogged, toogleUserFlow } = useContext(UserContext);
+    const [state, setState] = useState<State>("working");
+    const [name, setName] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const sent = useRef(false);
+
+    useEffect(() => {
+        const code = (params.get("code") || takePendingDiscordCode() || "").trim();
+        if (!code) return setState("failed");
+
+        if (!isLogged) {
+            setPendingDiscordCode(code);
+            setState("needLogin");
+            toogleUserFlow(true);
+            return;
+        }
+
+        if (sent.current) return;
+        sent.current = true;
+        // the login panel has done its job, and would otherwise sit on top of the answer
+        toogleUserFlow(false);
+        completeDiscordLink(code)
+            .then((result) => {
+                setName(result.discordName);
+                setState("done");
+            })
+            .catch((err) => {
+                setError(err?.response?.data?.message || null);
+                setState("failed");
+            });
+    }, [params, isLogged, toogleUserFlow]);
+
+    return (
+        <div className="w-full flex items-center justify-center px-4 py-16">
+            <div className="max-w-md w-full flex flex-col items-center gap-3 text-center bg-surface border border-line rounded-lg p-8">
+                {state === "working" && <span className="text-ink-soft">{i18n.t("discord.linking")}</span>}
+                {state === "needLogin" && (
+                    <>
+                        <span className="text-xl font-bold">{i18n.t("discord.needLogin")}</span>
+                        <span className="text-sm text-ink-soft">{i18n.t("discord.needLoginBody")}</span>
+                    </>
+                )}
+                {state === "done" && (
+                    <>
+                        <span className="text-xl font-bold">{i18n.t("discord.linked")}</span>
+                        <span className="text-sm text-ink-soft">
+                            {i18n.t("discord.linkedBody", { name: name || "Discord" })}
+                        </span>
+                        <Link to="/" className="text-sm text-ink-muted underline">
+                            {i18n.t("discord.keepPlaying")}
+                        </Link>
+                    </>
+                )}
+                {state === "failed" && (
+                    <>
+                        <span className="text-xl font-bold">{i18n.t("discord.failed")}</span>
+                        <span className="text-sm text-ink-soft">{error || i18n.t("discord.tryAgain")}</span>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default LinkDiscord;

--- a/src/services/discord/DiscordLinkService.ts
+++ b/src/services/discord/DiscordLinkService.ts
@@ -1,0 +1,32 @@
+import api from "../api";
+
+export interface DiscordLinkState {
+    linked: boolean;
+    discordName: string | null;
+    linkedAt: string | null;
+}
+
+export const completeDiscordLink = async (code: string): Promise<{ username: string; discordName: string | null }> => {
+    const { data } = await api.post("/discord/link/complete", { code });
+    return data;
+};
+
+export const getDiscordLink = async (): Promise<DiscordLinkState> => {
+    const { data } = await api.get("/discord/link/me");
+    return data;
+};
+
+export const unlinkDiscord = async (): Promise<void> => {
+    await api.delete("/discord/link");
+};
+
+// the code arrives before the login does, so it waits here while the visitor signs in
+const PENDING = "discord:pendingCode";
+
+export const setPendingDiscordCode = (code: string) => sessionStorage.setItem(PENDING, code);
+
+export const takePendingDiscordCode = (): string | null => {
+    const code = sessionStorage.getItem(PENDING);
+    if (code) sessionStorage.removeItem(PENDING);
+    return code;
+};


### PR DESCRIPTION
## Problem

Nothing brings new players in. The site has no presence where people already are, and Discord is where they are.

## Change

A read-only Discord bot in `bot/`, plus the backend and site half of account linking.

- `/link` mints a short code, privately. The site redeems it against whoever is logged in there, which is what proves which account is being linked, and means every linked player has visited the site.
- `/showcase`, `/topfan`, `/leaderboard` render what a player has and where they stand.
- Server boards count whoever runs a command in a server, not whoever is a member. No privileged intent, and the queries never scale with guild size.
- Opening cases and spending stay on the site. The bot is a way in, not a second place to play.

`/discord/*` is guarded by `DISCORD_BOT_SECRET`, because the site API key ships inside the frontend bundle and cannot guard a route that mints a code for an arbitrary Discord id.

Also fixes two modals that stacked on the link page: the tour now stays out of the way of `/link/*`, and the login panel closes once it has done its job.

## Cost

Every endpoint is bounded and none reads an inventory. `/showcase` is one indexed document; `/topfan` is one fan board plus an `$in` capped at the 50 rows it keeps; `/leaderboard` is an indexed lookup limited to 15. Nothing runs on a timer, and command spam is rejected in the bot's own memory before any HTTP call.

## Tests

21 new integration tests covering the secret guard, the link flow and its races, the account-age rule, and guild scoping. Full backend suite 980 passing, frontend 152 passing, `check:reads` clean.