### PR TITLE
fix(discord): make the reel one continuous strip, coloured by rarity

### DIFF
--- a/backend/__tests__/integration/discordOpen.test.js
+++ b/backend/__tests__/integration/discordOpen.test.js
@@ -228,6 +228,7 @@ describe("the spin for someone with no account", () => {
     expect(res.body.item.name).toEqual(expect.any(String));
     expect(res.body.item.value).toEqual(expect.any(Number));
     expect(res.body.reel.length).toBeGreaterThan(0);
+    expect(res.body.reel[0]).toMatchObject({ name: expect.any(String), rarity: expect.any(String) });
     // no nonce spent, no audit row, nothing to reconcile later
     expect(await Roll.countDocuments()).toBe(before);
   });

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -427,7 +427,7 @@ router.get("/preview/:caseId", botOnly, async (req, res) => {
         rarity: item.rarity,
         value: sellValue(item.baseValue),
       },
-      reel: one.items.slice(0, 12).map((it) => it.name),
+      reel: one.items.slice(0, 16).map((it) => ({ name: it.name, rarity: it.rarity })),
     });
   } catch (err) {
     console.error("discord preview:", err.message);
@@ -493,8 +493,9 @@ router.post("/open", botOnly, async (req, res) => {
       walletBalance: result.walletBalance,
       level: result.level,
       fanRank,
-      // what the bot spins past on the way to the answer
-      reel: (result.caseData.items || []).slice(0, 12).map((item) => item.name),
+      // what the bot spins past on the way to the answer. the rarity rides along so the
+      // reel can be coloured: seeing a gold name walk toward the marker is the whole thrill
+      reel: (result.caseData.items || []).slice(0, 16).map((item) => ({ name: item.name, rarity: item.rarity })),
       items: result.items.map((item) => ({
         name: item.name,
         image: item.image,

--- a/bot/src/spin.js
+++ b/bot/src/spin.js
@@ -14,8 +14,16 @@ const SITE = (process.env.SITE_URL || "https://kanicasino.com").replace(/\/$/, "
 // the five the site paints items with, so a colour means the same thing in both places
 const RARITY_COLOR = { "1": 0x4b69ff, "2": 0x8847ff, "3": 0xd32ce6, "4": 0xeb4b4b, "5": 0xffff6e };
 const RARITY_NAME = { "1": "Common", "2": "Rare", "3": "Epic", "4": "Ultra Rare", "5": "Unique" };
-// while it is still spinning nothing has been decided, so it wears no rarity
+// while it is still spinning nothing has been decided, so the frame wears no rarity
 const SPINNING = 0x4a4a5a;
+
+// discord renders a small ansi palette inside a code block, and it is the only way to get
+// colour into the reel. as near the site's five as eight colours allow, so a gold name
+// walking toward the marker reads the way a gold reads on the site. a client that does not
+// render ansi shows the plain name, which is what it showed before.
+const ANSI = { "1": "34", "2": "35", "3": "1;35", "4": "31", "5": "1;33" };
+const ESC = String.fromCharCode(27);
+const paint = (text, rarity) => `${ESC}[${ANSI[String(rarity)] || "37"}m${text}${ESC}[0m`;
 
 const colorOf = (rarity) => RARITY_COLOR[String(rarity)] || SPINNING;
 const nameOf = (rarity) => RARITY_NAME[String(rarity)] || "";
@@ -25,48 +33,66 @@ const num = (value) => Math.round(Number(value) || 0).toLocaleString("en-US");
 // how many names are visible at once, and which of them sits under the marker
 const WINDOW = 5;
 const MIDDLE = 2;
-
-// a row of names that shifts one place per frame while the marker stays put, which is
-// what reads as movement in a message that can only be redrawn a few times
-function reelRow(names, offset, landed) {
-  const pool = names && names.length ? names : ["?"];
-  const shown = [];
-  for (let i = 0; i < WINDOW; i += 1) {
-    const name = pool[(offset + i) % pool.length];
-    shown.push(name.length > 12 ? `${name.slice(0, 11)}…` : name);
-  }
-  if (landed) shown[MIDDLE] = landed.length > 12 ? `${landed.slice(0, 11)}…` : landed;
-  return "```\n" + shown.map((name, i) => (i === MIDDLE ? `▐ ${name} ▌` : ` ${name} `)).join("│") + "\n```";
-}
-
-// how many times the reel is redrawn before it stops, and how long each is held. every
-// redraw is a call to discord and none to the site: the outcome was decided before the
-// first frame, exactly as the reel on the site is animated to an answer it already has.
+// how many times the reel is redrawn, and how long each is held. every redraw is a call to
+// discord and none to the site: the outcome was decided before the first frame, exactly as
+// the reel on the site animates toward an answer it already has.
 const FRAMES = 3;
 const FRAME_MS = 550;
 
-// a strip built fresh for each spin, so two openings of one case do not scroll the same
-// five names past in the same order, and so the item actually won is on it
-function buildStrip(names, winner) {
-  const pool = (names || []).filter(Boolean);
-  const strip = [...pool];
-  for (let i = strip.length - 1; i > 0; i -= 1) {
+// the offset is the frame number, so the cell that ends up under the marker on the last
+// frame is this one, and seating the prize there is what makes the reel continuous: it
+// sits at the far right on the first frame, walks one place in on the second, and arrives
+// on the third.
+//
+// the first version drew each frame as its own window into a shuffled list, so the names
+// to the right of the marker were not what came next. a player reads those as what is
+// about to land, and it was not, which is exactly why it read as fake.
+const LANDING = FRAMES - 1 + MIDDLE;
+
+const clip = (name) => (name.length > 12 ? `${name.slice(0, 11)}…` : name);
+// the reel used to be plain names; entries carry a rarity now, and both still work
+const entryOf = (value) =>
+  typeof value === "string" ? { name: value, rarity: null } : { name: value.name, rarity: value.rarity };
+
+function shuffled(list) {
+  const copy = [...list];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1));
-    [strip[i], strip[j]] = [strip[j], strip[i]];
+    [copy[i], copy[j]] = [copy[j], copy[i]];
   }
-  // a reel the prize is not on is the thing that reads as fake
-  if (winner && !strip.includes(winner)) strip.push(winner);
-  while (strip.length < WINDOW + 2) strip.push(...(strip.length ? strip : ["?"]));
+  return copy;
+}
+
+// one continuous strip per opening, long enough for every frame's window, shuffled so two
+// openings of a case do not scroll the same order, with the prize seated where it lands
+function buildStrip(pool, winner) {
+  const won = entryOf(winner || { name: "?", rarity: null });
+  const items = (pool || []).map(entryOf).filter((entry) => entry && entry.name);
+  const needed = FRAMES - 1 + WINDOW;
+
+  const strip = [];
+  while (strip.length < needed) strip.push(...shuffled(items.length ? items : [won]));
+  strip.length = needed;
+  strip[LANDING] = won;
   return strip;
 }
 
-// the last frame is the landing: the item actually won sits under the marker wearing its
-// own colour, so the reel arrives somewhere instead of being replaced mid-spin
-function spinningFrame(caseTitle, names, offset, landed, rarity) {
+function reelRow(strip, offset) {
+  const pool = strip && strip.length ? strip.map(entryOf) : [{ name: "?", rarity: null }];
+  const cells = [];
+  for (let i = 0; i < WINDOW; i += 1) {
+    const entry = pool[(offset + i) % pool.length];
+    const painted = paint(clip(entry.name), entry.rarity);
+    cells.push(i === MIDDLE ? `▐ ${painted} ▌` : ` ${painted} `);
+  }
+  return "```ansi\n" + cells.join("│") + "\n```";
+}
+
+function spinningFrame(caseTitle, strip, offset, landed, rarity) {
   return new ContainerBuilder()
     .setAccentColor(landed ? colorOf(rarity) : SPINNING)
     .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${caseTitle}**`))
-    .addTextDisplayComponents(new TextDisplayBuilder().setContent(reelRow(names, offset, landed)));
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(reelRow(strip, offset)));
 }
 
 const buttons = (...rows) => new ActionRowBuilder().addComponents(...rows.filter(Boolean));
@@ -130,4 +156,18 @@ function demoFrame({ item, caseTitle }) {
   return container;
 }
 
-module.exports = { reelRow, buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS, colorOf, nameOf, SITE };
+module.exports = {
+  reelRow,
+  buildStrip,
+  spinningFrame,
+  revealFrame,
+  demoFrame,
+  FRAMES,
+  FRAME_MS,
+  LANDING,
+  WINDOW,
+  MIDDLE,
+  colorOf,
+  nameOf,
+  SITE,
+};

--- a/bot/src/spin.test.js
+++ b/bot/src/spin.test.js
@@ -1,73 +1,106 @@
 // The spin is theatre over an answer the site already gave, so what matters here is that
-// every frame is a valid message and that the reveal says the right things to the right
-// person. Discord will not tell you a component is malformed until a player triggers it.
+// every frame is a valid message, that the reel is honest about what is coming, and that
+// the reveal says the right things to the right person. Discord will not tell you a
+// component is malformed until a player triggers it.
 process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
 
 const test = require("node:test");
 const assert = require("node:assert");
-const { reelRow, buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES } = require("./spin");
+const {
+  reelRow, buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES, LANDING, WINDOW, MIDDLE,
+} = require("./spin");
 
-const NAMES = ["Reimu", "Marisa", "Sanae", "Cirno", "Yukari"];
+const ESC = String.fromCharCode(27);
+const ANSI = new RegExp(ESC + "\\[[0-9;]*m", "g");
+const plain = (row) => row.replace(ANSI, "").replace(/```ansi\n?|```/g, "").trim();
+const cells = (row) => plain(row).split("│").map((cell) => cell.replace(/[▐▌]/g, "").trim());
+
+const POOL = [
+  { name: "Yukari", rarity: "4" }, { name: "Remilia", rarity: "3" }, { name: "Yuyuko", rarity: "3" },
+  { name: "Reisen", rarity: "2" }, { name: "Nitori", rarity: "2" }, { name: "Cirno", rarity: "1" },
+  { name: "Rumia", rarity: "1" }, { name: "Koakuma", rarity: "1" },
+];
+const WON = { name: "Sumireko", rarity: "5" };
 const ITEM = { name: "Yukari", rarity: "5", image: "https://example.test/y.png", value: 41200 };
 const text = (json) => json.components.filter((c) => c.type === 10).map((c) => c.content).join("\n");
 const row = (json) => json.components.find((c) => c.type === 1);
 
-test("the reel moves between frames, so it reads as spinning", () => {
-  const frames = Array.from({ length: FRAMES }, (_, i) => reelRow(NAMES, i));
-  assert.strictEqual(new Set(frames).size, FRAMES, "every frame must differ from the last");
-  for (const frame of frames) assert.match(frame, /▐ .+ ▌/, "the marker sits in every frame");
+// the first version drew each frame as its own window into a shuffled list, so the names
+// to the right of the marker were not what came next. a player reads those as what is
+// about to land. it was not, and that is what made the whole thing read as a lie.
+test("what sits right of the marker is what lands next", () => {
+  const strip = buildStrip(POOL, WON);
+  for (let frame = 0; frame < FRAMES - 1; frame += 1) {
+    const comingUp = cells(reelRow(strip, frame))[MIDDLE + 1];
+    const landsNext = cells(reelRow(strip, frame + 1))[MIDDLE];
+    assert.strictEqual(landsNext, comingUp, `frame ${frame} promised ${comingUp} and gave ${landsNext}`);
+  }
 });
 
-// the first version scrolled the case's first twelve items in catalogue order and never
-// put the prize on the reel at all, which is exactly what made it read as fake
-test("the item actually won is on the strip, however far down the case it sits", () => {
-  const strip = buildStrip(["Kisaki", "Shiroko", "Nozomi"], "Hatsune Miku");
-  assert.ok(strip.includes("Hatsune Miku"));
+test("the prize walks in from the right rather than appearing from nowhere", () => {
+  const strip = buildStrip(POOL, WON);
+  const seen = [];
+  for (let frame = 0; frame < FRAMES; frame += 1) seen.push(cells(reelRow(strip, frame)).indexOf(WON.name));
+  assert.ok(seen.every((at) => at >= 0), `the prize was off screen at some point: ${seen}`);
+  // strictly decreasing: far right, one in, under the marker
+  for (let i = 1; i < seen.length; i += 1) assert.ok(seen[i] < seen[i - 1], `did not move: ${seen}`);
+  assert.strictEqual(seen[seen.length - 1], MIDDLE, "the last frame puts it under the marker");
 });
 
-test("the last frame lands on it, under the marker", () => {
-  const won = "Hatsune Miku";
-  const strip = buildStrip(["Kisaki", "Shiroko", "Nozomi", "Kanna", "Saori"], won);
-  const landing = reelRow(strip, FRAMES - 1, won);
-  assert.match(landing, /▐ Hatsune Miku ▌/);
+test("the prize is seated where the last frame's marker will be", () => {
+  const strip = buildStrip(POOL, WON);
+  assert.strictEqual(strip[LANDING].name, WON.name);
+  assert.strictEqual(LANDING, FRAMES - 1 + MIDDLE);
 });
 
-test("the landing wears the prize's colour, and the frames before it do not", () => {
-  const strip = buildStrip(NAMES, "Yukari");
-  const spinning = spinningFrame("c", strip, 0, null, "5").toJSON();
-  const landed = spinningFrame("c", strip, 2, "Yukari", "5").toJSON();
-  assert.strictEqual(spinning.accent_color, 0x4a4a5a);
-  assert.strictEqual(landed.accent_color, 0xffff6e);
+test("the strip is long enough that no frame runs off the end", () => {
+  const strip = buildStrip(POOL, WON);
+  assert.ok(strip.length >= FRAMES - 1 + WINDOW);
 });
 
-// two openings of one case scrolling the same five names in the same order is what makes
-// a reel look like a fixed picture rather than a draw
+test("the prize is on the strip however far down the case it sits", () => {
+  const strip = buildStrip([{ name: "Kisaki", rarity: "1" }], { name: "Hatsune Miku", rarity: "1" });
+  assert.ok(strip.some((entry) => entry.name === "Hatsune Miku"));
+});
+
+// two openings of one case scrolling the same names in the same order is what makes a reel
+// look like a fixed picture rather than a draw
 test("two spins of one case do not scroll the same order", () => {
-  const many = new Set(Array.from({ length: 8 }, () => buildStrip(NAMES, "Yukari").join(",")));
+  const many = new Set(Array.from({ length: 8 }, () => buildStrip(POOL, WON).map((e) => e.name).join(",")));
   assert.ok(many.size > 1, "the strip is shuffled per spin");
 });
 
-test("a case with barely any items still fills the window", () => {
-  const strip = buildStrip(["Only"], "Only");
-  assert.ok(strip.length >= 5);
-  assert.match(reelRow(strip, 0), /▐/);
+test("each name is painted by its own rarity", () => {
+  const row0 = reelRow(buildStrip(POOL, WON), 0);
+  assert.ok(row0.includes(ESC + "["), "colour is in the payload");
+  assert.match(row0, /^```ansi/, "discord only renders colour in an ansi block");
+  // a unique is the loud one, and it has to differ from a common
+  const unique = reelRow([{ name: "A", rarity: "5" }], 0);
+  const common = reelRow([{ name: "A", rarity: "1" }], 0);
+  assert.notStrictEqual(unique, common);
+});
+
+test("a reel of plain names still renders, since that is what it used to be", () => {
+  const row0 = reelRow(["Reimu", "Marisa", "Sanae"], 0);
+  assert.match(plain(row0), /Reimu|Marisa|Sanae/);
+  assert.match(plain(row0), /▐ .+ ▌/);
 });
 
 test("a long name is cut rather than wrapping the row", () => {
-  const wide = reelRow(["Yukari (Blue Archive) The Longest"], 0);
+  const wide = plain(reelRow([{ name: "Yukari (Blue Archive) The Longest", rarity: "1" }], 0));
   for (const line of wide.split("\n")) assert.ok(line.length < 90, `row too wide: ${line.length}`);
 });
 
 test("it still draws a row for a case whose names never arrived", () => {
-  assert.match(reelRow([], 0), /▐/);
-  assert.match(reelRow(undefined, 3), /▐/);
+  assert.match(plain(reelRow([], 0)), /▐/);
+  assert.match(plain(reelRow(undefined, 3)), /▐/);
+  assert.ok(buildStrip([], null).length >= WINDOW);
 });
 
-test("a spinning frame wears no rarity, because nothing has been decided", () => {
-  const spinning = spinningFrame("Touhou Case", NAMES, 1).toJSON();
-  const landed = revealFrame({ item: ITEM, caseTitle: "Touhou Case", caseId: "c1", ownerId: "u1", balance: 10 }).toJSON();
-  assert.notStrictEqual(spinning.accent_color, landed.accent_color);
-  assert.strictEqual(landed.accent_color, 0xffff6e, "a unique lands gold, the same gold the site paints");
+test("a spinning frame wears no rarity, and the landing wears the prize's", () => {
+  const strip = buildStrip(POOL, WON);
+  assert.strictEqual(spinningFrame("c", strip, 0, null, "5").toJSON().accent_color, 0x4a4a5a);
+  assert.strictEqual(spinningFrame("c", strip, FRAMES - 1, WON.name, "5").toJSON().accent_color, 0xffff6e);
 });
 
 test("the reveal names the item, its rarity and what it is worth", () => {
@@ -82,11 +115,7 @@ test("the reveal names the item, its rarity and what it is worth", () => {
 // business there
 test("the reveal never shows a balance", () => {
   const json = revealFrame({
-    item: ITEM,
-    caseTitle: "c",
-    caseId: "c1",
-    ownerId: "u1",
-    balance: 77671,
+    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 77671,
     fanRank: { name: "Yukari", count: 140, rank: 1, fans: 14 },
   }).toJSON();
   const whole = JSON.stringify(json);
@@ -96,23 +125,21 @@ test("the reveal never shows a balance", () => {
 
 // a fractional balance rendered as "77,671.455", which reads as a typo rather than money
 test("a value with a fraction is rounded rather than shown raw", () => {
-  const json = revealFrame({
-    item: { ...ITEM, value: 9.455 }, caseTitle: "c", caseId: "c1", ownerId: "u1",
-  }).toJSON();
+  const json = revealFrame({ item: { ...ITEM, value: 9.455 }, caseTitle: "c", caseId: "c1", ownerId: "u1" }).toJSON();
   assert.match(text(json), /K₽ 9\b/);
   assert.doesNotMatch(text(json), /9\.455/);
 });
 
 test("holding a board says so, and says it differently when the lead is somebody else's", () => {
   const first = text(revealFrame({
-    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1",
     fanRank: { name: "Yukari", count: 140, rank: 1, fans: 14 },
   }).toJSON());
   assert.match(first, /#1/);
   assert.match(first, /140 Yukari/);
 
   const chasing = text(revealFrame({
-    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+    item: ITEM, caseTitle: "c", caseId: "c1", ownerId: "u1",
     fanRank: { name: "Yukari", count: 9, rank: 3, fans: 14 },
   }).toJSON());
   assert.match(chasing, /#3/);
@@ -122,11 +149,9 @@ test("holding a board says so, and says it differently when the lead is somebody
 // clicking "open another" on somebody else's reveal would charge the clicker, so the
 // button has to carry whose it is
 test("the open again button carries the case and its owner", () => {
-  const json = revealFrame({ item: ITEM, caseTitle: "c", caseId: "case42", ownerId: "user99", balance: 1 }).toJSON();
+  const json = revealFrame({ item: ITEM, caseTitle: "c", caseId: "case42", ownerId: "user99" }).toJSON();
   const button = row(json).components.find((c) => c.custom_id);
   assert.strictEqual(button.custom_id, "open:case42:user99");
-  const [action, caseId, ownerId] = button.custom_id.split(":");
-  assert.deepStrictEqual([action, caseId, ownerId], ["open", "case42", "user99"]);
   assert.ok(button.custom_id.length <= 100, "discord caps a custom id at 100 characters");
 });
 
@@ -150,22 +175,19 @@ test("the demo never offers a button that would open another", () => {
 test("an item with no usable art still builds a frame", () => {
   for (const image of [undefined, null, "", "not-a-url", "javascript:alert(1)"]) {
     const json = revealFrame({
-      item: { name: "Cirno", rarity: "2", value: 10, image },
-      caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+      item: { name: "Cirno", rarity: "2", value: 10, image }, caseTitle: "c", caseId: "c1", ownerId: "u1",
     }).toJSON();
     assert.ok(json.components.length > 0, `failed on image ${String(image)}`);
     assert.match(text(json) + JSON.stringify(json.components), /Cirno/);
   }
-  const demo = demoFrame({ item: { name: "Cirno", rarity: "2" }, caseTitle: "c" }).toJSON();
-  assert.ok(demo.components.length > 0);
+  assert.ok(demoFrame({ item: { name: "Cirno", rarity: "2" }, caseTitle: "c" }).toJSON().components.length > 0);
 });
 
 test("real art is still shown as a thumbnail", () => {
   const json = revealFrame({
     item: { name: "Cirno", rarity: "2", value: 10, image: "https://example.test/c.png" },
-    caseTitle: "c", caseId: "c1", ownerId: "u1", balance: 1,
+    caseTitle: "c", caseId: "c1", ownerId: "u1",
   }).toJSON();
   const section = json.components.find((c) => c.type === 9);
-  assert.ok(section, "art means a section with an accessory");
   assert.strictEqual(section.accessory.media.url, "https://example.test/c.png");
 });


### PR DESCRIPTION
## The problem, diagnosed from a screenshot

Frame 2 of a Nuclear Case spin showed `Yukari │ Remilia │▐ Yuyuko ▌│ Reisen │ Nitori`. A player reads Reisen and Nitori as what is about to land. The result was **Sumireko**, who was not on the reel at all.

My previous fix seated the prize under the marker on the last frame by **overwriting that cell**. That made the landing correct and left everything before it a lie: each frame was still its own window into a shuffled list, so the names right of the marker had no relationship to what came next.

## The fix

The strip is built once per opening and the prize is **seated at the index the last frame's marker lands on** — `FRAMES - 1 + MIDDLE`. Nothing is overwritten, so the reel is genuinely continuous:

```
frame 0:  Nitori │ Remilia │▐ Reisen ▌│ Yuyuko │ Sumireko
frame 1:  Remilia │ Reisen │▐ Yuyuko ▌│ Sumireko │ Rumia
frame 2:  Reisen │ Yuyuko │▐ Sumireko ▌│ Rumia │ Koakuma      <- lands
```

The prize enters at the far right, walks one place in, arrives. And the cell right of the marker really is the one that lands next — there is a test asserting that frame by frame, because it is the whole difference between a reel and a slideshow.

## Colour

Reel entries carry their rarity from the backend now, painted in an ` ```ansi ` block, which is the only colour Discord renders inside a code block. Eight ANSI colours to cover five rarities, so epic borrows pink and leans on bold. A client that does not render ANSI shows the plain name, which is what it showed before.

Seeing a gold name walk toward the marker is most of what makes a case reel worth watching.

## Tests

Bot 20 → 22, and the two that matter are new: **what sits right of the marker is what lands next**, checked for every frame transition, and **the prize walks in from the right**, asserting its window position strictly decreases and ends under the marker. Backend 1,023.