### PR TITLE
refactor(cases): one opening path, so a second caller cannot drift

### DIFF
--- a/backend/__tests__/integration/openCaseShared.test.js
+++ b/backend/__tests__/integration/openCaseShared.test.js
@@ -1,0 +1,172 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Case = require("../../models/Case");
+const Transaction = require("../../models/Transaction");
+const Roll = require("../../models/Roll");
+const realtime = require("../../utils/realtime");
+const { openCase } = require("../../games/openCase");
+const { recomputeCaseValues } = require("../../utils/itemValue");
+
+beforeAll(setupDb);
+afterEach(async () => {
+  realtime.setIo(null);
+  await clearDb();
+});
+afterAll(teardownDb);
+
+// a stand-in that keeps what was announced, so the live feed can be asserted on
+function captureIo() {
+  const emitted = [];
+  const rooms = [];
+  realtime.setIo({
+    emit: (event, payload) => emitted.push({ event, payload }),
+    to: (room) => ({ emit: (event, payload) => rooms.push({ room, event, payload }) }),
+  });
+  return { emitted, rooms };
+}
+
+async function makeCase(price = 100) {
+  const s = uniqueSuffix();
+  const items = await Item.create([
+    { name: `common-${s}`, image: "c.png", rarity: "1", baseValue: 10 },
+    { name: `rare-${s}`, image: "r.png", rarity: "5", baseValue: 900 },
+  ]);
+  const one = await Case.create({
+    title: `case-${s}`,
+    image: "case.png",
+    price,
+    category: "Touhou",
+    items: items.map((item) => item._id),
+  });
+  await recomputeCaseValues(one._id);
+  return Case.findById(one._id);
+}
+
+async function makeUser(walletBalance = 10000) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance,
+  });
+}
+
+// the route hands this a user document without its inventory, so the tests do too:
+// reading one back in here is what the shared path must never start doing
+const asCaller = (user) => User.findById(user._id).select({ password: 0, inventory: 0 });
+
+describe("the shared opening", () => {
+  it("charges, hands the item over and writes one ledger row", async () => {
+    const one = await makeCase(250);
+    const user = await makeUser(1000);
+
+    const result = await openCase({ user: await asCaller(user), caseId: one._id, quantity: 2 });
+
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(2);
+    expect(result.cost).toBe(500);
+    expect(result.walletBalance).toBe(500);
+
+    const after = await User.findById(user._id).lean();
+    expect(after.walletBalance).toBe(500);
+    expect(after.inventory).toHaveLength(2);
+    expect(after.xp).toBe(2500);
+
+    const ledger = await Transaction.find({ userId: user._id }).lean();
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]).toMatchObject({ direction: "debit", amount: 500, balanceAfter: 500 });
+  });
+
+  it("refuses when the balance will not cover it, and charges nothing", async () => {
+    const one = await makeCase(900);
+    const user = await makeUser(100);
+
+    const result = await openCase({ user: await asCaller(user), caseId: one._id, quantity: 1 });
+
+    expect(result).toMatchObject({ ok: false, status: 400 });
+    const after = await User.findById(user._id).lean();
+    expect(after.walletBalance).toBe(100);
+    expect(after.inventory).toHaveLength(0);
+    expect(await Transaction.countDocuments({ userId: user._id })).toBe(0);
+  });
+
+  it("writes one provably-fair roll per opening, tied to the item it produced", async () => {
+    const one = await makeCase(10);
+    const user = await makeUser(1000);
+
+    const result = await openCase({ user: await asCaller(user), caseId: one._id, quantity: 3 });
+
+    const rolls = await Roll.find({ userId: user._id }).sort({ nonce: 1 }).lean();
+    expect(rolls).toHaveLength(3);
+    expect(rolls.map((r) => r.rollId)).toEqual(result.rollIds);
+    expect(new Set(rolls.map((r) => r.nonce)).size).toBe(3);
+    for (const [index, roll] of rolls.entries()) {
+      expect(roll.game).toBe("case");
+      expect(roll.uniqueId).toBe(result.items[index].uniqueId);
+    }
+  });
+
+  it("holds the quantity between one and five", async () => {
+    const one = await makeCase(10);
+    const caller = await asCaller(await makeUser());
+    for (const quantity of [0, -1, 6, 2.5, "2"]) {
+      expect((await openCase({ user: caller, caseId: one._id, quantity })).ok).toBe(false);
+    }
+  });
+});
+
+describe("what the live feed is told", () => {
+  it("announces the drop, and says nothing about a source when there is none", async () => {
+    const io = captureIo();
+    const one = await makeCase(100);
+    const user = await makeUser();
+
+    await openCase({ user: await asCaller(user), caseId: one._id, quantity: 1 });
+
+    const drop = io.emitted.find((e) => e.event === "caseOpened");
+    expect(drop).toBeTruthy();
+    expect(drop.payload.winningItems).toHaveLength(1);
+    expect(drop.payload.user).toMatchObject({ name: expect.any(String), id: user._id });
+    expect(drop.payload.caseImage).toBe("case.png");
+    expect("source" in drop.payload).toBe(false);
+  });
+
+  // the ticker paints a marker off this, the way it already does for an upgrade
+  it("carries the source through when the opening came from somewhere else", async () => {
+    const io = captureIo();
+    const one = await makeCase(100);
+    const user = await makeUser();
+
+    await openCase({ user: await asCaller(user), caseId: one._id, quantity: 1, source: "discord" });
+
+    const drop = io.emitted.find((e) => e.event === "caseOpened");
+    expect(drop.payload.source).toBe("discord");
+  });
+
+  it("tells the opener's own sockets their new balance", async () => {
+    const io = captureIo();
+    const one = await makeCase(300);
+    const user = await makeUser(1000);
+
+    await openCase({ user: await asCaller(user), caseId: one._id, quantity: 1 });
+
+    const mine = io.rooms.find((r) => r.event === "userDataUpdated");
+    expect(mine.room).toBe(String(user._id));
+    expect(mine.payload).toMatchObject({ walletBalance: 700 });
+  });
+
+  it("opens fine with no socket server attached at all", async () => {
+    realtime.setIo(null);
+    const one = await makeCase(100);
+    const user = await makeUser();
+
+    const result = await openCase({ user: await asCaller(user), caseId: one._id, quantity: 1 });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/backend/games/openCase.js
+++ b/backend/games/openCase.js
@@ -1,0 +1,200 @@
+const User = require("../models/User");
+const Case = require("../models/Case");
+const badges = require("../utils/badges");
+const realtime = require("../utils/realtime");
+const { calculateLevelFromXp, recordTransaction, runAtomic, TX, WITHOUT_INVENTORY } = require("../utils/economy");
+const referrals = require("../utils/referrals");
+const fandom = require("../utils/fandom");
+const { addUniqueInfoToItem, toInventoryEntry } = require("../utils/caseOpening");
+const { buildRangeTable } = require("../utils/caseRanges");
+const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
+const seeds = require("../utils/seeds");
+const rolls = require("../utils/rolls");
+const { sellValue, recomputeCaseValues } = require("../utils/itemValue");
+
+const MAX_PER_OPEN = 5;
+
+// a refusal the caller turns into its own kind of answer: an http status on the site, an
+// embed in discord. nothing here knows which.
+const no = (status, message) => ({ ok: false, status, message });
+
+// the whole opening: reserve the nonces, draw, charge, hand the items over, record the
+// audit rolls, announce it. lifted out of the route so the discord bot opens a case
+// through this exact path rather than a second one that drifts from it.
+//
+// `user` is a User document without its inventory, which is what isAuthenticated hands
+// the route and what the bot loads for itself. `source` rides along to the live feed, so
+// a drop can say where it came from.
+async function openCase({ user, caseId, quantity, grantId = null, source = null }) {
+  const winningItems = [];
+  let caseData = await Case.findById(caseId).populate("items");
+
+  if (!caseData) return no(404, "Case not found");
+  if (!user) return no(404, "User not found");
+
+  if (!Number.isInteger(quantity)) return no(400, "Quantity to open must be an integer");
+  if (quantity > MAX_PER_OPEN) return no(400, `You can only open up to ${MAX_PER_OPEN} cases at a time`);
+  if (quantity < 1) return no(400, "You need to open at least 1 case");
+
+  // a daily-gift grant pays for openings of one specific case and nothing else, so a
+  // cheap win cannot be spent on the dearest case in the same category
+  let grant = null;
+  if (grantId) {
+    grant = (user.freeOpens || []).find((g) => g.grantId === grantId);
+    if (!grant) return no(404, "Gift not found");
+    if (String(grant.caseId) !== String(caseData._id)) return no(400, "That gift is for a different case");
+    if (new Date(grant.expiresAt) <= new Date()) return no(400, "That gift has expired");
+    if (grant.remaining < quantity) return no(400, "That gift has fewer openings left");
+  }
+
+  const cost = grant ? 0 : caseData.price * quantity;
+
+  // reserve the nonces atomically up front (never rolled back), then derive each
+  // item from the case's committed range table (provably fair, one draw per open)
+  const reserved = await seeds.reserveNonces(user._id, quantity);
+
+  // self-heal: materialize + commit this case's config on first open if it has
+  // none yet, so the roll stays verifiable even if the backfill hasn't run
+  if (!caseData.rangeTable || !caseData.rangeTable.length) {
+    await recomputeCaseValues(caseData._id);
+    caseData = await Case.findById(caseId).populate("items");
+  }
+  let rangeTable = caseData.rangeTable;
+  let configHash = caseData.configHash;
+  const configVersion = caseData.configVersion || 0;
+  if (!rangeTable || !rangeTable.length) {
+    const built = buildRangeTable(caseData); // safety net (e.g. a case with no items)
+    rangeTable = built.rangeTable;
+    configHash = built.configHash;
+  }
+
+  const draws = [];
+  for (let i = 0; i < quantity; i++) {
+    const nonce = reserved.startNonce + i;
+    const rollValue = roll(reserved.serverSeed, reserved.clientSeed, nonce); // 1..TOTAL
+    const picked = pickFromRanges(rollValue, rangeTable);
+    const sourceItem = caseData.items.find((it) => String(it._id) === String(picked.itemId));
+    const itemWithUniqueId = addUniqueInfoToItem(sourceItem);
+    winningItems.push(itemWithUniqueId);
+    draws.push({ nonce, roll: rollValue, itemId: picked.itemId, uniqueId: itemWithUniqueId.uniqueId });
+  }
+
+  // charge the cost, add the items and write the ledger row together: a failed row
+  // rolls the charge back, so the player is never charged without a record
+  const updatedUser = await runAtomic(async (session) => {
+    const filter = { _id: user._id, walletBalance: { $gte: cost } };
+    const update = {
+      $inc: { walletBalance: -cost, xp: cost * 5 },
+      $push: { inventory: { $each: winningItems.map(toInventoryEntry) } },
+    };
+    // the push has just made this inventory bigger; handing it back would cost more
+    // than the opening did
+    const options = { new: true, projection: WITHOUT_INVENTORY, session };
+
+    // spend the openings in the same update that hands over the items, and require
+    // the count to still cover it, so two concurrent opens cannot overdraw one grant
+    if (grant) {
+      filter.freeOpens = {
+        $elemMatch: { grantId: grant.grantId, remaining: { $gte: quantity } },
+      };
+      update.$inc["freeOpens.$[g].remaining"] = -quantity;
+      options.arrayFilters = [{ "g.grantId": grant.grantId, "g.remaining": { $gte: quantity } }];
+    }
+
+    const u = await User.findOneAndUpdate(filter, update, options);
+    if (!u) return null;
+    // a gift open moves no coins, so it gets no ledger row: the ledger records
+    // balance changes and a zero one would only be noise
+    if (cost > 0) {
+      await recordTransaction(
+        {
+          userId: user._id,
+          type: TX.CASE_OPEN,
+          direction: "debit",
+          amount: cost,
+          balanceAfter: u.walletBalance,
+          meta: { caseId: caseData._id, caseTitle: caseData.title, quantity, source: source || undefined },
+        },
+        session
+      );
+    }
+    return u;
+  });
+
+  if (!updatedUser) return no(400, "Insufficient balance");
+
+  // record one provably-fair audit roll per open (after the charge commits)
+  const rollIds = [];
+  for (const d of draws) {
+    const rec = await rolls.recordRoll({
+      game: "case",
+      userId: user._id,
+      seedId: reserved.seedId,
+      clientSeed: reserved.clientSeed,
+      serverSeedHash: reserved.serverSeedHash,
+      nonce: d.nonce,
+      roll: d.roll,
+      total: TOTAL,
+      caseId: caseData._id,
+      caseConfigVersion: configVersion,
+      caseConfigHash: configHash,
+      itemId: d.itemId,
+      uniqueId: d.uniqueId,
+    });
+    rollIds.push(rec.rollId);
+  }
+
+  const newLevel = calculateLevelFromXp(updatedUser.xp);
+  if (newLevel !== updatedUser.level) {
+    updatedUser.level = newLevel;
+    await User.updateOne({ _id: user._id }, { $set: { level: newLevel } });
+    referrals.maybePayReferralMilestone(user._id, newLevel).catch(() => {});
+  }
+
+  const io = realtime.getIo();
+  if (io) {
+    io.emit("caseOpened", {
+      winningItems,
+      user: {
+        name: user.username,
+        id: user._id,
+        profilePicture: user.profilePicture,
+        badge: badges.wornBadge(user),
+      },
+      caseImage: caseData.image,
+      // the feed says where a drop came from, the way an upgrade already does
+      ...(source ? { source } : {}),
+    });
+  }
+
+  // the fan boards are a ten-minute snapshot, so a player who just pulled the
+  // character they pinned would read the old count next to their new inventory
+  await fandom.touch(user._id, winningItems.map((item) => item._id));
+
+  const items = winningItems.map((item, index) => ({
+    ...item,
+    sellValue: sellValue(item.baseValue),
+    rollId: rollIds[index],
+  }));
+
+  if (io) {
+    io.to(user._id.toString()).emit("userDataUpdated", {
+      walletBalance: updatedUser.walletBalance,
+      xp: updatedUser.xp,
+      level: updatedUser.level,
+    });
+  }
+
+  return {
+    ok: true,
+    items,
+    rollIds,
+    caseData,
+    cost,
+    walletBalance: updatedUser.walletBalance,
+    xp: updatedUser.xp,
+    level: updatedUser.level,
+  };
+}
+
+module.exports = { openCase, MAX_PER_OPEN };

--- a/backend/routes/gamesRoutes.js
+++ b/backend/routes/gamesRoutes.js
@@ -4,222 +4,39 @@ const router = express.Router();
 const { isAuthenticated } = require("../middleware/authMiddleware");
 const { plinkoDropLimiter, diceRollLimiter, minesActionLimiter, hiloActionLimiter } = require("../middleware/rateLimit");
 
-const User = require("../models/User");
 const Case = require("../models/Case");
 const Round = require("../models/Round");
 const upgradeItems = require("../games/upgrade");
+const { openCase } = require("../games/openCase");
 const SlotGameController = require("../games/slot");
 const PlinkoGameController = require("../games/plinko");
 const BlackjackGameController = require("../games/blackjack");
 const DiceGameController = require("../games/dice");
 const MinesGameController = require("../games/mines");
 const HiloGameController = require("../games/hilo");
-const { calculateLevelFromXp, recordTransaction, runAtomic, TX, WITHOUT_INVENTORY } = require("../utils/economy");
-const referrals = require("../utils/referrals");
-const fandom = require("../utils/fandom");
-const { addUniqueInfoToItem, toInventoryEntry } = require("../utils/caseOpening");
-const { buildRangeTable } = require("../utils/caseRanges");
-const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
-const seeds = require("../utils/seeds");
-const rolls = require("../utils/rolls");
-const { sellValue, recomputeCaseValues } = require("../utils/itemValue");
 
 // Exports
 module.exports = (io) => {
   // Routes
+  // the opening itself lives in games/openCase.js, because the discord bot has to run the
+  // same one: a second path through the money would drift from this one the first time
+  // either changed.
   router.post("/openCase/:id", isAuthenticated, async (req, res) => {
     try {
-      const { id } = req.params;
-      const user = req.user;
-      const quantityToOpen = req.body.quantity;
-      const winningItems = [];
-
-      let caseData = await Case.findById(id).populate("items");
-
-      if (!caseData || !user) {
-        if (!caseData) {
-          return res.status(404).json({ message: "Case not found" });
-        } else {
-          return res.status(404).json({ message: "User not found" });
-        }
-      }
-
-      if (!Number.isInteger(quantityToOpen)) {
-        return res.status(400).json({ message: "Quantity to open must be an integer" });
-      }
-
-      if (quantityToOpen > 5) {
-        return res.status(400).json({ message: "You can only open up to 5 cases at a time" });
-      }
-
-      if (quantityToOpen < 1) {
-        return res.status(400).json({ message: "You need to open at least 1 case" });
-      }
-
-      // a daily-gift grant pays for openings of one specific case and nothing else, so a
-      // cheap win cannot be spent on the dearest case in the same category
-      const grantId = req.body.grantId;
-      let grant = null;
-      if (grantId) {
-        grant = (user.freeOpens || []).find((g) => g.grantId === grantId);
-        if (!grant) return res.status(404).json({ message: "Gift not found" });
-        if (String(grant.caseId) !== String(caseData._id)) {
-          return res.status(400).json({ message: "That gift is for a different case" });
-        }
-        if (new Date(grant.expiresAt) <= new Date()) {
-          return res.status(400).json({ message: "That gift has expired" });
-        }
-        if (grant.remaining < quantityToOpen) {
-          return res.status(400).json({ message: "That gift has fewer openings left" });
-        }
-      }
-
-      const cost = grant ? 0 : caseData.price * quantityToOpen;
-
-      // reserve the nonces atomically up front (never rolled back), then derive each
-      // item from the case's committed range table (provably fair, one draw per open)
-      const reserved = await seeds.reserveNonces(user._id, quantityToOpen);
-
-      // self-heal: materialize + commit this case's config on first open if it has
-      // none yet, so the roll stays verifiable even if the backfill hasn't run
-      if (!caseData.rangeTable || !caseData.rangeTable.length) {
-        await recomputeCaseValues(caseData._id);
-        caseData = await Case.findById(id).populate("items");
-      }
-      let rangeTable = caseData.rangeTable;
-      let configHash = caseData.configHash;
-      const configVersion = caseData.configVersion || 0;
-      if (!rangeTable || !rangeTable.length) {
-        const built = buildRangeTable(caseData); // safety net (e.g. a case with no items)
-        rangeTable = built.rangeTable;
-        configHash = built.configHash;
-      }
-
-      const draws = [];
-      for (let i = 0; i < quantityToOpen; i++) {
-        const nonce = reserved.startNonce + i;
-        const rollValue = roll(reserved.serverSeed, reserved.clientSeed, nonce); // 1..TOTAL
-        const picked = pickFromRanges(rollValue, rangeTable);
-        const sourceItem = caseData.items.find((it) => String(it._id) === String(picked.itemId));
-        const itemWithUniqueId = addUniqueInfoToItem(sourceItem);
-        winningItems.push(itemWithUniqueId);
-        draws.push({ nonce, roll: rollValue, itemId: picked.itemId, uniqueId: itemWithUniqueId.uniqueId });
-      }
-
-      // charge the cost, add the items and write the ledger row together: a failed row
-      // rolls the charge back, so the player is never charged without a record
-      const updatedUser = await runAtomic(async (session) => {
-        const filter = { _id: user._id, walletBalance: { $gte: cost } };
-        const update = {
-          $inc: { walletBalance: -cost, xp: cost * 5 },
-          $push: { inventory: { $each: winningItems.map(toInventoryEntry) } },
-        };
-        // the push has just made this inventory bigger; handing it back would cost more
-        // than the opening did
-        const options = { new: true, projection: WITHOUT_INVENTORY, session };
-
-        // spend the openings in the same update that hands over the items, and require
-        // the count to still cover it, so two concurrent opens cannot overdraw one grant
-        if (grant) {
-          filter.freeOpens = {
-            $elemMatch: { grantId: grant.grantId, remaining: { $gte: quantityToOpen } },
-          };
-          update.$inc["freeOpens.$[g].remaining"] = -quantityToOpen;
-          options.arrayFilters = [
-            { "g.grantId": grant.grantId, "g.remaining": { $gte: quantityToOpen } },
-          ];
-        }
-
-        const u = await User.findOneAndUpdate(filter, update, options);
-        if (!u) return null;
-        // a gift open moves no coins, so it gets no ledger row: the ledger records
-        // balance changes and a zero one would only be noise
-        if (cost > 0) {
-          await recordTransaction(
-            {
-              userId: user._id,
-              type: TX.CASE_OPEN,
-              direction: "debit",
-              amount: cost,
-              balanceAfter: u.walletBalance,
-              meta: { caseId: caseData._id, caseTitle: caseData.title, quantity: quantityToOpen },
-            },
-            session
-          );
-        }
-        return u;
+      const result = await openCase({
+        user: req.user,
+        caseId: req.params.id,
+        quantity: req.body.quantity,
+        grantId: req.body.grantId,
       });
-
-      if (!updatedUser) {
-        return res.status(400).json({ message: "Insufficient balance" });
-      }
-
-      // record one provably-fair audit roll per open (after the charge commits)
-      const rollIds = [];
-      for (const d of draws) {
-        const rec = await rolls.recordRoll({
-          game: "case",
-          userId: user._id,
-          seedId: reserved.seedId,
-          clientSeed: reserved.clientSeed,
-          serverSeedHash: reserved.serverSeedHash,
-          nonce: d.nonce,
-          roll: d.roll,
-          total: TOTAL,
-          caseId: caseData._id,
-          caseConfigVersion: configVersion,
-          caseConfigHash: configHash,
-          itemId: d.itemId,
-          uniqueId: d.uniqueId,
-        });
-        rollIds.push(rec.rollId);
-      }
-
-      const newLevel = calculateLevelFromXp(updatedUser.xp);
-      if (newLevel !== updatedUser.level) {
-        updatedUser.level = newLevel;
-        await User.updateOne({ _id: user._id }, { $set: { level: newLevel } });
-        referrals.maybePayReferralMilestone(user._id, newLevel).catch(() => {});
-      }
-
-      const winnerUser = {
-        name: user.username,
-        id: user._id,
-        profilePicture: user.profilePicture,
-        badge: badges.wornBadge(user)
-      }
-
-      // Emit the caseOpened event
-      io.emit("caseOpened", {
-        winningItems: winningItems,
-        user: winnerUser,
-        caseImage: caseData.image,
-      });
-
-      // the fan boards are a ten-minute snapshot, so a player who just pulled the
-      // character they pinned would read the old count next to their new inventory
-      await fandom.touch(user._id, winningItems.map((item) => item._id));
-
-      res.json({
-        items: winningItems.map((i, idx) => ({
-          ...i,
-          sellValue: sellValue(i.baseValue),
-          rollId: rollIds[idx],
-        })),
-      });
-
-      const userDataPayload = {
-        walletBalance: updatedUser.walletBalance,
-        xp: updatedUser.xp,
-        level: updatedUser.level,
-      }
-      io.to(user._id.toString()).emit('userDataUpdated', userDataPayload);
-
+      if (!result.ok) return res.status(result.status).json({ message: result.message });
+      res.json({ items: result.items });
     } catch (error) {
       console.error(error);
       res.status(500).json({ message: "Internal server error" });
     }
   });
+
 
   // Upgrade items
   router.post("/upgrade", isAuthenticated, async (req, res) => {


### PR DESCRIPTION
Groundwork for opening cases from the Discord bot. **No behaviour change.**

## Problem

The whole opening lived inside `router.post("/openCase/:id")`: nonce reservation, the committed range table, the draw, the atomic charge-and-hand-over, the ledger row, the audit rolls, the level-up, the feed emit. Around 180 lines, all of it reaching `req.user`.

The bot has a Discord id, not a JWT. Opening from there meant either a second path through the money, which drifts from this one the first time either changes, or this.

## Change

`games/openCase.js` holds it, copied rather than rewritten. The route is now twelve lines that turn a refusal into a status code.

Two deliberate differences:

- It reaches socket.io through `realtime.getIo()` instead of the router factory's closure, because the bot has no factory to close over. `index.js` sets that at boot, before any request.
- `source` rides along to the `caseOpened` payload when given, the way `upgrade` already marks its own drops, so the ticker can show where an opening happened.

Ten imports in `gamesRoutes.js` became dead and are gone.

## Why this is safe to believe

The existing suite already covers this path properly: `api.test.js` (opening), `dailyGift.test.js` (grants, including two concurrent opens racing one grant), `openCasePF.test.js` (provable fairness), `transactions.test.js` (the ledger), `fandom.test.js` (the board touch). All pass unchanged.

The one part nothing asserted was the live-feed emit, which is exactly what the next change rides on, so `openCaseShared.test.js` adds 8 cases: charge and ledger, insufficient funds charging nothing, one roll per opening tied to its item, the quantity bounds, the feed payload with and without a source, the opener's own balance push, and opening with no socket server attached.

Backend 1,005 passing.