### PR TITLE
feat(discord): link and unlink from the settings tab

### DIFF
--- a/backend/__tests__/integration/discordBot.test.js
+++ b/backend/__tests__/integration/discordBot.test.js
@@ -302,3 +302,127 @@ describe("discord bot routes", () => {
     });
   });
 });
+
+// linking from the site instead of from the bot. discord is the only thing that can say
+// which discord account a browser belongs to, so the player is sent there and back.
+describe("linking from the site", () => {
+  const jwt = require("jsonwebtoken");
+  const CLIENT = "1541676225133809714";
+  let realFetch;
+
+  beforeAll(() => {
+    process.env.DISCORD_CLIENT_ID = CLIENT;
+    process.env.DISCORD_CLIENT_SECRET = "test-client-secret";
+    process.env.DISCORD_REDIRECT_URI = "https://api.example.test/discord/oauth/callback";
+    realFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  // discord answers twice: once to trade the code for a token, once for the account
+  const discordAnswers = (account) => {
+    global.fetch = jest.fn(async (url) =>
+      String(url).endsWith("/oauth2/token")
+        ? { ok: true, json: async () => ({ access_token: "token" }) }
+        : { ok: true, json: async () => account }
+    );
+  };
+
+  const start = (user) => auth(request(app).get("/discord/oauth/start"), user);
+  const callback = (query) => request(app).get("/discord/oauth/callback").query(query);
+
+  it("hands back a discord url carrying a state only this session could have made", async () => {
+    const user = await makeUser();
+    const res = await start(user);
+    expect(res.status).toBe(200);
+
+    const url = new URL(res.body.url);
+    expect(url.origin + url.pathname).toBe("https://discord.com/oauth2/authorize");
+    expect(url.searchParams.get("client_id")).toBe(CLIENT);
+    expect(url.searchParams.get("scope")).toBe("identify");
+    expect(url.searchParams.get("response_type")).toBe("code");
+
+    const claim = jwt.verify(url.searchParams.get("state"), process.env.JWT_SECRET);
+    expect(claim.userId).toBe(String(user._id));
+  });
+
+  it("needs a session of its own", async () => {
+    expect((await request(app).get("/discord/oauth/start")).status).toBe(401);
+  });
+
+  it("will not start for an account that is already linked", async () => {
+    const user = await makeUser();
+    await linkUser(user, oldEnough());
+    expect((await start(user)).status).toBe(409);
+  });
+
+  it("links the account the state names, and sends them back to their settings", async () => {
+    const user = await makeUser();
+    const discordId = oldEnough();
+    const state = (await start(user)).body.url;
+    discordAnswers({ id: discordId, username: "someone" });
+
+    const res = await callback({ code: "auth-code", state: new URL(state).searchParams.get("state") });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain(`/profile/${user._id}?tab=settings&discord=linked`);
+
+    const stored = await User.findById(user._id).select("discordId discordName").lean();
+    expect(stored.discordId).toBe(discordId);
+    expect(stored.discordName).toBe("someone");
+  });
+
+  it("refuses a state it did not sign", async () => {
+    const forged = jwt.sign({ userId: "000000000000000000000000", use: "discord-oauth" }, "not-the-secret");
+    const res = await callback({ code: "auth-code", state: forged });
+    expect(res.headers.location).toContain("discord=expired");
+  });
+
+  // a login token is signed with the same secret, so the purpose has to be checked too
+  it("refuses a token minted for something other than this flow", async () => {
+    const user = await makeUser();
+    const res = await callback({ code: "auth-code", state: tokenFor(user) });
+    expect(res.headers.location).toContain("discord=failed");
+    const stored = await User.findById(user._id).select("discordId").lean();
+    expect(stored.discordId).toBeUndefined();
+  });
+
+  it("turns away a discord account that belongs to someone else", async () => {
+    const holder = await makeUser();
+    const discordId = oldEnough();
+    await linkUser(holder, discordId);
+
+    const other = await makeUser();
+    const state = new URL((await start(other)).body.url).searchParams.get("state");
+    discordAnswers({ id: discordId, username: "someone" });
+
+    const res = await callback({ code: "auth-code", state });
+    expect(res.headers.location).toContain("discord=taken");
+    const stored = await User.findById(other._id).select("discordId").lean();
+    expect(stored.discordId).toBeUndefined();
+  });
+
+  it("applies the same age rule the bot does", async () => {
+    const user = await makeUser();
+    const state = new URL((await start(user)).body.url).searchParams.get("state");
+    discordAnswers({ id: snowflakeFor(daysAgo(2)), username: "fresh" });
+
+    const res = await callback({ code: "auth-code", state });
+    expect(res.headers.location).toContain("discord=young");
+    const stored = await User.findById(user._id).select("discordId").lean();
+    expect(stored.discordId).toBeUndefined();
+  });
+
+  it("survives discord refusing the code", async () => {
+    const user = await makeUser();
+    const state = new URL((await start(user)).body.url).searchParams.get("state");
+    global.fetch = jest.fn(async () => ({ ok: false, json: async () => ({}) }));
+
+    const res = await callback({ code: "stale", state });
+    expect(res.headers.location).toContain("discord=failed");
+  });
+
+  it("goes nowhere without a code", async () => {
+    expect((await callback({})).headers.location).toContain("discord=failed");
+  });
+});

--- a/backend/__tests__/integration/helpers.js
+++ b/backend/__tests__/integration/helpers.js
@@ -42,6 +42,8 @@ function makeApp() {
   app.use("/items", itemRoutes);
   app.use("/fandom", fandomRoutes);
   app.use("/predictions", predictionRoutes(io));
+  // discord redirects a browser here, so it is mounted outside the router in index.js too
+  app.get("/discord/oauth/callback", discordRoutes.oauthCallback);
   app.use("/discord", discordRoutes);
   return app;
 }

--- a/backend/index.js
+++ b/backend/index.js
@@ -22,6 +22,10 @@ app.post("/deploy/github", express.raw({ type: "*/*" }), githubDeployHandler);
 // public liveness probe (also bypasses the api-key gate so monitors can hit it)
 app.get("/health", (req, res) => res.json({ status: "ok", uptime: process.uptime() }));
 
+// discord redirects the player's browser back here after they approve the link, so it
+// arrives with no api key and no token. it verifies its own signed state instead.
+app.get("/discord/oauth/callback", require("./routes/discordRoutes").oauthCallback);
+
 const isDevelopment = process.env.NODE_ENV === "development";
 
 // allowed origins are configurable via ALLOWED_ORIGINS (comma-separated); falls

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const crypto = require("crypto");
+const jwt = require("jsonwebtoken");
 const router = express.Router();
 
 const User = require("../models/User");
@@ -220,6 +221,104 @@ router.get("/link/me", isAuthenticated, async (req, res) => {
   }
 });
 
+// linking the other way round: from the site, with no bot involved. discord is the only
+// thing that can say which account a browser belongs to, so it has to be asked directly.
+const DISCORD_API = "https://discord.com/api/v10";
+const OAUTH_TTL = "10m";
+
+const siteUrl = () => (process.env.SITE_URL || "https://kanicasino.com").replace(/\/$/, "");
+const redirectUri = () =>
+  process.env.DISCORD_REDIRECT_URI || `${(process.env.API_URL || "").replace(/\/$/, "")}/discord/oauth/callback`;
+
+router.get("/oauth/start", isAuthenticated, async (req, res) => {
+  try {
+    if (!process.env.DISCORD_CLIENT_ID || !process.env.DISCORD_CLIENT_SECRET) {
+      return res.status(503).json({ message: "Discord linking is not configured" });
+    }
+    const mine = await User.findById(req.user._id, { discordId: 1 }).lean();
+    if (!mine) return res.status(404).json({ message: "User not found" });
+    if (mine.discordId) return res.status(409).json({ message: "This account is already linked to a Discord user." });
+
+    // the state is signed rather than stored: it says which session opened the flow, it
+    // expires on its own, and a callback replayed by anyone else carries no session at all
+    const state = jwt.sign({ userId: String(req.user._id), use: "discord-oauth" }, process.env.JWT_SECRET, {
+      expiresIn: OAUTH_TTL,
+    });
+    const url = new URL("https://discord.com/oauth2/authorize");
+    url.searchParams.set("client_id", process.env.DISCORD_CLIENT_ID);
+    url.searchParams.set("redirect_uri", redirectUri());
+    url.searchParams.set("response_type", "code");
+    // identify is the whole ask: an id and a name, no email, no servers, no messages
+    url.searchParams.set("scope", "identify");
+    url.searchParams.set("state", state);
+    res.json({ url: url.toString() });
+  } catch (err) {
+    console.error("discord oauth start:", err.message);
+    res.status(500).json({ message: "Could not start linking" });
+  }
+});
+
+// discord sends the player's browser here, so it carries no api key and no bearer token.
+// mounted ahead of the api-key gate in index.js, and everything it trusts comes out of the
+// signed state or from discord itself.
+async function oauthCallback(req, res) {
+  const done = (userId, status) =>
+    res.redirect(`${siteUrl()}/profile/${userId || "me"}?tab=settings&discord=${status}`);
+
+  let userId = null;
+  try {
+    const { code, state } = req.query;
+    if (!code || !state) return done(null, "failed");
+
+    let claim;
+    try {
+      claim = jwt.verify(String(state), process.env.JWT_SECRET);
+    } catch {
+      return done(null, "expired");
+    }
+    if (claim.use !== "discord-oauth") return done(null, "failed");
+    userId = claim.userId;
+
+    const token = await fetch(`${DISCORD_API}/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: process.env.DISCORD_CLIENT_ID,
+        client_secret: process.env.DISCORD_CLIENT_SECRET,
+        grant_type: "authorization_code",
+        code: String(code),
+        redirect_uri: redirectUri(),
+      }),
+      signal: AbortSignal.timeout(8000),
+    }).then((r) => (r.ok ? r.json() : null));
+    if (!token || !token.access_token) return done(userId, "failed");
+
+    const me = await fetch(`${DISCORD_API}/users/@me`, {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+      signal: AbortSignal.timeout(8000),
+    }).then((r) => (r.ok ? r.json() : null));
+    if (!me || !me.id) return done(userId, "failed");
+
+    const born = snowflakeDate(me.id);
+    if (!born || Date.now() - born.getTime() < MIN_ACCOUNT_AGE_MS) return done(userId, "young");
+
+    const taken = await User.findOne({ discordId: me.id }, { _id: 1 }).lean();
+    if (taken) return done(userId, String(taken._id) === String(userId) ? "already" : "taken");
+
+    const written = await User.updateOne(
+      { _id: userId, discordId: { $exists: false } },
+      { $set: { discordId: me.id, discordName: me.username || null, discordLinkedAt: new Date() } }
+    );
+    if (!written.modifiedCount) return done(userId, "already");
+    return done(userId, "linked");
+  } catch (err) {
+    // the unique index is still the last word if two browsers race the same discord account
+    if (err && err.code === 11000) return done(userId, "taken");
+    console.error("discord oauth callback:", err.message);
+    return done(userId, "failed");
+  }
+}
+
 router.get("/showcase/:discordId", botOnly, async (req, res) => {
   try {
     const user = await User.findOne(visible({ discordId: String(req.params.discordId) }), CARD_FIELDS).lean();
@@ -305,5 +404,8 @@ router.get("/leaderboard", botOnly, async (req, res) => {
     res.status(500).json({ message: "Could not load the leaderboard" });
   }
 });
+
+// attached rather than routed: index.js mounts it ahead of the api-key gate
+router.oauthCallback = oauthCallback;
 
 module.exports = router;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -301,14 +301,27 @@
     "winChance": "Gewinnchance"
   },
   "discord": {
+    "errAlready": "Dieses Konto ist bereits verknüpft.",
+    "errExpired": "Das hat zu lange gedauert. Fang neu an.",
+    "errFailed": "Die Verknüpfung hat nicht geklappt. Versuch es erneut.",
+    "errTaken": "Dieses Discord-Konto gehört einem anderen Spieler.",
+    "errYoung": "Dieses Discord-Konto ist zu neu zum Verknüpfen.",
     "failed": "Dieser Link hat nicht funktioniert",
     "keepPlaying": "Öffne eine Kiste, wenn du schon hier bist",
+    "linkButton": "Discord verknüpfen",
+    "linkHint": "Verknüpfe dein Konto, um den Bot zu nutzen: zeig deine Sammlung und hol dir die Ranglisten deines Servers.",
     "linked": "Discord verknüpft",
+    "linkedAs": "Verknüpft als {{name}}",
     "linkedBody": "{{name}} ist jetzt mit deinem Konto verknüpft. Geh zurück zu Discord und probier /showcase.",
+    "linkedToast": "Discord verknüpft",
     "linking": "Dein Konto wird verknüpft",
     "needLogin": "Melde dich an, um die Verknüpfung abzuschließen",
     "needLoginBody": "Melde dich an oder erstelle ein Konto, dann wird dein Discord-Benutzer sofort verknüpft.",
-    "tryAgain": "Führe /link in Discord erneut aus, um einen neuen Code zu bekommen."
+    "notLinked": "Kein Discord-Konto verknüpft",
+    "settingsTitle": "Discord",
+    "tryAgain": "Führe /link in Discord erneut aus, um einen neuen Code zu bekommen.",
+    "unlinkButton": "Trennen",
+    "unlinked": "Discord getrennt"
   },
   "fair": {
     "autoVerifySupportedFor": "Automatische Prüfung möglich für Kisten-, Plinko-, Blackjack-, Würfel-, Minen- und Hilo-Rolls",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -301,14 +301,27 @@
     "winChance": "Win Chance"
   },
   "discord": {
+    "errAlready": "This account is already linked.",
+    "errExpired": "That took too long. Start again.",
+    "errFailed": "Linking did not work. Try again.",
+    "errTaken": "That Discord account belongs to another player.",
+    "errYoung": "That Discord account is too new to link.",
     "failed": "That link did not work",
     "keepPlaying": "Open a case while you are here",
+    "linkButton": "Link Discord",
+    "linkHint": "Link your account to use the bot: show your collection off, and take your server's boards.",
     "linked": "Discord linked",
+    "linkedAs": "Linked as {{name}}",
     "linkedBody": "{{name}} is now attached to your account. Head back to Discord and try /showcase.",
+    "linkedToast": "Discord linked",
     "linking": "Linking your account",
     "needLogin": "Log in to finish linking",
     "needLoginBody": "Sign in or create an account, and your Discord user gets attached straight away.",
-    "tryAgain": "Run /link in Discord again for a fresh code."
+    "notLinked": "No Discord account linked",
+    "settingsTitle": "Discord",
+    "tryAgain": "Run /link in Discord again for a fresh code.",
+    "unlinkButton": "Unlink",
+    "unlinked": "Discord unlinked"
   },
   "fair": {
     "autoVerifySupportedFor": "Auto-verify supported for case, plinko, blackjack, dice, mines and hilo rolls",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -301,14 +301,27 @@
     "winChance": "Probabilidad de ganar"
   },
   "discord": {
+    "errAlready": "Esta cuenta ya está vinculada.",
+    "errExpired": "Tardó demasiado. Empieza de nuevo.",
+    "errFailed": "La vinculación no funcionó. Inténtalo otra vez.",
+    "errTaken": "Esa cuenta de Discord pertenece a otro jugador.",
+    "errYoung": "Esa cuenta de Discord es demasiado nueva para vincularla.",
     "failed": "Ese enlace no funcionó",
     "keepPlaying": "Abre una caja ya que estás aquí",
+    "linkButton": "Vincular Discord",
+    "linkHint": "Vincula tu cuenta para usar el bot: presume tu colección y pelea por los tableros de tu servidor.",
     "linked": "Discord vinculado",
+    "linkedAs": "Vinculado como {{name}}",
     "linkedBody": "{{name}} ya está vinculado a tu cuenta. Vuelve a Discord y prueba /showcase.",
+    "linkedToast": "Discord vinculado",
     "linking": "Vinculando tu cuenta",
     "needLogin": "Inicia sesión para terminar de vincular",
     "needLoginBody": "Inicia sesión o crea una cuenta y tu usuario de Discord se vinculará al instante.",
-    "tryAgain": "Usa /link en Discord otra vez para conseguir un código nuevo."
+    "notLinked": "Ninguna cuenta de Discord vinculada",
+    "settingsTitle": "Discord",
+    "tryAgain": "Usa /link en Discord otra vez para conseguir un código nuevo.",
+    "unlinkButton": "Desvincular",
+    "unlinked": "Discord desvinculado"
   },
   "fair": {
     "autoVerifySupportedFor": "Verificación automática disponible para tiradas de caja, plinko, blackjack, dados, minas e hilo",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -301,14 +301,27 @@
     "winChance": "Chance de gagner"
   },
   "discord": {
+    "errAlready": "Ce compte est déjà associé.",
+    "errExpired": "Cela a pris trop de temps. Recommence.",
+    "errFailed": "L'association n'a pas fonctionné. Réessaie.",
+    "errTaken": "Ce compte Discord appartient à un autre joueur.",
+    "errYoung": "Ce compte Discord est trop récent pour être associé.",
     "failed": "Ce lien n'a pas fonctionné",
     "keepPlaying": "Ouvre une caisse tant que tu es là",
+    "linkButton": "Associer Discord",
+    "linkHint": "Associe ton compte pour utiliser le bot : montre ta collection et prends les classements de ton serveur.",
     "linked": "Discord associé",
+    "linkedAs": "Associé en tant que {{name}}",
     "linkedBody": "{{name}} est maintenant associé à ton compte. Retourne sur Discord et essaie /showcase.",
+    "linkedToast": "Discord associé",
     "linking": "Association de ton compte",
     "needLogin": "Connecte-toi pour terminer l'association",
     "needLoginBody": "Connecte-toi ou crée un compte, et ton utilisateur Discord sera associé aussitôt.",
-    "tryAgain": "Relance /link sur Discord pour obtenir un nouveau code."
+    "notLinked": "Aucun compte Discord associé",
+    "settingsTitle": "Discord",
+    "tryAgain": "Relance /link sur Discord pour obtenir un nouveau code.",
+    "unlinkButton": "Dissocier",
+    "unlinked": "Discord dissocié"
   },
   "fair": {
     "autoVerifySupportedFor": "Vérification automatique disponible pour les tirages de caisse, plinko, blackjack, dés, mines et hilo",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -301,14 +301,27 @@
     "winChance": "Kesempatan menang"
   },
   "discord": {
+    "errAlready": "Akun ini sudah tertaut.",
+    "errExpired": "Terlalu lama. Mulai lagi.",
+    "errFailed": "Penautan gagal. Coba lagi.",
+    "errTaken": "Akun Discord itu milik pemain lain.",
+    "errYoung": "Akun Discord itu terlalu baru untuk ditautkan.",
     "failed": "Tautan itu tidak berhasil",
     "keepPlaying": "Buka satu case selagi di sini",
+    "linkButton": "Tautkan Discord",
+    "linkHint": "Tautkan akunmu untuk memakai bot: pamerkan koleksimu dan rebut papan peringkat servermu.",
     "linked": "Discord tertaut",
+    "linkedAs": "Tertaut sebagai {{name}}",
     "linkedBody": "{{name}} sekarang tertaut ke akunmu. Kembali ke Discord dan coba /showcase.",
+    "linkedToast": "Discord tertaut",
     "linking": "Menautkan akunmu",
     "needLogin": "Masuk untuk menyelesaikan penautan",
     "needLoginBody": "Masuk atau buat akun, dan pengguna Discord-mu langsung tertaut.",
-    "tryAgain": "Jalankan /link lagi di Discord untuk kode baru."
+    "notLinked": "Belum ada akun Discord yang tertaut",
+    "settingsTitle": "Discord",
+    "tryAgain": "Jalankan /link lagi di Discord untuk kode baru.",
+    "unlinkButton": "Lepas tautan",
+    "unlinked": "Tautan Discord dilepas"
   },
   "fair": {
     "autoVerifySupportedFor": "Verifikasi otomatis didukung untuk permainan case, plinko, blackjack, dadu, mines, dan hilo rolls.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -301,14 +301,27 @@
     "winChance": "Probabilità di vincita"
   },
   "discord": {
+    "errAlready": "Questo account è già collegato.",
+    "errExpired": "Ci è voluto troppo. Ricomincia.",
+    "errFailed": "Il collegamento non ha funzionato. Riprova.",
+    "errTaken": "Quell'account Discord appartiene a un altro giocatore.",
+    "errYoung": "Quell'account Discord è troppo recente per collegarlo.",
     "failed": "Quel link non ha funzionato",
     "keepPlaying": "Apri una cassa già che ci sei",
+    "linkButton": "Collega Discord",
+    "linkHint": "Collega il tuo account per usare il bot: mostra la tua collezione e conquista le classifiche del tuo server.",
     "linked": "Discord collegato",
+    "linkedAs": "Collegato come {{name}}",
     "linkedBody": "{{name}} ora è collegato al tuo account. Torna su Discord e prova /showcase.",
+    "linkedToast": "Discord collegato",
     "linking": "Collegamento del tuo account",
     "needLogin": "Accedi per completare il collegamento",
     "needLoginBody": "Accedi o crea un account e il tuo utente Discord verrà collegato subito.",
-    "tryAgain": "Usa di nuovo /link su Discord per un codice nuovo."
+    "notLinked": "Nessun account Discord collegato",
+    "settingsTitle": "Discord",
+    "tryAgain": "Usa di nuovo /link su Discord per un codice nuovo.",
+    "unlinkButton": "Scollega",
+    "unlinked": "Discord scollegato"
   },
   "fair": {
     "autoVerifySupportedFor": "Verifica automatica disponibile per i roll di cassa, plinko, blackjack, dadi, mine e hilo",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -301,14 +301,27 @@
     "winChance": "勝率"
   },
   "discord": {
+    "errAlready": "このアカウントはすでに連携済みです。",
+    "errExpired": "時間がかかりすぎました。もう一度お試しください。",
+    "errFailed": "連携できませんでした。もう一度お試しください。",
+    "errTaken": "その Discord アカウントは他のプレイヤーのものです。",
+    "errYoung": "その Discord アカウントは新しすぎて連携できません。",
     "failed": "このリンクは使えませんでした",
     "keepPlaying": "せっかくなのでケースを開けてみる",
+    "linkButton": "Discord を連携",
+    "linkHint": "アカウントを連携するとボットが使えます。コレクションを自慢して、サーバーのランキングを取りに行きましょう。",
     "linked": "Discord を連携しました",
+    "linkedAs": "{{name}} として連携中",
     "linkedBody": "{{name}} がアカウントに連携されました。Discord に戻って /showcase を試してみてください。",
+    "linkedToast": "Discord を連携しました",
     "linking": "アカウントを連携しています",
     "needLogin": "ログインして連携を完了してください",
     "needLoginBody": "ログインするかアカウントを作成すると、Discord アカウントがすぐに連携されます。",
-    "tryAgain": "Discord でもう一度 /link を実行して、新しいコードを取得してください。"
+    "notLinked": "Discord アカウントは未連携です",
+    "settingsTitle": "Discord",
+    "tryAgain": "Discord でもう一度 /link を実行して、新しいコードを取得してください。",
+    "unlinkButton": "連携を解除",
+    "unlinked": "Discord の連携を解除しました"
   },
   "fair": {
     "autoVerifySupportedFor": "ケース、プリンコ、ブラックジャック、ダイス、マインズ、HiLo のロールは自動検証に対応しています",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -301,14 +301,27 @@
     "winChance": "승리 확률"
   },
   "discord": {
+    "errAlready": "이미 연결된 계정입니다.",
+    "errExpired": "시간이 너무 지났습니다. 다시 시작하세요.",
+    "errFailed": "연결에 실패했습니다. 다시 시도하세요.",
+    "errTaken": "그 Discord 계정은 다른 플레이어의 것입니다.",
+    "errYoung": "그 Discord 계정은 너무 최근에 만들어져 연결할 수 없습니다.",
     "failed": "이 링크는 작동하지 않았습니다",
     "keepPlaying": "온 김에 케이스 하나 열어보기",
+    "linkButton": "Discord 연결",
+    "linkHint": "계정을 연결하면 봇을 쓸 수 있습니다. 컬렉션을 자랑하고 서버 순위를 차지하세요.",
     "linked": "Discord 연결 완료",
+    "linkedAs": "{{name}}(으)로 연결됨",
     "linkedBody": "{{name}}이(가) 계정에 연결되었습니다. Discord로 돌아가 /showcase를 사용해 보세요.",
+    "linkedToast": "Discord 연결 완료",
     "linking": "계정을 연결하는 중",
     "needLogin": "로그인하고 연결을 마치세요",
     "needLoginBody": "로그인하거나 계정을 만들면 Discord 계정이 바로 연결됩니다.",
-    "tryAgain": "Discord에서 /link를 다시 실행해 새 코드를 받으세요."
+    "notLinked": "연결된 Discord 계정이 없습니다",
+    "settingsTitle": "Discord",
+    "tryAgain": "Discord에서 /link를 다시 실행해 새 코드를 받으세요.",
+    "unlinkButton": "연결 해제",
+    "unlinked": "Discord 연결을 해제했습니다"
   },
   "fair": {
     "autoVerifySupportedFor": "케이스, 플린코, 블랙잭, 주사위, 마인즈, HiLo 롤은 자동 검증을 지원합니다",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -301,14 +301,27 @@
     "winChance": "Chance de ganhar"
   },
   "discord": {
+    "errAlready": "Esta conta já está vinculada.",
+    "errExpired": "Demorou demais. Comece de novo.",
+    "errFailed": "A vinculação não funcionou. Tente de novo.",
+    "errTaken": "Essa conta do Discord pertence a outro jogador.",
+    "errYoung": "Essa conta do Discord é nova demais para vincular.",
     "failed": "Esse link não funcionou",
     "keepPlaying": "Abra uma caixa já que está por aqui",
+    "linkButton": "Vincular Discord",
+    "linkHint": "Vincule sua conta para usar o bot: mostre sua coleção e dispute os rankings do seu servidor.",
     "linked": "Discord vinculado",
+    "linkedAs": "Vinculado como {{name}}",
     "linkedBody": "{{name}} agora está vinculado à sua conta. Volte ao Discord e tente /showcase.",
+    "linkedToast": "Discord vinculado",
     "linking": "Vinculando sua conta",
     "needLogin": "Entre para concluir a vinculação",
     "needLoginBody": "Faça login ou crie uma conta, e seu usuário do Discord será vinculado na hora.",
-    "tryAgain": "Use /link no Discord de novo para obter um código novo."
+    "notLinked": "Nenhuma conta do Discord vinculada",
+    "settingsTitle": "Discord",
+    "tryAgain": "Use /link no Discord de novo para obter um código novo.",
+    "unlinkButton": "Desvincular",
+    "unlinked": "Discord desvinculado"
   },
   "fair": {
     "autoVerifySupportedFor": "Verificação automática disponível para rolls de caixa, plinko, blackjack, dados, minas e hilo",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -301,14 +301,27 @@
     "winChance": "Tỉ lệ thắng"
   },
   "discord": {
+    "errAlready": "Tài khoản này đã được liên kết.",
+    "errExpired": "Quá lâu rồi. Hãy bắt đầu lại.",
+    "errFailed": "Liên kết không thành công. Thử lại nhé.",
+    "errTaken": "Tài khoản Discord đó thuộc về người chơi khác.",
+    "errYoung": "Tài khoản Discord đó quá mới để liên kết.",
     "failed": "Liên kết đó không hoạt động",
     "keepPlaying": "Mở một hòm đi, tiện thể",
+    "linkButton": "Liên kết Discord",
+    "linkHint": "Liên kết tài khoản để dùng bot: khoe bộ sưu tập và giành bảng xếp hạng của máy chủ bạn.",
     "linked": "Đã liên kết Discord",
+    "linkedAs": "Đã liên kết với {{name}}",
     "linkedBody": "{{name}} đã được liên kết với tài khoản của bạn. Quay lại Discord và thử /showcase.",
+    "linkedToast": "Đã liên kết Discord",
     "linking": "Đang liên kết tài khoản của bạn",
     "needLogin": "Đăng nhập để hoàn tất liên kết",
     "needLoginBody": "Đăng nhập hoặc tạo tài khoản, và người dùng Discord của bạn sẽ được liên kết ngay.",
-    "tryAgain": "Chạy lại /link trong Discord để lấy mã mới."
+    "notLinked": "Chưa liên kết tài khoản Discord",
+    "settingsTitle": "Discord",
+    "tryAgain": "Chạy lại /link trong Discord để lấy mã mới.",
+    "unlinkButton": "Hủy liên kết",
+    "unlinked": "Đã hủy liên kết Discord"
   },
   "fair": {
     "autoVerifySupportedFor": "Hỗ trợ kiểm chứng tự động cho roll của hòm, plinko, blackjack, xúc xắc, dò mìn và hilo",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -301,14 +301,27 @@
     "winChance": "获胜概率"
   },
   "discord": {
+    "errAlready": "该账号已经关联过了。",
+    "errExpired": "耗时过长，请重新开始。",
+    "errFailed": "关联失败，请重试。",
+    "errTaken": "那个 Discord 账号属于其他玩家。",
+    "errYoung": "那个 Discord 账号太新，无法关联。",
     "failed": "该链接无法使用",
     "keepPlaying": "来都来了，开个箱吧",
+    "linkButton": "关联 Discord",
+    "linkHint": "关联账号即可使用机器人：晒出你的收藏，拿下你所在服务器的榜单。",
     "linked": "Discord 已关联",
+    "linkedAs": "已关联为 {{name}}",
     "linkedBody": "{{name}} 已关联到你的账号。回到 Discord 试试 /showcase。",
+    "linkedToast": "Discord 已关联",
     "linking": "正在关联你的账号",
     "needLogin": "登录后完成关联",
     "needLoginBody": "登录或注册账号，你的 Discord 用户就会立即关联。",
-    "tryAgain": "在 Discord 中重新运行 /link 获取新的验证码。"
+    "notLinked": "未关联 Discord 账号",
+    "settingsTitle": "Discord",
+    "tryAgain": "在 Discord 中重新运行 /link 获取新的验证码。",
+    "unlinkButton": "解除关联",
+    "unlinked": "已解除 Discord 关联"
   },
   "fair": {
     "autoVerifySupportedFor": "开箱、Plinko、21点、骰子、扫雷和 HiLo 的 roll 支持自动验证",

--- a/src/pages/Profile/DiscordSettings.tsx
+++ b/src/pages/Profile/DiscordSettings.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import {
+    getDiscordLink,
+    startDiscordOAuth,
+    unlinkDiscord,
+    DiscordLinkState,
+} from "../../services/discord/DiscordLinkService";
+import i18n from "../../i18n";
+
+// what the backend redirect can come back saying, and which of those read as a failure
+const OUTCOMES: Record<string, { key: string; ok: boolean }> = {
+    linked: { key: "discord.linkedToast", ok: true },
+    already: { key: "discord.errAlready", ok: false },
+    taken: { key: "discord.errTaken", ok: false },
+    young: { key: "discord.errYoung", ok: false },
+    expired: { key: "discord.errExpired", ok: false },
+    failed: { key: "discord.errFailed", ok: false },
+};
+
+const DiscordSettings = () => {
+    const [params, setParams] = useSearchParams();
+    const [state, setState] = useState<DiscordLinkState | null>(null);
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        getDiscordLink().then(setState).catch(() => undefined);
+    }, []);
+
+    // the oauth round trip lands back on this tab, so the answer is in the url
+    useEffect(() => {
+        const outcome = params.get("discord");
+        if (!outcome) return;
+        const found = OUTCOMES[outcome] || OUTCOMES.failed;
+        toast[found.ok ? "success" : "error"](i18n.t(found.key), { theme: "dark" });
+        params.delete("discord");
+        setParams(params, { replace: true });
+    }, [params, setParams]);
+
+    const link = async () => {
+        setBusy(true);
+        try {
+            window.location.href = await startDiscordOAuth();
+        } catch {
+            toast.error(i18n.t("discord.errFailed"), { theme: "dark" });
+            setBusy(false);
+        }
+    };
+
+    const unlink = async () => {
+        setBusy(true);
+        try {
+            await unlinkDiscord();
+            setState({ linked: false, discordName: null, linkedAt: null });
+            toast.success(i18n.t("discord.unlinked"), { theme: "dark" });
+        } catch {
+            toast.error(i18n.t("settings.saveFailed"), { theme: "dark" });
+        }
+        setBusy(false);
+    };
+
+    if (!state) return null;
+
+    return (
+        <>
+            <span className="text-lg font-bold">{i18n.t("discord.settingsTitle")}</span>
+
+            <div className="flex items-start justify-between gap-4 bg-surface border border-line rounded-lg p-4">
+                <div className="flex flex-col gap-1">
+                    <span className="font-semibold">
+                        {state.linked
+                            ? i18n.t("discord.linkedAs", { name: state.discordName || "Discord" })
+                            : i18n.t("discord.notLinked")}
+                    </span>
+                    <span className="text-sm text-ink-muted">{i18n.t("discord.linkHint")}</span>
+                </div>
+                <button
+                    onClick={state.linked ? unlink : link}
+                    disabled={busy}
+                    className="shrink-0 px-4 h-9 rounded-md border border-line bg-surface-nav font-semibold transition-colors hover:bg-line disabled:opacity-50"
+                >
+                    {state.linked ? i18n.t("discord.unlinkButton") : i18n.t("discord.linkButton")}
+                </button>
+            </div>
+        </>
+    );
+};
+
+export default DiscordSettings;

--- a/src/pages/Profile/EmailSettings.tsx
+++ b/src/pages/Profile/EmailSettings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
 import { getEmailPreferences, setMarketingOptIn } from "../../services/email/EmailService";
 import LanguageSelector from "../../components/LanguageSelector";
+import DiscordSettings from "./DiscordSettings";
 import i18n from "../../i18n";
 
 const EmailSettings = () => {
@@ -46,6 +47,8 @@ const EmailSettings = () => {
                 <LanguageSelector />
                 <span className="text-sm text-ink-muted">{i18n.t("settings.languageHint")}</span>
             </div>
+
+            <DiscordSettings />
 
             <span className="text-lg font-bold">{i18n.t("auth.emailShort")}</span>
 

--- a/src/services/discord/DiscordLinkService.ts
+++ b/src/services/discord/DiscordLinkService.ts
@@ -16,6 +16,13 @@ export const getDiscordLink = async (): Promise<DiscordLinkState> => {
     return data;
 };
 
+// discord is the only thing that can say which account a browser belongs to, so linking
+// from the site means sending the player there and back
+export const startDiscordOAuth = async (): Promise<string> => {
+    const { data } = await api.get("/discord/oauth/start");
+    return data.url;
+};
+
 export const unlinkDiscord = async (): Promise<void> => {
     await api.delete("/discord/link");
 };


### PR DESCRIPTION
## Problem

Linking only worked from inside Discord: run `/link`, follow the code back to the site. Someone already on the site had no way to start it, and no way to undo it once done.

## Change

The settings tab gets a Discord panel: status, Link, Unlink.

Unlink already had an endpoint. Linking is the new half, and it cannot reuse the bot's code, because the site has no way to know which Discord account a browser belongs to. Only Discord can say that, so the player goes to Discord and back via OAuth2 with the `identify` scope: an id and a name, no email, no server list, no messages.

- `GET /discord/oauth/start` is authenticated and returns the authorize URL.
- `GET /discord/oauth/callback` is where Discord returns the browser. It arrives with no api key and no bearer token, so it is mounted ahead of the api-key gate next to `/health`.

**The state is a signed token, not a stored row**, so it needs no collection, no TTL and no sweep. It carries `use: "discord-oauth"` and the callback checks that field: a login token is signed with the same `JWT_SECRET`, so without the check someone could hand back their own login token as state and attach a Discord account to whoever it belonged to. There is a test for precisely that.

Both paths apply the same 30-day account-age rule and rest on the same unique sparse index on `discordId`.

## Deploy needs one manual step

`DISCORD_CLIENT_SECRET` goes in `backend/.env`, and `https://kanicasino.fabrixhosting.com.au/discord/oauth/callback` must be added under Redirects in the Discord developer portal. Discord refuses the handoff otherwise. Nothing in the repo can do that step.

Until it is configured, `/oauth/start` answers 503 and the panel still shows status and unlink.

## Tests

10 new integration cases: the authorize URL and its state, auth and already-linked guards, the happy path, a forged state, a login token replayed as state, a Discord account held by someone else, the age rule, Discord refusing the code, and a missing code. Backend 995 passing, frontend 152, lint unchanged.