### PR TITLE
feat(discord): the backend half of opening a case from the bot

### DIFF
--- a/backend/__tests__/integration/discordOpen.test.js
+++ b/backend/__tests__/integration/discordOpen.test.js
@@ -1,0 +1,277 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+process.env.DISCORD_BOT_SECRET = "bot-secret-for-tests";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+const Item = require("../../models/Item");
+const Case = require("../../models/Case");
+const Roll = require("../../models/Roll");
+const Transaction = require("../../models/Transaction");
+const DiscordOpen = require("../../models/DiscordOpen");
+const realtime = require("../../utils/realtime");
+const { recomputeCaseValues } = require("../../utils/itemValue");
+
+const SECRET = process.env.DISCORD_BOT_SECRET;
+const DISCORD_EPOCH = 1420070400000;
+
+let app;
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(async () => {
+  realtime.setIo(null);
+  await clearDb();
+});
+afterAll(teardownDb);
+
+const snowflakeFor = (date) => String(BigInt(date.getTime() - DISCORD_EPOCH) << 22n);
+const oldEnough = () => snowflakeFor(new Date(Date.now() - 400 * 86400000));
+const bot = (req) => req.set("x-bot-secret", SECRET);
+
+let ticket = 0;
+const interaction = () => `interaction-${(ticket += 1)}-${uniqueSuffix()}`;
+
+async function makeUser(walletBalance = 5000) {
+  const s = uniqueSuffix();
+  return User.create({
+    username: `user-${s}`,
+    email: `user-${s}@example.com`,
+    password: "x",
+    walletBalance,
+  });
+}
+
+// the bot's own flow, so the link is real rather than written straight onto the document
+async function linkUser(user, discordId) {
+  const started = await bot(request(app).post("/discord/link/start")).send({ discordId, discordName: "someone" });
+  const jwt = require("jsonwebtoken");
+  const token = jwt.sign({ userId: user._id.toString() }, process.env.JWT_SECRET, { expiresIn: "1h" });
+  await request(app)
+    .post("/discord/link/complete")
+    .set("Authorization", `Bearer ${token}`)
+    .send({ code: started.body.code });
+}
+
+async function makeCase(price = 100, title) {
+  const s = uniqueSuffix();
+  const items = await Item.create([
+    { name: `cheap-${s}`, image: "c.png", rarity: "1", baseValue: 10 },
+    { name: `dear-${s}`, image: "d.png", rarity: "5", baseValue: 900 },
+  ]);
+  const one = await Case.create({
+    title: title || `case-${s}`,
+    image: "case.png",
+    price,
+    category: "Touhou",
+    items: items.map((item) => item._id),
+  });
+  await recomputeCaseValues(one._id);
+  return one;
+}
+
+const open = (body) => bot(request(app).post("/discord/open")).send(body);
+
+// the money itself runs through games/openCase.js, the same path the site uses. what is
+// tested here is everything wrapped around it.
+describe("opening a case from discord", () => {
+  it("charges the linked account and hands the items over", async () => {
+    const user = await makeUser(5000);
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const one = await makeCase(300);
+
+    const res = await open({ discordId, interactionId: interaction(), caseId: one._id, quantity: 2 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.cost).toBe(600);
+    expect(res.body.walletBalance).toBe(4400);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.items[0].rollId).toEqual(expect.any(String));
+
+    const after = await User.findById(user._id).lean();
+    expect(after.walletBalance).toBe(4400);
+    expect(after.inventory).toHaveLength(2);
+  });
+
+  it("marks the drop as having come from discord", async () => {
+    const emitted = [];
+    realtime.setIo({ emit: (event, payload) => emitted.push({ event, payload }), to: () => ({ emit: () => {} }) });
+
+    const user = await makeUser();
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const one = await makeCase(100);
+    await open({ discordId, interactionId: interaction(), caseId: one._id, quantity: 1 });
+
+    expect(emitted.find((x) => x.event === "caseOpened").payload.source).toBe("discord");
+  });
+
+  // a gateway resume replays whatever the bot missed while it was disconnected, so one
+  // /open can arrive twice. this is the guard, and it is a claim rather than a check.
+  it("charges once when the same interaction arrives twice", async () => {
+    const user = await makeUser(5000);
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const one = await makeCase(400);
+    const id = interaction();
+
+    const first = await open({ discordId, interactionId: id, caseId: one._id, quantity: 1 });
+    const again = await open({ discordId, interactionId: id, caseId: one._id, quantity: 1 });
+
+    expect(first.status).toBe(200);
+    expect(again.status).toBe(409);
+    expect(again.body.duplicate).toBe(true);
+
+    const after = await User.findById(user._id).lean();
+    expect(after.walletBalance).toBe(4600);
+    expect(after.inventory).toHaveLength(1);
+    expect(await Transaction.countDocuments({ userId: user._id })).toBe(1);
+  });
+
+  it("charges once when both arrive at the same moment", async () => {
+    const user = await makeUser(5000);
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const one = await makeCase(400);
+    const id = interaction();
+
+    const both = await Promise.all([
+      open({ discordId, interactionId: id, caseId: one._id, quantity: 1 }),
+      open({ discordId, interactionId: id, caseId: one._id, quantity: 1 }),
+    ]);
+
+    expect(both.filter((res) => res.status === 200)).toHaveLength(1);
+    const after = await User.findById(user._id).lean();
+    expect(after.inventory).toHaveLength(1);
+  });
+
+  // an opening that never happened must not burn the interaction, or somebody who tops up
+  // and presses the button again is told they already opened it
+  it("frees the interaction again when the opening was refused", async () => {
+    const user = await makeUser(10);
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const one = await makeCase(900);
+    const id = interaction();
+
+    const broke = await open({ discordId, interactionId: id, caseId: one._id, quantity: 1 });
+    expect(broke.status).toBe(400);
+    expect(await DiscordOpen.countDocuments({ interactionId: id })).toBe(0);
+
+    await User.updateOne({ _id: user._id }, { $set: { walletBalance: 5000 } });
+    expect((await open({ discordId, interactionId: id, caseId: one._id, quantity: 1 })).status).toBe(200);
+  });
+
+  it("turns away a discord user with no account", async () => {
+    const one = await makeCase(100);
+    const res = await open({ discordId: oldEnough(), interactionId: interaction(), caseId: one._id, quantity: 1 });
+    expect(res.status).toBe(404);
+  });
+
+  it("keeps the dearest cases on the site", async () => {
+    const user = await makeUser(10000000);
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const dear = await makeCase(999999);
+
+    const res = await open({ discordId, interactionId: interaction(), caseId: dear._id, quantity: 1 });
+    expect(res.status).toBe(403);
+    const after = await User.findById(user._id).lean();
+    expect(after.inventory).toHaveLength(0);
+  });
+
+  it("holds the quantity between one and five", async () => {
+    const user = await makeUser();
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const one = await makeCase(10);
+    for (const quantity of [0, 6, 2.5]) {
+      expect((await open({ discordId, interactionId: interaction(), caseId: one._id, quantity })).status).toBe(400);
+    }
+  });
+
+  it("needs the bot secret like everything else", async () => {
+    const one = await makeCase(100);
+    const res = await request(app).post("/discord/open").send({ discordId: oldEnough(), interactionId: interaction(), caseId: one._id, quantity: 1 });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("the spin for someone with no account", () => {
+  it("draws a real item, hands over nothing and stores nothing", async () => {
+    const one = await makeCase(100);
+    const before = await Roll.countDocuments();
+
+    const res = await bot(request(app).get(`/discord/preview/${one._id}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.kept).toBe(false);
+    expect(res.body.item.name).toEqual(expect.any(String));
+    expect(res.body.item.value).toEqual(expect.any(Number));
+    expect(res.body.reel.length).toBeGreaterThan(0);
+    // no nonce spent, no audit row, nothing to reconcile later
+    expect(await Roll.countDocuments()).toBe(before);
+  });
+
+  it("draws from the case it was asked about", async () => {
+    const one = await makeCase(100);
+    const names = (await Item.find({ _id: { $in: one.items } }).lean()).map((item) => item.name);
+    const res = await bot(request(app).get(`/discord/preview/${one._id}`));
+    expect(names).toContain(res.body.item.name);
+  });
+
+  it("will not preview a case the bot could not open either", async () => {
+    const dear = await makeCase(999999);
+    expect((await bot(request(app).get(`/discord/preview/${dear._id}`))).status).toBe(403);
+  });
+});
+
+describe("what autocomplete offers", () => {
+  it("lists only the cases the bot is allowed to open", async () => {
+    await makeCase(50);
+    await makeCase(999999);
+
+    const res = await bot(request(app).get("/discord/cases"));
+    expect(res.status).toBe(200);
+    expect(res.body.cases.length).toBeGreaterThan(0);
+    expect(res.body.cases.every((one) => one.price <= res.body.maxPrice)).toBe(true);
+  });
+
+  it("narrows on what has been typed", async () => {
+    const s = uniqueSuffix();
+    await makeCase(50, `Lunatic ${s}`);
+    await makeCase(60, `Festival ${s}`);
+
+    const res = await bot(request(app).get(`/discord/cases?q=Lunatic ${s}`));
+    expect(res.body.cases).toHaveLength(1);
+    expect(res.body.cases[0].title).toContain("Lunatic");
+  });
+
+  // the box is free text, so a bracket is something a player typed, not a pattern
+  it("treats a typed bracket as text", async () => {
+    const s = uniqueSuffix();
+    await makeCase(50, `Special (Package) ${s}`);
+    const res = await bot(request(app).get(`/discord/cases?q=${encodeURIComponent(`Special (Package) ${s}`)}`));
+    expect(res.status).toBe(200);
+    expect(res.body.cases).toHaveLength(1);
+  });
+
+  it("leads with what this player opened last", async () => {
+    const user = await makeUser(50000);
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const cheap = await makeCase(20, `aaa-cheap-${uniqueSuffix()}`);
+    const other = await makeCase(80, `zzz-other-${uniqueSuffix()}`);
+
+    // the dearer one is opened, so price order alone would not put it first
+    await open({ discordId, interactionId: interaction(), caseId: other._id, quantity: 1 });
+
+    const res = await bot(request(app).get(`/discord/cases?discordId=${discordId}`));
+    expect(String(res.body.cases[0].id)).toBe(String(other._id));
+    expect(res.body.cases.map((one) => String(one.id))).toContain(String(cheap._id));
+  });
+});

--- a/backend/models/DiscordOpen.js
+++ b/backend/models/DiscordOpen.js
@@ -1,0 +1,22 @@
+const mongoose = require("mongoose");
+
+// one row per opening the bot has already run, keyed by the discord interaction that
+// asked for it.
+//
+// discord does not retry a gateway interaction the way it retries a webhook, but a
+// session resume replays whatever the bot missed while it was disconnected. That is a
+// narrow window in which one /open could arrive twice and charge twice, which is not a
+// thing to leave to luck on a money path.
+//
+// nothing but the id is kept. a replayed interaction is already past its three second
+// reply window, so there is nothing to render and nothing worth storing to render it.
+const DiscordOpenSchema = new mongoose.Schema({
+  interactionId: { type: String, required: true, unique: true },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+// long enough to cover any resume worth worrying about, short enough to cost nothing
+DiscordOpenSchema.index({ createdAt: 1 }, { expireAfterSeconds: 3600 });
+
+module.exports = mongoose.model("DiscordOpen", DiscordOpenSchema);

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -6,9 +6,16 @@ const router = express.Router();
 const User = require("../models/User");
 const DiscordLink = require("../models/DiscordLink");
 const FanBoard = require("../models/FanBoard");
+const Case = require("../models/Case");
+const Roll = require("../models/Roll");
+const DiscordOpen = require("../models/DiscordOpen");
 const { isAuthenticated } = require("../middleware/authMiddleware");
 const { visible } = require("../utils/visibility");
 const badges = require("../utils/badges");
+const { openCase, MAX_PER_OPEN } = require("../games/openCase");
+const { pickFromRanges, TOTAL } = require("../utils/provablyFair");
+const { buildRangeTable } = require("../utils/caseRanges");
+const { sellValue } = require("../utils/itemValue");
 
 // how long a link code stays redeemable. long enough to switch to a browser and log in,
 // short enough that a code read off someone else's screen is worthless by the time it lands.
@@ -37,6 +44,9 @@ const CARD_FIELDS = {
   discordId: 1,
   discordName: 1,
 };
+
+// a player types this into autocomplete, so it is data, never pattern
+const escapeRegex = (text) => String(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 // no ambiguous glyphs: this gets read off a phone screen and typed back
 const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -327,6 +337,161 @@ async function oauthCallback(req, res) {
   }
 }
 
+// the dearest cases stay on the site. a chat window is a fine place to pull a character
+// out of a 12k case and a poor one to spend a million, and the reveal that makes an
+// expensive opening worth watching does not survive the trip into an embed.
+const MAX_CASE_PRICE = Number(process.env.DISCORD_MAX_CASE_PRICE || 20000);
+// how many the autocomplete can show
+const CASE_CHOICES = 25;
+
+const publicCase = (one) => ({
+  id: one._id,
+  title: one.title,
+  price: one.price || 0,
+  image: one.image || null,
+  category: one.category || "",
+});
+
+// what the bot offers in autocomplete. with an empty box it leads with the cases this
+// player last opened, which is what makes opening the same one again quick to type.
+router.get("/cases", botOnly, async (req, res) => {
+  try {
+    const search = String(req.query.q || "").trim();
+    const filter = { price: { $lte: MAX_CASE_PRICE } };
+    if (search) {
+      filter.title = { $regex: escapeRegex(search), $options: "i" };
+    }
+
+    const found = await Case.find(filter, { title: 1, price: 1, image: 1, category: 1 })
+      .sort({ price: 1 })
+      .limit(CASE_CHOICES * 2)
+      .lean();
+
+    let ordered = found;
+    const discordId = String(req.query.discordId || "");
+    if (!search && discordId) {
+      const user = await User.findOne({ discordId }, { _id: 1 }).lean();
+      if (user) {
+        // rolls carry the case and are already indexed on user and time, and they expire
+        // themselves, so "recently opened" costs one bounded lookup and no new storage
+        const recent = await Roll.find({ userId: user._id, game: "case" }, { caseId: 1 })
+          .sort({ createdAt: -1 })
+          .limit(40)
+          .lean();
+        const rank = new Map();
+        for (const roll of recent) {
+          const key = String(roll.caseId);
+          if (!rank.has(key)) rank.set(key, rank.size);
+        }
+        ordered = [...found].sort(
+          (a, b) => (rank.has(String(a._id)) ? rank.get(String(a._id)) : 999) -
+                    (rank.has(String(b._id)) ? rank.get(String(b._id)) : 999)
+        );
+      }
+    }
+
+    res.json({ cases: ordered.slice(0, CASE_CHOICES).map(publicCase), maxPrice: MAX_CASE_PRICE });
+  } catch (err) {
+    console.error("discord cases:", err.message);
+    res.status(500).json({ message: "Could not load the cases" });
+  }
+});
+
+// a spin for somebody with no account. it draws on the case's real committed odds so the
+// answer is honest, consumes no nonce, stores nothing and hands nothing over. the point
+// is to show what the game is, and the bot must say plainly that the item was not kept.
+router.get("/preview/:caseId", botOnly, async (req, res) => {
+  try {
+    const one = await Case.findById(req.params.caseId).populate("items");
+    if (!one) return res.status(404).json({ message: "Case not found" });
+    if ((one.price || 0) > MAX_CASE_PRICE) return res.status(403).json({ message: "That case is site only" });
+
+    let rangeTable = one.rangeTable;
+    if (!rangeTable || !rangeTable.length) rangeTable = buildRangeTable(one).rangeTable;
+
+    // not provably fair, and it does not need to be: nothing is won, so there is nothing
+    // to prove. the odds are the case's own, which is the part that has to be true.
+    const drawn = pickFromRanges(crypto.randomInt(1, TOTAL + 1), rangeTable);
+    const item = one.items.find((it) => String(it._id) === String(drawn.itemId));
+    if (!item) return res.status(500).json({ message: "Case has no items" });
+
+    res.json({
+      kept: false,
+      case: publicCase(one),
+      item: {
+        name: item.name,
+        image: item.image,
+        rarity: item.rarity,
+        value: sellValue(item.baseValue),
+      },
+      reel: one.items.slice(0, 12).map((it) => it.name),
+    });
+  } catch (err) {
+    console.error("discord preview:", err.message);
+    res.status(500).json({ message: "Could not spin that case" });
+  }
+});
+
+// the real thing, for a linked account, through the same path the site uses
+router.post("/open", botOnly, async (req, res) => {
+  try {
+    const discordId = String((req.body && req.body.discordId) || "");
+    const interactionId = String((req.body && req.body.interactionId) || "");
+    const caseId = String((req.body && req.body.caseId) || "");
+    // `|| 1` would turn a zero into a one, which is the one bad quantity that looks fine
+    const asked = req.body ? req.body.quantity : undefined;
+    const quantity = asked === undefined || asked === null ? 1 : Number(asked);
+    if (!discordId || !interactionId || !caseId) {
+      return res.status(400).json({ message: "Missing discordId, interactionId or caseId" });
+    }
+    if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_PER_OPEN) {
+      return res.status(400).json({ message: `Open between 1 and ${MAX_PER_OPEN} at a time` });
+    }
+
+    const user = await User.findOne(visible({ discordId }), { password: 0, inventory: 0 });
+    if (!user) return res.status(404).json({ message: "Not linked" });
+
+    const one = await Case.findById(caseId, { price: 1, title: 1 }).lean();
+    if (!one) return res.status(404).json({ message: "Case not found" });
+    if ((one.price || 0) > MAX_CASE_PRICE) {
+      return res.status(403).json({ message: "That case can only be opened on the site" });
+    }
+
+    // claim the interaction before charging. the unique index is what makes this a claim
+    // rather than a check, so a replayed interaction loses the race instead of charging.
+    try {
+      await DiscordOpen.create({ interactionId, userId: user._id });
+    } catch (err) {
+      if (err && err.code === 11000) return res.status(409).json({ message: "Already opened", duplicate: true });
+      throw err;
+    }
+
+    const result = await openCase({ user, caseId, quantity, source: "discord" });
+    if (!result.ok) {
+      // it never happened, so the interaction is free to be tried again
+      await DiscordOpen.deleteOne({ interactionId }).catch(() => {});
+      return res.status(result.status).json({ message: result.message });
+    }
+
+    res.json({
+      case: { id: one._id, title: one.title, price: one.price || 0 },
+      cost: result.cost,
+      walletBalance: result.walletBalance,
+      level: result.level,
+      items: result.items.map((item) => ({
+        name: item.name,
+        image: item.image,
+        rarity: item.rarity,
+        value: item.sellValue,
+        rollId: item.rollId,
+      })),
+    });
+  } catch (err) {
+    console.error("discord open:", err.message);
+    res.status(500).json({ message: "Could not open that case" });
+  }
+});
+
 router.get("/showcase/:discordId", botOnly, async (req, res) => {
   try {
     const user = await User.findOne(visible({ discordId: String(req.params.discordId) }), CARD_FIELDS).lean();
@@ -345,7 +510,7 @@ router.get("/topfan/:name", botOnly, async (req, res) => {
     const guildId = String(req.query.guild || "");
     if (!guildId) return res.status(400).json({ message: "Missing guild" });
 
-    const escaped = String(req.params.name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escaped = escapeRegex(req.params.name);
     const board = await FanBoard.findOne(
       { name: new RegExp("^" + escaped + "$", "i") },
       { name: 1, image: 1, rarity: 1, ranks: 1, fanCount: 1, topCount: 1 }


### PR DESCRIPTION
Follows the extraction in #252. Three routes, all behind `x-bot-secret`. No bot changes yet, so nothing is reachable by a player until the command ships.

## `POST /discord/open`

Runs `games/openCase.js` — the same path the site uses — with `source: "discord"`, so the live ticker can mark where a drop came from.

**It claims the interaction id before charging.** Discord does not retry a gateway interaction the way it retries a webhook, but a session resume replays whatever the bot missed while disconnected, so one `/open` can arrive twice. A unique index on `interactionId` makes that a claim rather than a check, so the replay loses the race instead of charging. Two tests cover it: sequential and simultaneous.

A refused opening **releases the claim**, otherwise somebody who tops up and presses the button again is told they already opened it.

## `POST /discord/preview`

The spin for somebody with no account. Draws on the case's own committed range table so the odds are honest, spends no nonce, writes no roll and hands nothing over. The bot has to say plainly that the item was not kept.

## `GET /discord/cases`

Feeds autocomplete. 64 cases is well past Discord's 25-choice cap, so this filters, and with an empty box it leads with whatever this player opened last — read off `rolls`, which is already indexed on user and time and expires itself, so it costs one bounded lookup and no new storage.

## Price cap

`DISCORD_MAX_CASE_PRICE`, default 20,000. Every character case is under it; the expensive Counter-Strike cases are not. A chat window is a fine place to pull a character out of a 12k case and a poor one to spend a million, and the reveal that makes an expensive opening worth watching does not survive the trip into an embed.

## A bug the tests caught

`Number(req.body.quantity || 1)` turned a quantity of **0** into 1, which is the one bad quantity that looks fine. Fixed and covered.

## Tests

16 new: charging, the discord source reaching the feed, both duplicate-interaction races, the claim being released on refusal, unlinked, the price cap, quantity bounds, the secret, the preview granting and storing nothing, and autocomplete filtering, escaping a typed bracket, and recency ordering.

Backend 1,021 passing.