### PR TITLE
docs(legal): give the terms a url, and cover the Discord bot

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -107,7 +107,7 @@ const caseMeta = (c) => {
 const writeSitemap = (caseRoutes) => {
   const entry = (loc, priority) =>
     `  <url>\n    <loc>${esc(loc)}</loc>\n    <priority>${priority}</priority>\n  </url>`;
-  const priorities = { "/": "1.0", "/provably-fair": "0.6", "/privacy-policy": "0.3" };
+  const priorities = { "/": "1.0", "/provably-fair": "0.6", "/privacy-policy": "0.3", "/terms": "0.3" };
   const urls = Object.keys(routes.static).map((r) =>
     entry(routes.site + r, priorities[r] || "0.8")
   );

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -13,6 +13,7 @@ import Dice from "./pages/Dice";
 import Mines from "./pages/Mines";
 import Hilo from "./pages/Hilo";
 import PrivacyPolicy from "./pages/About/PrivacyPolicy"
+import Terms from "./pages/About/Terms"
 import Unsubscribe from "./pages/About/Unsubscribe"
 import Gift from "./pages/Gift"
 import ItemPage from "./pages/Market/ItemPage";
@@ -53,6 +54,7 @@ const defaultRoutes = (
     <Route path="/r/:code" element={<ReferralRedirect />} />
     <Route path="/backoffice" element={<Backoffice />} />
     <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+    <Route path="/terms" element={<Terms />} />
     <Route path="/unsubscribe" element={<Unsubscribe />} />
     <Route path="/gift" element={<Gift />} />
     <Route path="/link/discord" element={<LinkDiscord />} />

--- a/src/components/modalsChilden/TermsOfPrivacy.tsx
+++ b/src/components/modalsChilden/TermsOfPrivacy.tsx
@@ -16,12 +16,12 @@ const TermsOfPrivacy = () => {
     return (
         <div className="flex flex-col text-sm">
             <span className="font-bold text-lg mb-1">Privacy Policy</span>
-            <span className="mb-1 italic">Last updated: 26 July 2026</span>
+            <span className="mb-1 italic">Last updated: 25 August 2026</span>
             <span className="mb-4 text-ink-muted">
                 KaniCasino ("we") is an independent project run from Brazil, and is the controller
                 of the personal data described below. This policy explains what we
-                collect when you use <span className="text-blue-500">kanicasino.com</span>, why, and
-                the rights you have over it. It is written to meet the Brazilian General Data
+                collect when you use <span className="text-blue-500">kanicasino.com</span> and our
+                Discord bot, why, and the rights you have over it. It is written to meet the Brazilian General Data
                 Protection Law (LGPD, Law 13.709/2018). For anything in this policy, including the
                 rights in section 8, write to{" "}
                 <span className="text-blue-500">novadrake77@gmail.com</span> and a person will
@@ -54,7 +54,17 @@ const TermsOfPrivacy = () => {
                     site and prevent abuse. Analytics and advertising providers set cookies and
                     similar identifiers in your browser (see section 5).
                 </Row>
-                <Row label="2.4 Communications">
+                <Row label="2.4 Discord, if you link it">
+                    Linking is optional and nothing below is collected unless you do it. We store
+                    your Discord user ID, your Discord username, and when you linked. We also store
+                    the IDs of the Discord servers you have used a bot command in, so a server can
+                    have its own leaderboard: that is the server's ID only, never its members, its
+                    channels or its messages. The bot requests only the "identify" scope and the
+                    Guilds gateway intent, so it cannot read messages. The ID of a command you send
+                    is kept for one hour to stop the same command being counted twice, then deleted
+                    automatically. Unlinking from your profile settings removes all of it.
+                </Row>
+                <Row label="2.5 Communications">
                     Messages you send us, and whether our emails to you were delivered, bounced or
                     reported as spam.
                 </Row>
@@ -103,7 +113,13 @@ const TermsOfPrivacy = () => {
                     <li>Cloudflare (content delivery and protection)</li>
                     <li>Google Analytics (usage measurement) and Google AdSense (advertising)</li>
                     <li>Google Sign-In, if you choose to use it</li>
-                    <li>Discord, whose public server widget on our home page receives your IP address so it can load</li>
+                    <li>
+                        Discord. Their public server widget on our home page receives your IP
+                        address so it can load. If you use our Discord bot, your commands and the
+                        replies to them pass through Discord under their own privacy policy, and
+                        anything the bot posts in a channel is visible to whoever can see that
+                        channel.
+                    </li>
                 </ul>
                 <span>
                     We do not sell your personal data and we do not share it for anyone else's
@@ -128,6 +144,10 @@ const TermsOfPrivacy = () => {
                     Kept while the account exists so balances and provably-fair verification stay
                     meaningful. Some game round records are deleted automatically after a short
                     period.
+                </Row>
+                <Row label="Discord link data">
+                    While the link exists. Unlinking deletes your Discord ID, username and the list
+                    of servers immediately. Command IDs expire on their own within an hour.
                 </Row>
                 <Row label="Suppressed email addresses">
                     If your address hard-bounces or you report our mail as spam, we keep a record of

--- a/src/components/modalsChilden/UserAgreement.tsx
+++ b/src/components/modalsChilden/UserAgreement.tsx
@@ -1,37 +1,190 @@
-const UserAgreementSection = ({ title, content }: { title: string, content: string }) => (
-    <div className="mb-2">
-        <span className="font-bold">{title}: </span>
-        <span className="ml-2 text-justify">{content}</span>
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div className="mb-4">
+        <span className="font-bold text-base block mb-1">{title}</span>
+        <div className="text-justify flex flex-col gap-2">{children}</div>
+    </div>
+);
+
+const Row = ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+        <span className="font-semibold">{label}: </span>
+        <span>{children}</span>
     </div>
 );
 
 const UserAgreement = () => {
     return (
-        <div className="flex flex-col text-sm text-white">
-            <span className="font-bold text-lg mb-4">User Agreement for KaniCasino</span>
-            <span className="mb-2">Last Updated: 04/02/2024</span>
-            <span className="mb-2">
-                Welcome to KaniCasino! This User Agreement outlines the terms and conditions for using our open-source online casino at <span className="text-blue-500">kanicasino.novadrake.com</span>.
+        <div className="flex flex-col text-sm">
+            <span className="font-bold text-lg mb-1">Terms of Service</span>
+            <span className="mb-1 italic">Last updated: 25 August 2026</span>
+            <span className="mb-4 text-ink-muted">
+                These terms cover <span className="text-blue-500">kanicasino.com</span> and the
+                KaniCasino Discord bot. By using either you agree to them. KaniCasino is an
+                independent, open-source project run from Brazil. If anything here is unclear,
+                write to <span className="text-blue-500">novadrake77@gmail.com</span> and a person
+                will answer you.
             </span>
 
-            {[
-                { title: '1. Acceptance of Terms', content: 'By using KaniCasino, you agree to comply with and be bound by the terms and conditions outlined in this User Agreement.' },
-                { title: '2. Eligibility', content: 'You must be of legal age to participate in any form of gambling activity in your jurisdiction. KaniCasino is not intended for individuals under the legal gambling age.' },
-                { title: '3. Account Registration', content: 'To access certain features of KaniCasino, you may be required to register an account. You are responsible for maintaining the confidentiality of your account information.' },
-                { title: '4. Prohibited Activities', content: 'You agree not to engage in any activities that violate applicable laws, regulations, or the terms outlined in this User Agreement. Prohibited activities include, but are not limited to, cheating, fraud, and abuse of the platform.' },
-                { title: '5. Termination of Account', content: 'We reserve the right to terminate or suspend your account if you violate the terms of this User Agreement. You may also close your account at any time.' },
-                { title: '6. Disclaimers', content: 'KaniCasino is provided "as is" without any warranties. We do not guarantee the accuracy, completeness, or reliability of the content and features on the platform.' },
-                { title: '7. Governing Law', content: 'This User Agreement is governed by and construed in accordance with the laws of Brazilian Judicial Branch. Any disputes arising from or related to this agreement will be subject to the exclusive jurisdiction of the courts in Brazil.' },
-                { title: '8. Contact Us', content: 'If you have any questions or concerns about this User Agreement, please contact us at novadrake76@gmail.com' },
-            ].map((section, index) => (
-                <UserAgreementSection key={index} title={section.title} content={section.content} />
-            ))}
+            <Section title="1. There is no real money in KaniCasino">
+                <span>
+                    KaniCasino is a game. Its currency, K₽, is fictional. It cannot be bought, sold,
+                    deposited, withdrawn, transferred out, or exchanged for money or anything of
+                    real value, by us or by anyone else. There are no prizes. We never ask for
+                    payment details and we do not process payments.
+                </span>
+                <span>
+                    Items you win exist only inside KaniCasino and have no value outside it. Buying
+                    or selling KaniCasino accounts, items or K₽ for real money is forbidden, and
+                    doing it is grounds for closing the account. Nothing on the site is an
+                    investment, and nothing here is gambling in the legal sense, because nothing of
+                    value is ever staked or won.
+                </span>
+            </Section>
 
-            <span className="mt-4">
-                By using KaniCasino, you agree to abide by the terms and conditions outlined in this User Agreement.
-            </span>
+            <Section title="2. Who may use it">
+                <span>
+                    You must be at least 18. KaniCasino uses the look and mechanics of casino games,
+                    and it is not intended for children. You must also be allowed to use games of
+                    this kind where you live. If you are not, do not use it.
+                </span>
+            </Section>
+
+            <Section title="3. Your account">
+                <Row label="3.1 One person, one account">
+                    Extra accounts made to collect the same rewards twice, or to influence
+                    leaderboards, rankings or the marketplace, may all be closed.
+                </Row>
+                <Row label="3.2 Keeping it yours">
+                    You are responsible for your login and for what happens through it. Tell us if
+                    you think somebody else has it.
+                </Row>
+                <Row label="3.3 Names and pictures">
+                    Usernames and profile pictures that are hateful, sexual, impersonate somebody
+                    else, or are otherwise abusive will be changed or the account closed.
+                </Row>
+                <Row label="3.4 Closing it">
+                    You can stop using KaniCasino whenever you like, and ask us to delete your
+                    account by email. We may suspend or close an account that breaks these terms.
+                </Row>
+            </Section>
+
+            <Section title="4. The Discord bot">
+                <Row label="4.1 What it is">
+                    An optional way to use KaniCasino from Discord. It shows what a player has
+                    collected, ranks the players in a server, and opens cases on the balance of an
+                    account that has been linked. It is the same account and the same K₽ as the
+                    site.
+                </Row>
+                <Row label="4.2 Linking is yours to choose">
+                    The bot can only act on your account after you link it, which needs you to be
+                    signed in on the site. You can unlink at any time from the settings tab on your
+                    profile, and one Discord account can be linked to one KaniCasino account.
+                </Row>
+                <Row label="4.3 Opening a case costs K₽">
+                    A case opened through the bot charges your balance exactly as it would on the
+                    site, and the item is added to the same inventory. Somebody with no linked
+                    account can watch a demonstration spin, which keeps nothing and charges nothing.
+                </Row>
+                <Row label="4.4 Using it fairly">
+                    Do not automate the bot, script commands, or use it in a way meant to flood a
+                    server or our service. Server administrators may remove the bot from their
+                    server at any time, and we may stop serving a Discord account or a server that
+                    abuses it.
+                </Row>
+                <Row label="4.5 Discord's own rules">
+                    Discord is a separate company. Using the bot also means following Discord's
+                    Terms of Service and Community Guidelines, and Discord's own terms govern your
+                    Discord account, not us.
+                </Row>
+            </Section>
+
+            <Section title="5. Fair play">
+                <span>
+                    Do not cheat, exploit bugs, or use bots, scripts or automation against the site
+                    or the games. If you find a way to get K₽ or items that you should not have,
+                    tell us instead of using it. We may reverse balances, items and results that
+                    came from a bug or from abuse, and we may close accounts that did it knowingly.
+                </span>
+                <span>
+                    Every draw is provably fair and can be checked yourself: the server seed is
+                    committed before the bet and revealed afterwards, and the page at{" "}
+                    <span className="text-blue-500">kanicasino.com/provably-fair</span> shows how to
+                    verify any result.
+                </span>
+            </Section>
+
+            <Section title="6. The game changes">
+                <span>
+                    KaniCasino is worked on continuously. Cases, odds, prices, features and games
+                    may be added, changed or removed, and balances or items may be adjusted where
+                    something was broken. Because K₽ and items have no real value, none of this is
+                    a loss of property, and we do not owe compensation for it.
+                </span>
+                <span>
+                    We may also stop running KaniCasino. If we do, we will say so on the site
+                    beforehand where we reasonably can.
+                </span>
+            </Section>
+
+            <Section title="7. Content and ownership">
+                <span>
+                    Character art belongs to its respective creators and rights holders, and is used
+                    here by a fan project with no claim of ownership and no affiliation with them.
+                    The artists page credits the artists we know of. If you hold rights to something
+                    used here and want it removed, email us and we will remove it.
+                </span>
+                <span>
+                    KaniCasino's own source code is open source under its repository licence. These
+                    terms cover the service we run, not your use of that code.
+                </span>
+            </Section>
+
+            <Section title="8. No warranty, and what we are responsible for">
+                <span>
+                    KaniCasino is provided as it is, free of charge, with no warranty of any kind.
+                    We do not promise it will be available, uninterrupted, or free of errors. To the
+                    extent the law allows, we are not liable for any loss arising from using it, and
+                    since the service is free and its currency is fictional, any liability that
+                    cannot be excluded is limited to what you paid us, which is nothing.
+                </span>
+                <span>
+                    Nothing here limits rights you have under Brazilian consumer law that cannot be
+                    limited by agreement.
+                </span>
+            </Section>
+
+            <Section title="9. Your data">
+                <span>
+                    What we collect and why is set out in our Privacy Policy at{" "}
+                    <span className="text-blue-500">kanicasino.com/privacy-policy</span>, which is
+                    part of these terms.
+                </span>
+            </Section>
+
+            <Section title="10. Changes to these terms">
+                <span>
+                    We may update these terms. The date at the top always shows the current version,
+                    and if a change materially affects you we will say so on the site before it
+                    takes effect. Continuing to use KaniCasino after that means you accept them.
+                </span>
+            </Section>
+
+            <Section title="11. Governing law">
+                <span>
+                    These terms are governed by Brazilian law, and disputes go to the courts of
+                    Brazil. If you are a consumer, this does not take away the right to bring a
+                    claim where you live.
+                </span>
+            </Section>
+
+            <Section title="12. Contact">
+                <span>
+                    Questions, rights requests, takedown requests and anything else:{" "}
+                    <span className="text-blue-500">novadrake77@gmail.com</span>.
+                </span>
+            </Section>
         </div>
     );
-}
+};
 
 export default UserAgreement;

--- a/src/pages/About/Terms.tsx
+++ b/src/pages/About/Terms.tsx
@@ -1,0 +1,13 @@
+import UserAgreement from "../../components/modalsChilden/UserAgreement";
+
+// the routed page and the footer modal render the same document, so the two cannot
+// drift apart. discord's bot verification wants a url rather than a modal.
+const Terms = () => (
+    <div className="flex items-start justify-center w-full px-4 py-8">
+        <div className="max-w-3xl w-full">
+            <UserAgreement />
+        </div>
+    </div>
+);
+
+export default Terms;

--- a/src/seo/routes.json
+++ b/src/seo/routes.json
@@ -68,6 +68,10 @@
       "title": "Privacy Policy | KaniCasino",
       "description": "How KaniCasino handles your data."
     },
+    "/terms": {
+      "title": "Terms of Service | KaniCasino",
+      "description": "The rules for using KaniCasino and its Discord bot. Fictional currency, no real money, no prizes."
+    },
     "/predictions": {
       "title": "Predictions | Player Prediction Markets | KaniCasino",
       "description": "Buy shares in what you think happens next. Anime, gaming and site markets priced by the players, settled in fake coins."


### PR DESCRIPTION
Discord wants a **Terms of Service URL** and a **Privacy Policy URL** before it will verify a bot.

| | |
| --- | --- |
| Privacy Policy | `https://kanicasino.com/privacy-policy` (already existed) |
| Terms of Service | `https://kanicasino.com/terms` (**new**) |

## The terms had no URL, and were wrong

`UserAgreement` was only ever a footer modal, so there was no address to give Discord. It now also renders at `/terms`, sharing one component with the modal so the two cannot drift.

Reading it turned up three real errors:

- it pointed at **kanicasino.novadrake.com**, not the live domain
- the contact was **novadrake76@gmail.com**, one digit off the address in the privacy policy
- it was dated **04/02/2024**

And it never said the currency is fictional, which is the first thing a reviewer of a casino-shaped bot looks for. Section 1 now says plainly that K₽ cannot be bought, sold, deposited, withdrawn or exchanged, that there are no prizes, and that nothing of value is ever staked.

A new section 4 covers the bot: what it is, that linking is optional and reversible, that opening a case spends the same balance as the site, that a demo spin keeps nothing, no automation, and that Discord's own terms still apply.

## The privacy policy now discloses what the bot stores

A new 2.4 covers the Discord ID, the username, when you linked, and the IDs of servers a command was used in, plus the command ID kept for an hour against double charging. It states what is **not** collected: no members, no channels, no messages.

**Every claim was checked against the code**, not written from memory:

| Claim | Verified |
| --- | --- |
| only the `identify` scope | `discordRoutes.js:262` |
| Guilds intent only, cannot read messages | `bot/src/index.js:17` |
| command ID kept one hour | `DiscordOpen.js:20`, `expireAfterSeconds: 3600` |
| unlinking removes all of it | `discordRoutes.js:209`, unsets all four fields |

Retention and the processor list are updated to match.

## Checks

`tsc` clean, frontend 152 passing, build prerenders `/terms` with its own title and adds it to the sitemap (15 routes, was 14).

No legal name or company number appears in either document, only the contact address.