### PR TITLE
fix(discord): tell the player what to do next

### DIFF
--- a/backend/__tests__/integration/discordBot.test.js
+++ b/backend/__tests__/integration/discordBot.test.js
@@ -426,3 +426,30 @@ describe("linking from the site", () => {
     expect((await callback({})).headers.location).toContain("discord=failed");
   });
 });
+
+// the settings tab only renders for the account that owns it, so an outcome sent to
+// /profile/me collapses to the inventory and the player is told nothing at all
+describe("where a failed link sends the player", () => {
+  const jwt = require("jsonwebtoken");
+
+  it("lands an expired link on the settings page of whoever started it", async () => {
+    const user = await makeUser();
+    const stale = jwt.sign(
+      { userId: String(user._id), use: "discord-oauth" },
+      process.env.JWT_SECRET,
+      { expiresIn: -60 }
+    );
+
+    const res = await request(app).get("/discord/oauth/callback").query({ code: "c", state: stale });
+    expect(res.headers.location).toContain(`/profile/${user._id}?tab=settings&discord=expired`);
+  });
+
+  it("will not be pointed at a stranger's page by an unsigned state", async () => {
+    const forged = jwt.sign({ userId: "aaaaaaaaaaaaaaaaaaaaaaaa", use: "discord-oauth" }, "not-the-secret", {
+      expiresIn: -60,
+    });
+    const res = await request(app).get("/discord/oauth/callback").query({ code: "c", state: forged });
+    expect(res.headers.location).toContain("/profile/me?tab=settings&discord=expired");
+    expect(res.headers.location).not.toContain("aaaaaaaaaaaaaaaaaaaaaaaa");
+  });
+});

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -128,7 +128,7 @@ router.post("/link/start", botOnly, async (req, res) => {
 
     const born = snowflakeDate(discordId);
     if (!born || Date.now() - born.getTime() < MIN_ACCOUNT_AGE_MS) {
-      return res.status(403).json({ message: "This Discord account is too new to link" });
+      return res.status(403).json({ message: "Discord accounts under 30 days old cannot be linked yet." });
     }
 
     const existing = await User.findOne({ discordId }, { username: 1 }).lean();
@@ -165,27 +165,27 @@ router.post("/link/complete", isAuthenticated, async (req, res) => {
     const taken = await User.findOne({ discordId: pending.discordId }, { username: 1 }).lean();
     if (taken) {
       await DiscordLink.deleteOne({ code });
-      return res.status(409).json({ message: "That Discord account is already linked to " + taken.username + "." });
+      return res.status(409).json({ message: "That Discord account is already linked to " + taken.username + ". Unlink it from that account's settings tab first." });
     }
 
     const mine = await User.findById(req.user._id, { discordId: 1, username: 1 }).lean();
     if (!mine) return res.status(404).json({ message: "User not found" });
     if (mine.discordId) {
-      return res.status(409).json({ message: "This account is already linked to a Discord user." });
+      return res.status(409).json({ message: "This account is already linked to a Discord user. Change it from the settings tab on your profile." });
     }
 
     const done = await User.updateOne(
       { _id: req.user._id, discordId: { $exists: false } },
       { $set: { discordId: pending.discordId, discordName: pending.discordName, discordLinkedAt: new Date() } }
     );
-    if (!done.modifiedCount) return res.status(409).json({ message: "This account is already linked." });
+    if (!done.modifiedCount) return res.status(409).json({ message: "This account is already linked. Change it from the settings tab on your profile." });
     await DiscordLink.deleteOne({ code });
 
     res.json({ username: mine.username, discordName: pending.discordName || null });
   } catch (err) {
     // the unique index is the real guard against two accounts racing for one discord id
     if (err && err.code === 11000) {
-      return res.status(409).json({ message: "That Discord account is already linked." });
+      return res.status(409).json({ message: "That Discord account is already linked. Unlink it from that account first." });
     }
     console.error("discord link complete:", err.message);
     res.status(500).json({ message: "Could not finish the link" });
@@ -237,7 +237,7 @@ router.get("/oauth/start", isAuthenticated, async (req, res) => {
     }
     const mine = await User.findById(req.user._id, { discordId: 1 }).lean();
     if (!mine) return res.status(404).json({ message: "User not found" });
-    if (mine.discordId) return res.status(409).json({ message: "This account is already linked to a Discord user." });
+    if (mine.discordId) return res.status(409).json({ message: "This account is already linked to a Discord user. Change it from the settings tab on your profile." });
 
     // the state is signed rather than stored: it says which session opened the flow, it
     // expires on its own, and a callback replayed by anyone else carries no session at all

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -274,7 +274,15 @@ async function oauthCallback(req, res) {
     try {
       claim = jwt.verify(String(state), process.env.JWT_SECRET);
     } catch {
-      return done(null, "expired");
+      // the signature is still checked, so this cannot be pointed anywhere by a stranger.
+      // it only recovers whose settings page to land on: the answer is still no.
+      let expired = null;
+      try {
+        expired = jwt.verify(String(state), process.env.JWT_SECRET, { ignoreExpiration: true });
+      } catch {
+        expired = null;
+      }
+      return done(expired && expired.use === "discord-oauth" ? expired.userId : null, "expired");
     }
     if (claim.use !== "discord-oauth") return done(null, "failed");
     userId = claim.userId;

--- a/bot/package.json
+++ b/bot/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "scripts": {
     "start": "node src/index.js",
-    "register": "node src/register.js"
+    "register": "node src/register.js",
+    "test": "node --test src/messages.test.js"
   },
   "dependencies": {
     "discord.js": "^14.16.3",

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -22,7 +22,12 @@ setInterval(() => {
   for (const [key, at] of lastUsed) if (at < cutoff) lastUsed.delete(key);
 }, 60000).unref();
 
-const NOT_LINKED = `No KaniCasino account is linked to that Discord user yet. Run \`/link\` to attach one.`;
+// never state that an account is missing without saying how to get one: on its own that
+// reads as a refusal, and somebody has to answer "so how do I link it?" by hand
+const LINK_HINT = "Run `/link` to attach one, it takes about a minute.";
+const NOT_LINKED = `You have not linked a KaniCasino account yet. ${LINK_HINT}`;
+const theyAreNotLinked = (name) =>
+  `**${name}** has not linked a KaniCasino account yet. They can attach one with \`/link\`.`;
 
 const commands = [
   {
@@ -34,7 +39,11 @@ const commands = [
       const link = await api.linkStart(interaction.user.id, interaction.user.username);
       if (link.alreadyLinked) {
         await interaction.editReply({
-          embeds: [noticeEmbed(`You are already linked to **${link.username}**.`)],
+          embeds: [
+            noticeEmbed(
+              `You are already linked to **${link.username}**. Change it from the settings tab on ${SITE}.`
+            ),
+          ],
         });
         return;
       }
@@ -56,7 +65,7 @@ const commands = [
     },
     notFound: (interaction) => {
       const target = interaction.options.getUser("player");
-      return target ? `**${target.username}** has not linked a KaniCasino account.` : NOT_LINKED;
+      return target ? theyAreNotLinked(target.username) : NOT_LINKED;
     },
   },
   {

--- a/bot/src/embeds.js
+++ b/bot/src/embeds.js
@@ -72,7 +72,8 @@ function topFanEmbed(board, guildName) {
 
   if (!board.ranks.length) {
     embed.setDescription(
-      `Nobody here has pinned **${board.name}** yet. The board is open.\n[Take it](${boardUrl(board.name)})`
+      `Nobody here has pinned **${board.name}** yet. The board is open.
+[Take it](${boardUrl(board.name)}), and run \`/link\` first if you have not linked yet.`
     );
     return embed;
   }

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -33,7 +33,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
   if (!command) return;
 
   if (!interaction.guildId && interaction.commandName !== "link") {
-    return reply(interaction, "This one only works inside a server.");
+    return reply(interaction, "That one only works inside a server. Try it in a channel there.");
   }
 
   const wait = onCooldown(interaction.user.id, interaction.commandName);

--- a/bot/src/messages.test.js
+++ b/bot/src/messages.test.js
@@ -1,0 +1,54 @@
+// Every message that tells a player they have no linked account must also tell them how
+// to get one.
+//
+//   npm test        (from bot/)
+//
+// Someone ran /showcase on a player who had not linked and got "X has not linked a
+// KaniCasino account." full stop. That reads as a refusal, and a human had to answer
+// "so use /link" by hand. The rule is cheap to keep and easy to forget, so it is checked
+// against the source rather than trusted.
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SOURCES = ["commands.js", "embeds.js", "index.js"];
+
+// only the lines that state an account is missing. "Link your account" and "No account
+// yet? Sign up first" are the instruction itself, and must not be caught by their own rule.
+const STATES_AN_ABSENCE = /(have|has) not linked|nobody here has linked|no .{0,25}account is linked|is not linked/i;
+// LINK_HINT counts: it is the instruction, just held in a constant so it stays identical
+const OFFERS_THE_WAY = /\/link|settings tab|LINK_HINT/;
+
+test("no message says an account is missing without saying how to link one", () => {
+  const offenders = [];
+  for (const file of SOURCES) {
+    const source = fs.readFileSync(path.join(__dirname, file), "utf8");
+    source.split("\n").forEach((line, index) => {
+      if (line.trim().startsWith("//")) return;
+      if (!STATES_AN_ABSENCE.test(line)) return;
+      if (OFFERS_THE_WAY.test(line)) return;
+      // a template split across lines carries the instruction on the next one
+      const next = source.split("\n")[index + 1] || "";
+      if (OFFERS_THE_WAY.test(next)) return;
+      offenders.push(`${file}:${index + 1}  ${line.trim()}`);
+    });
+  }
+  assert.deepStrictEqual(offenders, [], "these tell a player they are not linked and stop there");
+});
+
+test("the showcase answers name the person who has to act", () => {
+  process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+  const { commands } = require("./commands");
+  const showcase = commands.find((command) => command.data.name === "showcase");
+  const asked = (username) => ({ options: { getUser: () => (username ? { username } : null) } });
+
+  const aboutSomeoneElse = showcase.notFound(asked("solidddarling"));
+  assert.match(aboutSomeoneElse, /solidddarling/);
+  assert.match(aboutSomeoneElse, /They can/, "it is their account to link, not the caller's");
+  assert.match(aboutSomeoneElse, /\/link/);
+
+  const aboutYou = showcase.notFound(asked(null));
+  assert.match(aboutYou, /^You have not/, "the caller is the one who has to act");
+  assert.match(aboutYou, /\/link/);
+});


### PR DESCRIPTION
Two dead ends in the Discord flow, both the same shape: the player is told what went wrong and not what to do about it.

## The one that actually bit

Someone ran `/showcase` on a player who had not linked, and got:

> **solidddarling** has not linked a KaniCasino account.

Full stop. It took a human replying "use `/link`" for them to get anywhere.

Every message that states an account is missing now carries the way out, worded by **who has to act**: your own card missing tells you to run `/link`; someone else's says they can. The already-linked answers point at the settings tab, since that is where it gets changed. The backend errors the bot echoes got the same treatment.

`bot/src/messages.test.js` reads the source for lines that state an absence and fails on any that do not also name `/link` or the settings tab. Reverting the old wording fails it, which is the only proof worth having. Zero dependencies, `npm test` from `bot/`.

## The silent one

The OAuth callback redirects to `/profile/<id>?tab=settings&discord=<outcome>`. With an unverifiable state there was no id, so it fell back to `/profile/me` — which loads, but `isSameUser` is false for the literal `me`, so the settings tab collapses to the inventory. `DiscordSettings` never mounts and **no toast appears at all**: an expired link failed silently.

Reachable by leaving Discord's consent screen open past the ten minute expiry.

Now the id is recovered by verifying the state again with `ignoreExpiration`. The signature is still checked, so a forged state cannot point the redirect at a stranger's page, and the link is refused either way.

## Tests

2 backend cases for the expired redirect and the forged one, plus the bot message guard. Backend 997 passing.