### PR TITLE
fix(fandom): stop two series sharing one character board

### DIFF
--- a/backend/__tests__/integration/fandom.test.js
+++ b/backend/__tests__/integration/fandom.test.js
@@ -420,3 +420,77 @@ describe("alt outfits", () => {
     expect(board.topCount).toBe(2);
   });
 });
+
+// two series can use one first name: Touhou and Blue Archive both have a Yukari, a Junko
+// and a Yuuka. sharing a board counted their copies together and hung the wrong portrait
+// on somebody's badge, so the newer side carries a name of its own.
+describe("a name two collections share", () => {
+  const makeAlt = (name, character, rarity = "5") =>
+    Item.create({ name, character, image: `${name}.png`, rarity, baseValue: 100 });
+
+  it("keeps the two on separate boards", async () => {
+    const touhou = await makeItem("Yukari", "4");
+    const archive = await makeAlt("Yukari", "Yukari (Blue Archive)", "2");
+    await makeUser({ pinned: touhou, inventory: [...copies(touhou, 3), ...copies(archive, 5)] });
+
+    await fandom.rebuild();
+
+    // the five from the other series must not count toward the board they did not join
+    const mine = await FanBoard.findOne({ name: "Yukari" }).lean();
+    expect(mine.topCount).toBe(3);
+    const theirs = await FanBoard.findOne({ name: "Yukari (Blue Archive)" }).lean();
+    expect(theirs.fanCount).toBe(0);
+  });
+
+  it("hangs each board's own portrait", async () => {
+    const touhou = await makeItem("Yukari", "4");
+    const archive = await makeAlt("Yukari", "Yukari (Blue Archive)", "2");
+
+    const byName = await fandom.charactersByName();
+
+    expect(byName.get("Yukari").image).toBe(touhou.image);
+    expect(byName.get("Yukari (Blue Archive)").image).toBe(archive.image);
+  });
+
+  // every item in the moved group carries a character now, so the base look can no longer
+  // be told by that field alone
+  it("still prefers the base look over an alt on the moved side", async () => {
+    const alt = await makeAlt("Yukari (Swimsuit)", "Yukari (Blue Archive)", "1");
+    const base = await makeAlt("Yukari", "Yukari (Blue Archive)", "2");
+
+    const character = (await fandom.charactersByName(["Yukari (Blue Archive)"])).get("Yukari (Blue Archive)");
+
+    expect(character.image).toBe(base.image);
+    expect(character.rarity).toBe("2");
+    expect(character.ids.has(String(alt._id))).toBe(true);
+  });
+
+  it("counts a base and its alt together on the moved side", async () => {
+    const base = await makeAlt("Yukari", "Yukari (Blue Archive)", "2");
+    const alt = await makeAlt("Yukari (Swimsuit)", "Yukari (Blue Archive)", "1");
+    await makeUser({
+      pinned: { name: "Yukari (Blue Archive)", image: base.image, rarity: base.rarity },
+      inventory: [...copies(base, 2), ...copies(alt, 4)],
+    });
+
+    await fandom.rebuild();
+
+    const board = await FanBoard.findOne({ name: "Yukari (Blue Archive)" }).lean();
+    expect(board.topCount).toBe(6);
+  });
+
+  it("pins the moved base without calling it an outfit", async () => {
+    const base = await makeAlt("Yukari", "Yukari (Blue Archive)", "2");
+    const owner = await makeUser({ inventory: copies(base, 1) });
+
+    await request(app)
+      .put("/users/fixedItem")
+      .set("Authorization", `Bearer ${tokenFor(owner)}`)
+      .send({ item: String(base._id) })
+      .expect(200);
+
+    const after = await User.findById(owner._id).select("fixedItem").lean();
+    expect(after.fixedItem.name).toBe("Yukari (Blue Archive)");
+    expect(after.fixedItem.variant).toBeUndefined();
+  });
+});

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -512,7 +512,7 @@ router.put("/fixedItem", authMiddleware.isAuthenticated, async (req, res) => {
     const movedFandom = previousFandom !== character;
     user.fixedItem = {
       name: character,
-      variant: catalogItem.character ? catalogItem.name : undefined,
+      variant: fandom.isBaseLook(catalogItem) ? undefined : catalogItem.name,
       image: catalogItem.image,
       rarity: catalogItem.rarity,
       description: user.fixedItem.description,

--- a/backend/scripts/checkCharacterCollisions.js
+++ b/backend/scripts/checkCharacterCollisions.js
@@ -1,0 +1,77 @@
+// Fails when one character key covers items from more than one collection.
+//
+//   node scripts/checkCharacterCollisions.js
+//
+// A fan board is keyed by character, and a character is `character || name`. Two series
+// can use the same first name: Touhou and Blue Archive both have a Yukari, a Junko and a
+// Yuuka. Left alone they share one board, so their copies are counted together, the board
+// wears whichever portrait the catalog returned last, and a player's badge shows someone
+// they have never held. It went unnoticed for months because nothing errors.
+//
+// Run it after every case import. Anything it prints needs a name of its own, which
+// scripts/splitCharacterBoards.js gives it.
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const Item = require("../models/Item");
+const Case = require("../models/Case");
+const FanBoard = require("../models/FanBoard");
+const { characterOf } = require("../utils/fandom");
+
+async function collisions() {
+  const [items, cases] = await Promise.all([
+    Item.find({}, { name: 1, character: 1, rarity: 1 }).lean(),
+    Case.find({}, { category: 1, items: 1 }).lean(),
+  ]);
+
+  const categoryOf = new Map();
+  for (const one of cases) {
+    for (const id of one.items || []) categoryOf.set(String(id), one.category);
+  }
+
+  const byCharacter = new Map();
+  for (const item of items) {
+    const key = characterOf(item);
+    const category = categoryOf.get(String(item._id)) || "(no case)";
+    if (!byCharacter.has(key)) byCharacter.set(key, new Map());
+    const spread = byCharacter.get(key);
+    if (!spread.has(category)) spread.set(category, []);
+    spread.get(category).push(item);
+  }
+
+  return [...byCharacter].filter(([, spread]) => spread.size > 1);
+}
+
+async function main() {
+  await mongoose.connect(process.env.MONGO_URI, { serverSelectionTimeoutMS: 15000 });
+  const found = await collisions();
+
+  if (!found.length) {
+    console.log("every character belongs to one collection");
+    await mongoose.disconnect();
+    return;
+  }
+
+  const boards = await FanBoard.find({ name: { $in: found.map(([key]) => key) } }, { name: 1, fanCount: 1, topCount: 1 }).lean();
+  const boardOf = new Map(boards.map((board) => [board.name, board]));
+
+  console.log(`${found.length} character${found.length === 1 ? "" : "s"} shared across collections:\n`);
+  for (const [key, spread] of found) {
+    const board = boardOf.get(key);
+    console.log(`${key}${board ? `  (${board.fanCount} fans, leader holds ${board.topCount})` : "  (no board)"}`);
+    for (const [category, list] of spread) {
+      console.log(`   ${category.padEnd(16)} ${list.map((item) => item.name).join(", ")}`);
+    }
+  }
+  await mongoose.disconnect();
+  process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("collision check:", err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { collisions };

--- a/backend/scripts/splitCharacterBoards.js
+++ b/backend/scripts/splitCharacterBoards.js
@@ -1,0 +1,111 @@
+// Gives one side of a shared character name a name of its own, so the two stop sharing
+// a fan board.
+//
+//   node scripts/splitCharacterBoards.js "Blue Archive"           # what it would do
+//   node scripts/splitCharacterBoards.js "Blue Archive" --apply
+//
+// The named collection is the one that moves: its items get `character` set to
+// "<name> (<collection>)", which is what the board is keyed by. Item names are untouched,
+// so nothing changes in a case, an inventory or the market.
+//
+// Whoever already pinned the side that keeps the plain name keeps their board, their
+// standing and their tie-break. Check that first with checkCharacterCollisions.js: the
+// collection to move is the one nobody has pinned.
+require("dotenv").config();
+const mongoose = require("mongoose");
+
+const Item = require("../models/Item");
+const Case = require("../models/Case");
+const User = require("../models/User");
+const fandom = require("../utils/fandom");
+const itemCatalog = require("../utils/itemCatalog");
+const { collisions } = require("./checkCharacterCollisions");
+
+async function plan(moving) {
+  const found = await collisions();
+  const cases = await Case.find({}, { category: 1, items: 1 }).lean();
+  const categoryOf = new Map();
+  for (const one of cases) {
+    for (const id of one.items || []) categoryOf.set(String(id), one.category);
+  }
+
+  const moves = [];
+  for (const [key, spread] of found) {
+    const mine = spread.get(moving);
+    if (!mine) continue;
+    if (spread.size < 2) continue;
+    const renamed = `${key} (${moving})`;
+    for (const item of mine) {
+      if (item.character === renamed) continue;
+      moves.push({ _id: item._id, name: item.name, from: key, to: renamed });
+    }
+  }
+  return { moves, categoryOf };
+}
+
+async function main() {
+  const moving = process.argv[2];
+  const apply = process.argv.includes("--apply");
+  if (!moving) {
+    console.error('usage: node scripts/splitCharacterBoards.js "<collection>" [--apply]');
+    process.exit(1);
+  }
+
+  await mongoose.connect(process.env.MONGO_URI, { serverSelectionTimeoutMS: 15000 });
+  const { moves } = await plan(moving);
+
+  if (!moves.length) {
+    console.log(`nothing in ${moving} shares a character with another collection`);
+    await mongoose.disconnect();
+    return;
+  }
+
+  // a pin on the moving side would be left pointing at the other collection's board, so
+  // it has to be seen rather than discovered afterwards
+  const stranded = await User.find(
+    { "fixedItem.name": { $in: [...new Set(moves.map((move) => move.from))] }, disabled: { $ne: true } },
+    { username: 1, "fixedItem.name": 1, "fixedItem.image": 1 }
+  ).lean();
+  const movingImages = new Set(
+    (await Item.find({ _id: { $in: moves.map((move) => move._id) } }, { image: 1 }).lean()).map((item) => item.image)
+  );
+  const atRisk = stranded.filter((user) => user.fixedItem && movingImages.has(user.fixedItem.image));
+
+  console.log(`${moves.length} item${moves.length === 1 ? "" : "s"} in ${moving} would be renamed:\n`);
+  for (const move of moves) console.log(`   ${move.name.padEnd(26)} ${move.from}  ->  ${move.to}`);
+  console.log(`\npins on the moving side that would need repointing: ${atRisk.length}`);
+  for (const user of atRisk) console.log(`   ${user.username} (${user.fixedItem.name})`);
+
+  if (!apply) {
+    console.log("\ndry run. pass --apply to write it.");
+    await mongoose.disconnect();
+    return;
+  }
+  if (atRisk.length) {
+    console.error("\nrefusing: repoint those pins first, or move the other collection instead.");
+    await mongoose.disconnect();
+    process.exit(1);
+  }
+
+  await Item.bulkWrite(
+    moves.map((move) => ({ updateOne: { filter: { _id: move._id }, update: { $set: { character: move.to } } } })),
+    { ordered: false }
+  );
+  console.log(`\n${moves.length} items updated`);
+
+  // a bulkWrite fires no hook, so the catalog would rebuild the boards off the old names
+  itemCatalog.invalidate();
+
+  const { boards, players } = await fandom.rebuild();
+  console.log(`boards rebuilt: ${boards} boards, ${players} players`);
+  await mongoose.disconnect();
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("split:", err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { plan };

--- a/backend/utils/fandom.js
+++ b/backend/utils/fandom.js
@@ -13,9 +13,15 @@ const RANKS_KEPT = 50;
 const NO_CONTEST = 999999;
 const COLLECTORS_KEPT = 100;
 
-// an item's character is its own name unless it is an alt outfit, which carries the base
-// name so both count as one person
+// an item's character is its own name unless it carries one of its own: an alt outfit
+// names the person wearing it, and a character who shares a first name with someone from
+// another series names themselves apart, so two franchises never land on one board
 const characterOf = (item) => item.character || item.name;
+
+// which of a character's items is the look the board wears. an alt always carries its
+// outfit in brackets, so the one without is the character as they normally appear. this
+// cannot key off `character` any more: a disambiguated base carries one too.
+const isBaseLook = (item) => !/\s\(/.test(item.name);
 
 // the same character can appear in more than one case, and in more than one outfit, as
 // separate item rows. the character is the board, so every id behind it counts toward it.
@@ -33,10 +39,11 @@ async function charactersByName(names) {
     entry.ids.add(String(item._id));
     // the board wears the base look, so an alt never takes the portrait off the character
     // it belongs to, whichever order the catalog came back in
-    if (!entry.image || !item.character) entry.image = item.image || entry.image;
-    if (!entry.rarity || !item.character) entry.rarity = item.rarity || entry.rarity;
+    const base = isBaseLook(item);
+    if (!entry.image || base) entry.image = item.image || entry.image;
+    if (!entry.rarity || base) entry.rarity = item.rarity || entry.rarity;
     // the first case the character drops from is where the page sends anyone chasing them
-    if (!entry.caseId || !item.character) entry.caseId = item.case || entry.caseId;
+    if (!entry.caseId || base) entry.caseId = item.case || entry.caseId;
   }
   return byName;
 }
@@ -423,6 +430,8 @@ module.exports = {
   sweep,
   standingsFrom,
   charactersByName,
+  characterOf,
+  isBaseLook,
   namesByItemId,
   isCopyOf,
   byStanding,


### PR DESCRIPTION
## Problem

A fan board is keyed by character, and a character is `character || name`. Touhou and Blue Archive both have a **Yukari**, **Junko**, **Yuuka**, **Momiji**, **Saki**, **Takane** and **Hina**, so all seven pairs shared a single board.

Three things went wrong on each, silently: copies from both series counted toward one total, the board wore whichever portrait the catalog happened to return last, and a player's Top Fan badge could show a character they had never held. That last one is how it surfaced, from a profile pinned to Touhou's Yukari wearing a Blue Archive portrait.

## Change

`scripts/splitCharacterBoards.js "<collection>"` sets `character` to `"<name> (<collection>)"` on the side that moves. Item names are untouched, so nothing changes in a case, an inventory or the market. Only the board key moves.

Once a base item carries a `character` for disambiguation, the absence of that field no longer marks the base outfit, so the board now picks its look by the bracket every alt name already uses.

`scripts/checkCharacterCollisions.js` exits non-zero on any character spanning two collections. It is the check that was missing when the Blue Archive cases landed, and it belongs after every import.

## Safety

Measured against production: all **48 pinners** across the seven boards had pinned the Touhou character, so moving Blue Archive repoints **zero pins**. The script refuses to apply if any pin sits on the moving side.

Counts on the affected boards will drop for the three players who held copies from both series. That is the correction, not a regression.

## Tests

5 new cases covering separate boards, per-board portraits, base-look preference when every item in a group carries a character, counting a base with its alt on the moved side, and pinning a moved base without labelling it an outfit. Full backend suite passing.