### PR TITLE
fix(discord): what the first real spin showed

### DIFF
--- a/backend/__tests__/integration/discordOpen.test.js
+++ b/backend/__tests__/integration/discordOpen.test.js
@@ -266,6 +266,26 @@ describe("what autocomplete offers", () => {
     expect(res.body.cases[0].title).toContain("Lunatic");
   });
 
+  // not one case is called "Touhou": they are Lunatic, Nuclear and The Special Package.
+  // a player asks for the series, so the series has to be searchable.
+  it("finds a series by name even though no case is called after it", async () => {
+    const s = uniqueSuffix();
+    const mine = await Case.create({
+      title: `Lunatic ${s}`,
+      image: "case.png",
+      price: 60,
+      category: `Touhou-${s}`,
+      items: (await Item.create([{ name: `i-${s}`, image: "i.png", rarity: "1", baseValue: 10 }])).map((i) => i._id),
+    });
+    await recomputeCaseValues(mine._id);
+
+    const res = await bot(request(app).get(`/discord/cases?q=Touhou-${s}`));
+    expect(res.status).toBe(200);
+    expect(res.body.cases.map((one) => String(one.id))).toContain(String(mine._id));
+    // and the row carries the series, since the title does not
+    expect(res.body.cases.find((one) => String(one.id) === String(mine._id)).category).toBe(`Touhou-${s}`);
+  });
+
   // the box is free text, so a bracket is something a player typed, not a pattern
   it("treats a typed bracket as text", async () => {
     const s = uniqueSuffix();

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -358,8 +358,11 @@ router.get("/cases", botOnly, async (req, res) => {
   try {
     const search = String(req.query.q || "").trim();
     const filter = { price: { $lte: MAX_CASE_PRICE } };
+    // the category is how players ask for these: not one case is called "Touhou", they are
+    // Lunatic and Nuclear and The Special Package, and typing the series has to find them
     if (search) {
-      filter.title = { $regex: escapeRegex(search), $options: "i" };
+      const like = { $regex: escapeRegex(search), $options: "i" };
+      filter.$or = [{ title: like }, { category: like }];
     }
 
     const found = await Case.find(filter, { title: 1, price: 1, image: 1, category: 1 })

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, MessageFlags, ContainerBuilder, TextDisplayBuilder } = require("discord.js");
 const api = require("./api");
 const { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE } = require("./embeds");
-const { spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS } = require("./spin");
+const { buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS } = require("./spin");
 
 // rejected in the bot's own memory, before any http call. spamming a command costs a map
 // lookup here rather than a query on a link that carries about 100 KB/s.
@@ -41,7 +41,7 @@ const OPENING = () =>
 
 // shared by the command and by the "open another" button, which is the quickest way to
 // open the same case again and the reason the command only has to be typed once
-async function runOpen(interaction, caseId, quantity) {
+async function runOpen(interaction, caseId) {
   if (!interaction.replied && !interaction.deferred) {
     await interaction.reply({ components: [OPENING()], ...V2 });
   }
@@ -49,7 +49,7 @@ async function runOpen(interaction, caseId, quantity) {
   let opened = null;
   let demo = null;
   try {
-    opened = await api.openCase(interaction.user.id, interaction.id, caseId, quantity);
+    opened = await api.openCase(interaction.user.id, interaction.id, caseId, 1);
   } catch (err) {
     // no account is not a refusal here: it is the whole pitch. spin it anyway, keep
     // nothing, and say so. any other 404 is a real one and belongs to the caller.
@@ -58,10 +58,17 @@ async function runOpen(interaction, caseId, quantity) {
   }
 
   const caseTitle = opened ? opened.case.title : demo.case.title;
-  const names = (opened ? opened.reel : demo.reel) || [];
+  const won = opened ? opened.items[0] : demo.item;
+  const strip = buildStrip(opened ? opened.reel : demo.reel, won.name);
 
+  // the last frame is the landing, so the reel arrives on the item actually won rather
+  // than being swapped out mid-spin for a card that came from nowhere
   for (let frame = 0; frame < FRAMES; frame += 1) {
-    await interaction.editReply({ components: [spinningFrame(caseTitle, names, frame)], ...V2 });
+    const landing = frame === FRAMES - 1;
+    await interaction.editReply({
+      components: [spinningFrame(caseTitle, strip, frame, landing ? won.name : null, won.rarity)],
+      ...V2,
+    });
     await sleep(FRAME_MS);
   }
 
@@ -70,18 +77,14 @@ async function runOpen(interaction, caseId, quantity) {
     return;
   }
 
-  // one card, carrying the rarest of the pull, the way the site's own feed does it
-  const best = opened.items.reduce((a, b) => (Number(b.rarity) > Number(a.rarity) ? b : a));
   await interaction.editReply({
     components: [
       revealFrame({
-        item: best,
+        item: won,
         caseTitle,
         caseId: opened.case.id,
         ownerId: interaction.user.id,
-        balance: opened.walletBalance,
         fanRank: opened.fanRank,
-        others: opened.items.length - 1,
       }),
     ],
     ...V2,
@@ -122,9 +125,6 @@ const commands = [
           .setDescription("Which case. Start typing, or pick the one you opened last.")
           .setRequired(true)
           .setAutocomplete(true)
-      )
-      .addIntegerOption((option) =>
-        option.setName("quantity").setDescription("How many, up to 5").setMinValue(1).setMaxValue(5)
       ),
     // 64 cases is well past discord's 25 choice cap, so the list is filtered server side.
     // an empty box leads with whatever this player opened last.
@@ -144,7 +144,7 @@ const commands = [
       );
     },
     async run(interaction) {
-      await runOpen(interaction, interaction.options.getString("case"), interaction.options.getInteger("quantity") || 1);
+      await runOpen(interaction, interaction.options.getString("case"));
     },
   },
   {

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -132,7 +132,15 @@ const commands = [
       const typed = interaction.options.getFocused();
       const { cases } = await api.cases(typed, interaction.user.id);
       await interaction.respond(
-        cases.map((one) => ({ name: `${one.title}  ·  K₽ ${one.price.toLocaleString("en-US")}`.slice(0, 100), value: String(one.id) }))
+        cases.map((one) => ({
+          // the series is on the label because the titles do not carry it, so a row reads
+          // as "Lunatic Case · Touhou" rather than leaving the player to know which is which
+          name: [one.title, one.category, `K₽ ${one.price.toLocaleString("en-US")}`]
+            .filter(Boolean)
+            .join("  ·  ")
+            .slice(0, 100),
+          value: String(one.id),
+        }))
       );
     },
     async run(interaction) {

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -57,7 +57,7 @@ async function pressed(interaction) {
       flags: MessageFlags.Ephemeral,
     });
   }
-  await runOpen(interaction, caseId, 1);
+  await runOpen(interaction, caseId);
 }
 
 client.on(Events.InteractionCreate, async (interaction) => {

--- a/bot/src/spin.js
+++ b/bot/src/spin.js
@@ -19,7 +19,8 @@ const SPINNING = 0x4a4a5a;
 
 const colorOf = (rarity) => RARITY_COLOR[String(rarity)] || SPINNING;
 const nameOf = (rarity) => RARITY_NAME[String(rarity)] || "";
-const num = (value) => Number(value || 0).toLocaleString("en-US");
+// values can carry fractions, and "K₽ 77,671.455" reads as a typo rather than a number
+const num = (value) => Math.round(Number(value) || 0).toLocaleString("en-US");
 
 // how many names are visible at once, and which of them sits under the marker
 const WINDOW = 5;
@@ -44,11 +45,28 @@ function reelRow(names, offset, landed) {
 const FRAMES = 3;
 const FRAME_MS = 550;
 
-function spinningFrame(caseTitle, names, offset) {
+// a strip built fresh for each spin, so two openings of one case do not scroll the same
+// five names past in the same order, and so the item actually won is on it
+function buildStrip(names, winner) {
+  const pool = (names || []).filter(Boolean);
+  const strip = [...pool];
+  for (let i = strip.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [strip[i], strip[j]] = [strip[j], strip[i]];
+  }
+  // a reel the prize is not on is the thing that reads as fake
+  if (winner && !strip.includes(winner)) strip.push(winner);
+  while (strip.length < WINDOW + 2) strip.push(...(strip.length ? strip : ["?"]));
+  return strip;
+}
+
+// the last frame is the landing: the item actually won sits under the marker wearing its
+// own colour, so the reel arrives somewhere instead of being replaced mid-spin
+function spinningFrame(caseTitle, names, offset, landed, rarity) {
   return new ContainerBuilder()
-    .setAccentColor(SPINNING)
+    .setAccentColor(landed ? colorOf(rarity) : SPINNING)
     .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${caseTitle}**`))
-    .addTextDisplayComponents(new TextDisplayBuilder().setContent(reelRow(names, offset)));
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(reelRow(names, offset, landed)));
 }
 
 const buttons = (...rows) => new ActionRowBuilder().addComponents(...rows.filter(Boolean));
@@ -72,14 +90,13 @@ function addHeading(container, item, caseTitle) {
   return container;
 }
 
-function revealFrame({ item, caseTitle, caseId, ownerId, balance, fanRank, others }) {
+function revealFrame({ item, caseTitle, caseId, ownerId, fanRank }) {
   const container = new ContainerBuilder().setAccentColor(colorOf(item.rarity));
 
   addHeading(container, item, caseTitle);
   container.addSeparatorComponents(new SeparatorBuilder());
 
-  const lines = [`Worth **K₽ ${num(item.value)}** · you have **K₽ ${num(balance)}** left`];
-  if (others > 0) lines.push(`and ${others} more from this opening`);
+  const lines = [`Worth **K₽ ${num(item.value)}**`];
   if (fanRank) {
     lines.push(
       fanRank.rank === 1
@@ -113,4 +130,4 @@ function demoFrame({ item, caseTitle }) {
   return container;
 }
 
-module.exports = { reelRow, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS, colorOf, nameOf, SITE };
+module.exports = { reelRow, buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS, colorOf, nameOf, SITE };

--- a/bot/src/spin.test.js
+++ b/bot/src/spin.test.js
@@ -5,7 +5,7 @@ process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
 
 const test = require("node:test");
 const assert = require("node:assert");
-const { reelRow, spinningFrame, revealFrame, demoFrame, FRAMES } = require("./spin");
+const { reelRow, buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES } = require("./spin");
 
 const NAMES = ["Reimu", "Marisa", "Sanae", "Cirno", "Yukari"];
 const ITEM = { name: "Yukari", rarity: "5", image: "https://example.test/y.png", value: 41200 };
@@ -16,6 +16,41 @@ test("the reel moves between frames, so it reads as spinning", () => {
   const frames = Array.from({ length: FRAMES }, (_, i) => reelRow(NAMES, i));
   assert.strictEqual(new Set(frames).size, FRAMES, "every frame must differ from the last");
   for (const frame of frames) assert.match(frame, /▐ .+ ▌/, "the marker sits in every frame");
+});
+
+// the first version scrolled the case's first twelve items in catalogue order and never
+// put the prize on the reel at all, which is exactly what made it read as fake
+test("the item actually won is on the strip, however far down the case it sits", () => {
+  const strip = buildStrip(["Kisaki", "Shiroko", "Nozomi"], "Hatsune Miku");
+  assert.ok(strip.includes("Hatsune Miku"));
+});
+
+test("the last frame lands on it, under the marker", () => {
+  const won = "Hatsune Miku";
+  const strip = buildStrip(["Kisaki", "Shiroko", "Nozomi", "Kanna", "Saori"], won);
+  const landing = reelRow(strip, FRAMES - 1, won);
+  assert.match(landing, /▐ Hatsune Miku ▌/);
+});
+
+test("the landing wears the prize's colour, and the frames before it do not", () => {
+  const strip = buildStrip(NAMES, "Yukari");
+  const spinning = spinningFrame("c", strip, 0, null, "5").toJSON();
+  const landed = spinningFrame("c", strip, 2, "Yukari", "5").toJSON();
+  assert.strictEqual(spinning.accent_color, 0x4a4a5a);
+  assert.strictEqual(landed.accent_color, 0xffff6e);
+});
+
+// two openings of one case scrolling the same five names in the same order is what makes
+// a reel look like a fixed picture rather than a draw
+test("two spins of one case do not scroll the same order", () => {
+  const many = new Set(Array.from({ length: 8 }, () => buildStrip(NAMES, "Yukari").join(",")));
+  assert.ok(many.size > 1, "the strip is shuffled per spin");
+});
+
+test("a case with barely any items still fills the window", () => {
+  const strip = buildStrip(["Only"], "Only");
+  assert.ok(strip.length >= 5);
+  assert.match(reelRow(strip, 0), /▐/);
 });
 
 test("a long name is cut rather than wrapping the row", () => {
@@ -35,27 +70,37 @@ test("a spinning frame wears no rarity, because nothing has been decided", () =>
   assert.strictEqual(landed.accent_color, 0xffff6e, "a unique lands gold, the same gold the site paints");
 });
 
-test("the reveal names the item, its rarity and what it left behind", () => {
-  const json = revealFrame({
-    item: ITEM,
-    caseTitle: "Touhou Case",
-    caseId: "c1",
-    ownerId: "u1",
-    balance: 958800,
-    others: 0,
-  }).toJSON();
+test("the reveal names the item, its rarity and what it is worth", () => {
+  const json = revealFrame({ item: ITEM, caseTitle: "Touhou Case", caseId: "c1", ownerId: "u1" }).toJSON();
   const body = text(json) + JSON.stringify(json.components.filter((c) => c.type === 9));
   assert.match(body, /Yukari/);
   assert.match(body, /Unique/);
   assert.match(body, /41,200/);
-  assert.match(body, /958,800/);
 });
 
-test("it mentions the rest of a multi opening rather than dropping them", () => {
-  const one = text(revealFrame({ item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1, others: 0 }).toJSON());
-  const many = text(revealFrame({ item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1, others: 4 }).toJSON());
-  assert.doesNotMatch(one, /more from this opening/);
-  assert.match(many, /4 more from this opening/);
+// this lands in a public channel, and what somebody has in their wallet is nobody else's
+// business there
+test("the reveal never shows a balance", () => {
+  const json = revealFrame({
+    item: ITEM,
+    caseTitle: "c",
+    caseId: "c1",
+    ownerId: "u1",
+    balance: 77671,
+    fanRank: { name: "Yukari", count: 140, rank: 1, fans: 14 },
+  }).toJSON();
+  const whole = JSON.stringify(json);
+  assert.doesNotMatch(whole, /77,671/);
+  assert.doesNotMatch(whole, /left/);
+});
+
+// a fractional balance rendered as "77,671.455", which reads as a typo rather than money
+test("a value with a fraction is rounded rather than shown raw", () => {
+  const json = revealFrame({
+    item: { ...ITEM, value: 9.455 }, caseTitle: "c", caseId: "c1", ownerId: "u1",
+  }).toJSON();
+  assert.match(text(json), /K₽ 9\b/);
+  assert.doesNotMatch(text(json), /9\.455/);
 });
 
 test("holding a board says so, and says it differently when the lead is somebody else's", () => {


### PR DESCRIPTION
Four things, all found by running `/open` rather than reading it.

## The reveal printed the opener's balance into a public channel

`Worth K₽ 9 · you have K₽ 77,671.455 left`. Gone. What somebody has in their wallet is nobody else's business in a channel.

Values are rounded now too: that fractional balance rendered as **77,671.455**, which reads as a typo rather than as money.

## The reel never landed on the prize

Two bugs stacked. `reelRow` took a `landed` argument that **nothing ever passed**, and the strip was the case's *first twelve items in catalogue order* — so a prize further down the list, like Hatsune Miku in the Kivotos Case, could never appear at all. The reel was then swapped out mid-spin for a card that came from nowhere.

Seen once in a real client it reads as fake immediately, which is exactly what happened.

Now the strip is shuffled per opening, the prize is pushed onto it if it is not already there, and the last frame puts it under the marker wearing its own rarity colour before the card replaces it:

```
Aru │ Kanna │▐ Shiroko ▌│ Mika │ Hoshino
Kanna │ Shiroko │▐ Mika ▌│ Hoshino │ Nozomi
Shiroko │ Mika │▐ Hatsune Miku ▌│ Nozomi │ Saori   <- lands, in the item's colour
```

Two openings of one case no longer scroll the same five names in the same order, which was the other half of why it looked like a fixed picture.

## One case per command

The `quantity` option is gone. The spin is the point, and five at once has nothing to land on.

## Autocomplete could not find a series

Typing `tou` returned nothing: no case is called Touhou, they are **Lunatic Case**, **Nuclear Case** and **The Special Package**. The search covers `category` now, and each row reads `Lunatic Case · Touhou · K₽ 60`.

## Tests

Bot 20, up from 14: the prize is on the strip however far down the case it sits, the last frame lands under the marker, the landing wears the prize's colour and earlier frames do not, two spins differ, a fractional value is rounded, and the reveal never contains a balance. Backend 1,023.