### PR TITLE
feat(discord): open a case from the bot, spinning

### DIFF
--- a/backend/__tests__/integration/discordOpen.test.js
+++ b/backend/__tests__/integration/discordOpen.test.js
@@ -166,10 +166,25 @@ describe("opening a case from discord", () => {
     expect((await open({ discordId, interactionId: id, caseId: one._id, quantity: 1 })).status).toBe(200);
   });
 
-  it("turns away a discord user with no account", async () => {
+  // the bot spins a demo for somebody with no account and must not do that for a case
+  // that does not exist, so the two 404s have to be told apart by something other than
+  // their wording
+  it("turns away a discord user with no account, and says that is why", async () => {
     const one = await makeCase(100);
     const res = await open({ discordId: oldEnough(), interactionId: interaction(), caseId: one._id, quantity: 1 });
     expect(res.status).toBe(404);
+    expect(res.body.notLinked).toBe(true);
+  });
+
+  it("does not call a missing case a missing account", async () => {
+    const user = await makeUser();
+    const discordId = oldEnough();
+    await linkUser(user, discordId);
+    const gone = new (require("mongoose").Types.ObjectId)();
+
+    const res = await open({ discordId, interactionId: interaction(), caseId: gone, quantity: 1 });
+    expect(res.status).toBe(404);
+    expect(res.body.notLinked).toBeUndefined();
   });
 
   it("keeps the dearest cases on the site", async () => {

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -449,7 +449,9 @@ router.post("/open", botOnly, async (req, res) => {
     }
 
     const user = await User.findOne(visible({ discordId }), { password: 0, inventory: 0 });
-    if (!user) return res.status(404).json({ message: "Not linked" });
+    // flagged rather than left to the wording: the bot spins a demo for somebody with no
+    // account, and must not do that for a case that simply does not exist
+    if (!user) return res.status(404).json({ message: "Not linked", notLinked: true });
 
     const one = await Case.findById(caseId, { price: 1, title: 1 }).lean();
     if (!one) return res.status(404).json({ message: "Case not found" });

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -473,11 +473,23 @@ router.post("/open", botOnly, async (req, res) => {
       return res.status(result.status).json({ message: result.message });
     }
 
+    // the standing is what makes somebody else in the channel want to compete, and the
+    // sweep has just been told about this drop, so it costs one small projection
+    const standing = await User.findById(user._id, { fanRank: 1 }).lean();
+    const pulled = new Set(result.items.map((item) => item.name));
+    const fanRank =
+      standing && standing.fanRank && standing.fanRank.name && pulled.has(standing.fanRank.name)
+        ? { name: standing.fanRank.name, count: standing.fanRank.count, rank: standing.fanRank.rank, fans: standing.fanRank.fans }
+        : null;
+
     res.json({
       case: { id: one._id, title: one.title, price: one.price || 0 },
       cost: result.cost,
       walletBalance: result.walletBalance,
       level: result.level,
+      fanRank,
+      // what the bot spins past on the way to the answer
+      reel: (result.caseData.items || []).slice(0, 12).map((item) => item.name),
       items: result.items.map((item) => ({
         name: item.name,
         image: item.image,

--- a/bot/package.json
+++ b/bot/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "register": "node src/register.js",
-    "test": "node --test src/messages.test.js"
+    "test": "node --test src/messages.test.js src/spin.test.js"
   },
   "dependencies": {
     "discord.js": "^14.16.3",

--- a/bot/src/api.js
+++ b/bot/src/api.js
@@ -54,4 +54,16 @@ module.exports = {
   // fired and forgotten: being on a server board is not worth failing a command over
   seen: (discordId, guildId) =>
     post("/discord/seen", { discordId, guildId }).catch(() => {}),
+
+  cases: (query, discordId) => {
+    const params = new URLSearchParams();
+    if (query) params.set("q", query);
+    if (discordId) params.set("discordId", discordId);
+    const suffix = params.toString();
+    return get("/discord/cases" + (suffix ? `?${suffix}` : ""));
+  },
+  preview: (caseId) => get(`/discord/preview/${encodeURIComponent(caseId)}`),
+  // the interaction id is what stops one command charging twice if the gateway replays it
+  openCase: (discordId, interactionId, caseId, quantity) =>
+    post("/discord/open", { discordId, interactionId, caseId, quantity }),
 };

--- a/bot/src/api.js
+++ b/bot/src/api.js
@@ -12,9 +12,11 @@ const headers = () => ({
 const TIMEOUT_MS = 8000;
 
 class ApiError extends Error {
-  constructor(status, message) {
+  constructor(status, message, data) {
     super(message);
     this.status = status;
+    // the whole body, so a caller can branch on a flag rather than on the wording
+    this.data = data || {};
   }
 }
 
@@ -30,7 +32,7 @@ async function call(method, path, body) {
     });
     const text = await res.text();
     const data = text ? JSON.parse(text) : {};
-    if (!res.ok) throw new ApiError(res.status, data.message || "Request failed");
+    if (!res.ok) throw new ApiError(res.status, data.message || "Request failed", data);
     return data;
   } catch (err) {
     if (err.name === "AbortError") throw new ApiError(504, "The site did not answer in time");

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -52,8 +52,8 @@ async function runOpen(interaction, caseId, quantity) {
     opened = await api.openCase(interaction.user.id, interaction.id, caseId, quantity);
   } catch (err) {
     // no account is not a refusal here: it is the whole pitch. spin it anyway, keep
-    // nothing, and say so.
-    if (err.status === 404) demo = await api.preview(caseId);
+    // nothing, and say so. any other 404 is a real one and belongs to the caller.
+    if (err.status === 404 && err.data.notLinked) demo = await api.preview(caseId);
     else throw err;
   }
 

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -1,6 +1,7 @@
-const { SlashCommandBuilder, MessageFlags } = require("discord.js");
+const { SlashCommandBuilder, MessageFlags, ContainerBuilder, TextDisplayBuilder } = require("discord.js");
 const api = require("./api");
 const { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE } = require("./embeds");
+const { spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS } = require("./spin");
 
 // rejected in the bot's own memory, before any http call. spamming a command costs a map
 // lookup here rather than a query on a link that carries about 100 KB/s.
@@ -26,6 +27,67 @@ setInterval(() => {
 // reads as a refusal, and somebody has to answer "so how do I link it?" by hand
 const LINK_HINT = "Run `/link` to attach one, it takes about a minute.";
 const NOT_LINKED = `You have not linked a KaniCasino account yet. ${LINK_HINT}`;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const V2 = { flags: MessageFlags.IsComponentsV2 };
+
+// the components v2 flag cannot be added to a message that was made without it, so the
+// first frame is the reply itself rather than a deferral. it costs nothing to draw and
+// buys the whole three second window for the call behind it.
+const OPENING = () =>
+  new ContainerBuilder()
+    .setAccentColor(0x4a4a5a)
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent("Opening…"));
+
+// shared by the command and by the "open another" button, which is the quickest way to
+// open the same case again and the reason the command only has to be typed once
+async function runOpen(interaction, caseId, quantity) {
+  if (!interaction.replied && !interaction.deferred) {
+    await interaction.reply({ components: [OPENING()], ...V2 });
+  }
+
+  let opened = null;
+  let demo = null;
+  try {
+    opened = await api.openCase(interaction.user.id, interaction.id, caseId, quantity);
+  } catch (err) {
+    // no account is not a refusal here: it is the whole pitch. spin it anyway, keep
+    // nothing, and say so.
+    if (err.status === 404) demo = await api.preview(caseId);
+    else throw err;
+  }
+
+  const caseTitle = opened ? opened.case.title : demo.case.title;
+  const names = (opened ? opened.reel : demo.reel) || [];
+
+  for (let frame = 0; frame < FRAMES; frame += 1) {
+    await interaction.editReply({ components: [spinningFrame(caseTitle, names, frame)], ...V2 });
+    await sleep(FRAME_MS);
+  }
+
+  if (demo) {
+    await interaction.editReply({ components: [demoFrame({ item: demo.item, caseTitle })], ...V2 });
+    return;
+  }
+
+  // one card, carrying the rarest of the pull, the way the site's own feed does it
+  const best = opened.items.reduce((a, b) => (Number(b.rarity) > Number(a.rarity) ? b : a));
+  await interaction.editReply({
+    components: [
+      revealFrame({
+        item: best,
+        caseTitle,
+        caseId: opened.case.id,
+        ownerId: interaction.user.id,
+        balance: opened.walletBalance,
+        fanRank: opened.fanRank,
+        others: opened.items.length - 1,
+      }),
+    ],
+    ...V2,
+  });
+}
+
 const theyAreNotLinked = (name) =>
   `**${name}** has not linked a KaniCasino account yet. They can attach one with \`/link\`.`;
 
@@ -48,6 +110,33 @@ const commands = [
         return;
       }
       await interaction.editReply({ embeds: [linkEmbed(link)] });
+    },
+  },
+  {
+    data: new SlashCommandBuilder()
+      .setName("open")
+      .setDescription("Open a case")
+      .addStringOption((option) =>
+        option
+          .setName("case")
+          .setDescription("Which case. Start typing, or pick the one you opened last.")
+          .setRequired(true)
+          .setAutocomplete(true)
+      )
+      .addIntegerOption((option) =>
+        option.setName("quantity").setDescription("How many, up to 5").setMinValue(1).setMaxValue(5)
+      ),
+    // 64 cases is well past discord's 25 choice cap, so the list is filtered server side.
+    // an empty box leads with whatever this player opened last.
+    async autocomplete(interaction) {
+      const typed = interaction.options.getFocused();
+      const { cases } = await api.cases(typed, interaction.user.id);
+      await interaction.respond(
+        cases.map((one) => ({ name: `${one.title}  ·  K₽ ${one.price.toLocaleString("en-US")}`.slice(0, 100), value: String(one.id) }))
+      );
+    },
+    async run(interaction) {
+      await runOpen(interaction, interaction.options.getString("case"), interaction.options.getInteger("quantity") || 1);
     },
   },
   {
@@ -128,4 +217,4 @@ const commands = [
   },
 ];
 
-module.exports = { commands, onCooldown };
+module.exports = { commands, onCooldown, runOpen };

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -3,7 +3,7 @@ require("dotenv").config();
 const { Client, Events, GatewayIntentBits, MessageFlags } = require("discord.js");
 const api = require("./api");
 const { noticeEmbed } = require("./embeds");
-const { commands, onCooldown } = require("./commands");
+const { commands, onCooldown, runOpen } = require("./commands");
 
 const REQUIRED = ["DISCORD_BOT_TOKEN", "DISCORD_BOT_SECRET", "API_KEY"];
 const missing = REQUIRED.filter((key) => !process.env[key]);
@@ -27,7 +27,48 @@ const reply = async (interaction, text) => {
   }
 };
 
+// the box has three seconds to fill, and an empty list is a better answer than a spinner
+// that never resolves, so a failure here is swallowed rather than logged loudly
+async function suggest(interaction) {
+  const command = byName.get(interaction.commandName);
+  if (!command || !command.autocomplete) return;
+  try {
+    await command.autocomplete(interaction);
+  } catch (err) {
+    await interaction.respond([]).catch(() => {});
+  }
+}
+
+// "open another" on somebody else's reveal would charge the clicker for a case they did
+// not choose, so the owner rides in the custom id and only they can press it
+async function pressed(interaction) {
+  const [action, caseId, ownerId] = interaction.customId.split(":");
+  if (action !== "open") return;
+  if (interaction.user.id !== ownerId) {
+    return interaction.reply({
+      embeds: [noticeEmbed("That one is not yours. Run `/open` and it will be.")],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+  const wait = onCooldown(interaction.user.id, "open");
+  if (wait) {
+    return interaction.reply({
+      embeds: [noticeEmbed(`Give it ${wait}s.`)],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+  await runOpen(interaction, caseId, 1);
+}
+
 client.on(Events.InteractionCreate, async (interaction) => {
+  try {
+    if (interaction.isAutocomplete()) return await suggest(interaction);
+    if (interaction.isButton()) return await pressed(interaction);
+  } catch (err) {
+    console.error("bot interaction:", err.message);
+    return reply(interaction, "The site did not answer. Try again in a moment.");
+  }
+
   if (!interaction.isChatInputCommand()) return;
   const command = byName.get(interaction.commandName);
   if (!command) return;

--- a/bot/src/spin.js
+++ b/bot/src/spin.js
@@ -1,0 +1,116 @@
+const {
+  ContainerBuilder,
+  TextDisplayBuilder,
+  SeparatorBuilder,
+  SectionBuilder,
+  ThumbnailBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require("discord.js");
+
+const SITE = (process.env.SITE_URL || "https://kanicasino.com").replace(/\/$/, "");
+
+// the five the site paints items with, so a colour means the same thing in both places
+const RARITY_COLOR = { "1": 0x4b69ff, "2": 0x8847ff, "3": 0xd32ce6, "4": 0xeb4b4b, "5": 0xffff6e };
+const RARITY_NAME = { "1": "Common", "2": "Rare", "3": "Epic", "4": "Ultra Rare", "5": "Unique" };
+// while it is still spinning nothing has been decided, so it wears no rarity
+const SPINNING = 0x4a4a5a;
+
+const colorOf = (rarity) => RARITY_COLOR[String(rarity)] || SPINNING;
+const nameOf = (rarity) => RARITY_NAME[String(rarity)] || "";
+const num = (value) => Number(value || 0).toLocaleString("en-US");
+
+// how many names are visible at once, and which of them sits under the marker
+const WINDOW = 5;
+const MIDDLE = 2;
+
+// a row of names that shifts one place per frame while the marker stays put, which is
+// what reads as movement in a message that can only be redrawn a few times
+function reelRow(names, offset, landed) {
+  const pool = names && names.length ? names : ["?"];
+  const shown = [];
+  for (let i = 0; i < WINDOW; i += 1) {
+    const name = pool[(offset + i) % pool.length];
+    shown.push(name.length > 12 ? `${name.slice(0, 11)}…` : name);
+  }
+  if (landed) shown[MIDDLE] = landed.length > 12 ? `${landed.slice(0, 11)}…` : landed;
+  return "```\n" + shown.map((name, i) => (i === MIDDLE ? `▐ ${name} ▌` : ` ${name} `)).join("│") + "\n```";
+}
+
+// how many times the reel is redrawn before it stops, and how long each is held. every
+// redraw is a call to discord and none to the site: the outcome was decided before the
+// first frame, exactly as the reel on the site is animated to an answer it already has.
+const FRAMES = 3;
+const FRAME_MS = 550;
+
+function spinningFrame(caseTitle, names, offset) {
+  return new ContainerBuilder()
+    .setAccentColor(SPINNING)
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${caseTitle}**`))
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(reelRow(names, offset)));
+}
+
+const buttons = (...rows) => new ActionRowBuilder().addComponents(...rows.filter(Boolean));
+
+// a section is only valid with an accessory, so an item carrying no art gets a plain
+// heading. building it the other way throws, and discord does not say so until a player
+// pulls the one item in the catalogue that has no picture.
+const isArt = (url) => typeof url === "string" && /^https?:\/\//.test(url);
+
+function addHeading(container, item, caseTitle) {
+  const content = `### ${item.name}\n${nameOf(item.rarity)} · ${caseTitle}`;
+  if (isArt(item.image)) {
+    container.addSectionComponents(
+      new SectionBuilder()
+        .addTextDisplayComponents(new TextDisplayBuilder().setContent(content))
+        .setThumbnailAccessory(new ThumbnailBuilder().setURL(item.image))
+    );
+  } else {
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(content));
+  }
+  return container;
+}
+
+function revealFrame({ item, caseTitle, caseId, ownerId, balance, fanRank, others }) {
+  const container = new ContainerBuilder().setAccentColor(colorOf(item.rarity));
+
+  addHeading(container, item, caseTitle);
+  container.addSeparatorComponents(new SeparatorBuilder());
+
+  const lines = [`Worth **K₽ ${num(item.value)}** · you have **K₽ ${num(balance)}** left`];
+  if (others > 0) lines.push(`and ${others} more from this opening`);
+  if (fanRank) {
+    lines.push(
+      fanRank.rank === 1
+        ? `You hold **${num(fanRank.count)} ${fanRank.name}**, still **#1** of ${num(fanRank.fans)} fans`
+        : `You hold **${num(fanRank.count)} ${fanRank.name}**, **#${fanRank.rank}** of ${num(fanRank.fans)} fans`
+    );
+  }
+  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(lines.join("\n")));
+
+  container.addActionRowComponents(
+    buttons(
+      new ButtonBuilder().setCustomId(`open:${caseId}:${ownerId}`).setLabel("Open another").setStyle(ButtonStyle.Primary),
+      new ButtonBuilder().setLabel("Open it on the site").setStyle(ButtonStyle.Link).setURL(`${SITE}/case/${caseId}`)
+    )
+  );
+  return container;
+}
+
+// the same reveal for somebody with no account, saying plainly that it was not kept
+function demoFrame({ item, caseTitle }) {
+  const container = new ContainerBuilder().setAccentColor(colorOf(item.rarity));
+
+  addHeading(container, item, caseTitle);
+  container.addSeparatorComponents(new SeparatorBuilder());
+  container.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent("This was a demo spin. Create an account to keep the next rolls.")
+  );
+  container.addActionRowComponents(
+    buttons(new ButtonBuilder().setLabel("Create an account").setStyle(ButtonStyle.Link).setURL(SITE))
+  );
+  return container;
+}
+
+module.exports = { reelRow, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS, colorOf, nameOf, SITE };

--- a/bot/src/spin.test.js
+++ b/bot/src/spin.test.js
@@ -1,0 +1,126 @@
+// The spin is theatre over an answer the site already gave, so what matters here is that
+// every frame is a valid message and that the reveal says the right things to the right
+// person. Discord will not tell you a component is malformed until a player triggers it.
+process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+
+const test = require("node:test");
+const assert = require("node:assert");
+const { reelRow, spinningFrame, revealFrame, demoFrame, FRAMES } = require("./spin");
+
+const NAMES = ["Reimu", "Marisa", "Sanae", "Cirno", "Yukari"];
+const ITEM = { name: "Yukari", rarity: "5", image: "https://example.test/y.png", value: 41200 };
+const text = (json) => json.components.filter((c) => c.type === 10).map((c) => c.content).join("\n");
+const row = (json) => json.components.find((c) => c.type === 1);
+
+test("the reel moves between frames, so it reads as spinning", () => {
+  const frames = Array.from({ length: FRAMES }, (_, i) => reelRow(NAMES, i));
+  assert.strictEqual(new Set(frames).size, FRAMES, "every frame must differ from the last");
+  for (const frame of frames) assert.match(frame, /▐ .+ ▌/, "the marker sits in every frame");
+});
+
+test("a long name is cut rather than wrapping the row", () => {
+  const wide = reelRow(["Yukari (Blue Archive) The Longest"], 0);
+  for (const line of wide.split("\n")) assert.ok(line.length < 90, `row too wide: ${line.length}`);
+});
+
+test("it still draws a row for a case whose names never arrived", () => {
+  assert.match(reelRow([], 0), /▐/);
+  assert.match(reelRow(undefined, 3), /▐/);
+});
+
+test("a spinning frame wears no rarity, because nothing has been decided", () => {
+  const spinning = spinningFrame("Touhou Case", NAMES, 1).toJSON();
+  const landed = revealFrame({ item: ITEM, caseTitle: "Touhou Case", caseId: "c1", ownerId: "u1", balance: 10 }).toJSON();
+  assert.notStrictEqual(spinning.accent_color, landed.accent_color);
+  assert.strictEqual(landed.accent_color, 0xffff6e, "a unique lands gold, the same gold the site paints");
+});
+
+test("the reveal names the item, its rarity and what it left behind", () => {
+  const json = revealFrame({
+    item: ITEM,
+    caseTitle: "Touhou Case",
+    caseId: "c1",
+    ownerId: "u1",
+    balance: 958800,
+    others: 0,
+  }).toJSON();
+  const body = text(json) + JSON.stringify(json.components.filter((c) => c.type === 9));
+  assert.match(body, /Yukari/);
+  assert.match(body, /Unique/);
+  assert.match(body, /41,200/);
+  assert.match(body, /958,800/);
+});
+
+test("it mentions the rest of a multi opening rather than dropping them", () => {
+  const one = text(revealFrame({ item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1, others: 0 }).toJSON());
+  const many = text(revealFrame({ item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1, others: 4 }).toJSON());
+  assert.doesNotMatch(one, /more from this opening/);
+  assert.match(many, /4 more from this opening/);
+});
+
+test("holding a board says so, and says it differently when the lead is somebody else's", () => {
+  const first = text(revealFrame({
+    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+    fanRank: { name: "Yukari", count: 140, rank: 1, fans: 14 },
+  }).toJSON());
+  assert.match(first, /#1/);
+  assert.match(first, /140 Yukari/);
+
+  const chasing = text(revealFrame({
+    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+    fanRank: { name: "Yukari", count: 9, rank: 3, fans: 14 },
+  }).toJSON());
+  assert.match(chasing, /#3/);
+  assert.doesNotMatch(chasing, /still \*\*#1\*\*/);
+});
+
+// clicking "open another" on somebody else's reveal would charge the clicker, so the
+// button has to carry whose it is
+test("the open again button carries the case and its owner", () => {
+  const json = revealFrame({ item: ITEM, caseTitle: "c", caseId: "case42", ownerId: "user99", balance: 1 }).toJSON();
+  const button = row(json).components.find((c) => c.custom_id);
+  assert.strictEqual(button.custom_id, "open:case42:user99");
+  const [action, caseId, ownerId] = button.custom_id.split(":");
+  assert.deepStrictEqual([action, caseId, ownerId], ["open", "case42", "user99"]);
+  assert.ok(button.custom_id.length <= 100, "discord caps a custom id at 100 characters");
+});
+
+test("the demo says plainly that nothing was kept, and offers the way to change that", () => {
+  const json = demoFrame({ item: ITEM, caseTitle: "Touhou Case" }).toJSON();
+  assert.match(text(json), /This was a demo spin\. Create an account to keep the next rolls\./);
+  const link = row(json).components[0];
+  assert.strictEqual(link.style, 5, "a link button, not one that charges anybody");
+  assert.match(link.url, /^https:\/\//);
+});
+
+test("the demo never offers a button that would open another", () => {
+  const json = demoFrame({ item: ITEM, caseTitle: "c" }).toJSON();
+  for (const component of row(json).components) {
+    assert.strictEqual(component.custom_id, undefined, "nothing here should charge somebody with no account");
+  }
+});
+
+// a section is only valid with an accessory, so building one around a missing picture
+// throws, and discord says nothing until a player pulls the item that has none
+test("an item with no usable art still builds a frame", () => {
+  for (const image of [undefined, null, "", "not-a-url", "javascript:alert(1)"]) {
+    const json = revealFrame({
+      item: { name: "Cirno", rarity: "2", value: 10, image },
+      caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+    }).toJSON();
+    assert.ok(json.components.length > 0, `failed on image ${String(image)}`);
+    assert.match(text(json) + JSON.stringify(json.components), /Cirno/);
+  }
+  const demo = demoFrame({ item: { name: "Cirno", rarity: "2" }, caseTitle: "c" }).toJSON();
+  assert.ok(demo.components.length > 0);
+});
+
+test("real art is still shown as a thumbnail", () => {
+  const json = revealFrame({
+    item: { name: "Cirno", rarity: "2", value: 10, image: "https://example.test/c.png" },
+    caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+  }).toJSON();
+  const section = json.components.find((c) => c.type === 9);
+  assert.ok(section, "art means a section with an accessory");
+  assert.strictEqual(section.accessory.media.url, "https://example.test/c.png");
+});

--- a/src/components/header/CaseOpenedNotification.tsx
+++ b/src/components/header/CaseOpenedNotification.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { GiUpgrade } from "react-icons/gi";
+import { FaDiscord } from "react-icons/fa";
 import Rarities from "../Rarities";
 import { Link } from "react-router-dom";
 import { BasicItem } from "../Types";
@@ -59,6 +60,14 @@ const CaseOpenedNotification: React.FC<CaseOpenedNotificationProps> = ({
               title={i18n.t("upgrade.wonByUpgrading")}
             >
               <GiUpgrade className="text-sm" />
+            </span>
+          )}
+          {source === "discord" && (
+            <span
+              className="absolute left-1 top-1 z-20 text-[#5865F2]"
+              title={i18n.t("discord.openedOnDiscord")}
+            >
+              <FaDiscord className="text-sm" />
             </span>
           )}
           {others > 0 && (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -318,6 +318,7 @@
     "needLogin": "Melde dich an, um die Verknüpfung abzuschließen",
     "needLoginBody": "Melde dich an oder erstelle ein Konto, dann wird dein Discord-Benutzer sofort verknüpft.",
     "notLinked": "Kein Discord-Konto verknüpft",
+    "openedOnDiscord": "Auf Discord geöffnet",
     "settingsTitle": "Discord",
     "tryAgain": "Führe /link in Discord erneut aus, um einen neuen Code zu bekommen.",
     "unlinkButton": "Trennen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -318,6 +318,7 @@
     "needLogin": "Log in to finish linking",
     "needLoginBody": "Sign in or create an account, and your Discord user gets attached straight away.",
     "notLinked": "No Discord account linked",
+    "openedOnDiscord": "Opened on Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Run /link in Discord again for a fresh code.",
     "unlinkButton": "Unlink",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -318,6 +318,7 @@
     "needLogin": "Inicia sesión para terminar de vincular",
     "needLoginBody": "Inicia sesión o crea una cuenta y tu usuario de Discord se vinculará al instante.",
     "notLinked": "Ninguna cuenta de Discord vinculada",
+    "openedOnDiscord": "Abierta en Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Usa /link en Discord otra vez para conseguir un código nuevo.",
     "unlinkButton": "Desvincular",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -318,6 +318,7 @@
     "needLogin": "Connecte-toi pour terminer l'association",
     "needLoginBody": "Connecte-toi ou crée un compte, et ton utilisateur Discord sera associé aussitôt.",
     "notLinked": "Aucun compte Discord associé",
+    "openedOnDiscord": "Ouverte sur Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Relance /link sur Discord pour obtenir un nouveau code.",
     "unlinkButton": "Dissocier",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -318,6 +318,7 @@
     "needLogin": "Masuk untuk menyelesaikan penautan",
     "needLoginBody": "Masuk atau buat akun, dan pengguna Discord-mu langsung tertaut.",
     "notLinked": "Belum ada akun Discord yang tertaut",
+    "openedOnDiscord": "Dibuka di Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Jalankan /link lagi di Discord untuk kode baru.",
     "unlinkButton": "Lepas tautan",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -318,6 +318,7 @@
     "needLogin": "Accedi per completare il collegamento",
     "needLoginBody": "Accedi o crea un account e il tuo utente Discord verrà collegato subito.",
     "notLinked": "Nessun account Discord collegato",
+    "openedOnDiscord": "Aperta su Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Usa di nuovo /link su Discord per un codice nuovo.",
     "unlinkButton": "Scollega",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -318,6 +318,7 @@
     "needLogin": "ログインして連携を完了してください",
     "needLoginBody": "ログインするかアカウントを作成すると、Discord アカウントがすぐに連携されます。",
     "notLinked": "Discord アカウントは未連携です",
+    "openedOnDiscord": "Discord で開封",
     "settingsTitle": "Discord",
     "tryAgain": "Discord でもう一度 /link を実行して、新しいコードを取得してください。",
     "unlinkButton": "連携を解除",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -318,6 +318,7 @@
     "needLogin": "로그인하고 연결을 마치세요",
     "needLoginBody": "로그인하거나 계정을 만들면 Discord 계정이 바로 연결됩니다.",
     "notLinked": "연결된 Discord 계정이 없습니다",
+    "openedOnDiscord": "Discord에서 개봉",
     "settingsTitle": "Discord",
     "tryAgain": "Discord에서 /link를 다시 실행해 새 코드를 받으세요.",
     "unlinkButton": "연결 해제",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -318,6 +318,7 @@
     "needLogin": "Entre para concluir a vinculação",
     "needLoginBody": "Faça login ou crie uma conta, e seu usuário do Discord será vinculado na hora.",
     "notLinked": "Nenhuma conta do Discord vinculada",
+    "openedOnDiscord": "Aberta no Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Use /link no Discord de novo para obter um código novo.",
     "unlinkButton": "Desvincular",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -318,6 +318,7 @@
     "needLogin": "Đăng nhập để hoàn tất liên kết",
     "needLoginBody": "Đăng nhập hoặc tạo tài khoản, và người dùng Discord của bạn sẽ được liên kết ngay.",
     "notLinked": "Chưa liên kết tài khoản Discord",
+    "openedOnDiscord": "Mở trên Discord",
     "settingsTitle": "Discord",
     "tryAgain": "Chạy lại /link trong Discord để lấy mã mới.",
     "unlinkButton": "Hủy liên kết",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -318,6 +318,7 @@
     "needLogin": "登录后完成关联",
     "needLoginBody": "登录或注册账号，你的 Discord 用户就会立即关联。",
     "notLinked": "未关联 Discord 账号",
+    "openedOnDiscord": "在 Discord 开启",
     "settingsTitle": "Discord",
     "tryAgain": "在 Discord 中重新运行 /link 获取新的验证码。",
     "unlinkButton": "解除关联",


### PR DESCRIPTION
Finishes what #252 and #253 set up. `/open` is now reachable by a player.

## The command

`/open <case> [quantity]`, with **autocomplete** — 64 cases is well past Discord's 25-choice cap, so the list is filtered server-side, and an empty box leads with whatever that player opened last. That makes it worth typing once: the reveal then carries an **Open another** button.

## The spin

Three frames at 550 ms, a monospace reel that shifts one place per frame with a fixed marker, grey while spinning and snapping to the rarity colour on the reveal. Those are the same five colours the site paints items with.

**It is theatre over an answer already given.** The site is called once, up front; the frames are drawn after, exactly as the reel on the site animates toward an outcome it already knows. Every frame is a call to Discord and none to the database.

## Four things that shaped it, all verified rather than assumed

- **The Components V2 flag cannot be added to a message created without it**, so the first frame is the reply itself rather than a `deferReply`. Drawing "Opening…" costs nothing and buys the full three-second window for the call behind it.
- **A `SectionBuilder` is only valid with an accessory.** Building one around an item with no picture throws, and Discord says nothing until a player pulls the one item in the catalogue that has none. There is a test for it, and it caught a real crash.
- **discord.js queues on a 429 rather than throwing** (`rejectOnRateLimit` defaults to null), so frames pushed too fast stretch the animation instead of breaking it.
- The button carries **whose it is** in its custom id. Otherwise pressing "Open another" on somebody else's reveal charges the presser for a case they never chose.

## The demo spin

Someone with no account still gets the animation, drawn on the case's real committed odds, spending no nonce and keeping nothing:

> This was a demo spin. Create an account to keep the next rolls.

That reveal carries **no button that could charge anybody** — only a link out. Tested.

## The live ticker

Discord openings emit the same `caseOpened` the site does with `source: "discord"`, and `CaseOpenedNotification` paints a Discord mark the way it already marks an upgrade. Site players watch Discord drops scroll past.

## Tests

14 in `bot/` (frames differ so it reads as spinning, long names cut rather than wrap, no-art fallback, button ownership and the 100-char cap, the demo offering nothing that charges, board standing wording). Backend 1,021, frontend 152, `tsc` clean.

## Deploy needs one extra step

`/open` is a new command, so `node src/register.js` has to run after the deploy or it will not appear.