### PR TITLE
fix(discord): stack the reel, so Discord stops dropping its colours

### DIFF
--- a/bot/src/spin.js
+++ b/bot/src/spin.js
@@ -49,7 +49,7 @@ const FRAME_MS = 550;
 // about to land, and it was not, which is exactly why it read as fake.
 const LANDING = FRAMES - 1 + MIDDLE;
 
-const clip = (name) => (name.length > 12 ? `${name.slice(0, 11)}…` : name);
+const clip = (name) => (name.length > 28 ? `${name.slice(0, 27)}…` : name);
 // the reel used to be plain names; entries carry a rarity now, and both still work
 const entryOf = (value) =>
   typeof value === "string" ? { name: value, rarity: null } : { name: value.name, rarity: value.rarity };
@@ -77,15 +77,25 @@ function buildStrip(pool, winner) {
   return strip;
 }
 
+// one colour span per line, and no more.
+//
+// the first version drew the five names across a single line, which needed ten escape
+// sequences in ninety characters, and discord's highlighter silently dropped two of them:
+// the payload asked for red and pink, the client painted grey. the codes were identical to
+// the ones it rendered correctly two cells earlier, so it is a limit in their parser and
+// nothing that can be fixed from this side, only avoided.
+//
+// stacked, each line carries exactly one set and one reset. it also stops truncating names
+// at twelve characters, and the prize now climbs toward the marker rather than sliding.
 function reelRow(strip, offset) {
   const pool = strip && strip.length ? strip.map(entryOf) : [{ name: "?", rarity: null }];
-  const cells = [];
+  const lines = [];
   for (let i = 0; i < WINDOW; i += 1) {
     const entry = pool[(offset + i) % pool.length];
-    const painted = paint(clip(entry.name), entry.rarity);
-    cells.push(i === MIDDLE ? `▐ ${painted} ▌` : ` ${painted} `);
+    const marker = i === MIDDLE ? "▸ " : "  ";
+    lines.push(paint(`${marker}${clip(entry.name)}`, entry.rarity));
   }
-  return "```ansi\n" + cells.join("│") + "\n```";
+  return ["```ansi", ...lines, "```"].join("\n");
 }
 
 function spinningFrame(caseTitle, strip, offset, landed, rarity) {

--- a/bot/src/spin.test.js
+++ b/bot/src/spin.test.js
@@ -13,7 +13,7 @@ const {
 const ESC = String.fromCharCode(27);
 const ANSI = new RegExp(ESC + "\\[[0-9;]*m", "g");
 const plain = (row) => row.replace(ANSI, "").replace(/```ansi\n?|```/g, "").trim();
-const cells = (row) => plain(row).split("│").map((cell) => cell.replace(/[▐▌]/g, "").trim());
+const cells = (row) => plain(row).split("\n").map((line) => line.replace(/▸/g, "").trim());
 
 const POOL = [
   { name: "Yukari", rarity: "4" }, { name: "Remilia", rarity: "3" }, { name: "Yuyuko", rarity: "3" },
@@ -80,10 +80,29 @@ test("each name is painted by its own rarity", () => {
   assert.notStrictEqual(unique, common);
 });
 
+// the reel was one line of five names, which needed ten escape sequences in ninety
+// characters, and discord's highlighter silently dropped two: the payload asked for red
+// and pink, the client painted grey. the codes were identical to ones it had rendered
+// correctly two cells earlier. one span per line is the shape that survives it.
+test("no line asks discord for more than one colour", () => {
+  const row = reelRow(buildStrip(POOL, WON), 0);
+  for (const line of row.split("\n")) {
+    const spans = (line.match(new RegExp(ESC + "\\[[0-9;]*m", "g")) || []).length;
+    assert.ok(spans <= 2, `a line carried ${spans} escape sequences: ${JSON.stringify(line)}`);
+  }
+});
+
+test("every name still gets its own line, and its own colour", () => {
+  const row = reelRow(buildStrip(POOL, WON), 0);
+  const body = row.split("\n").filter((line) => !line.startsWith("```"));
+  assert.strictEqual(body.length, WINDOW, "one line per visible name");
+  for (const line of body) assert.match(line, new RegExp(ESC + "\\["), "each line is coloured");
+});
+
 test("a reel of plain names still renders, since that is what it used to be", () => {
   const row0 = reelRow(["Reimu", "Marisa", "Sanae"], 0);
   assert.match(plain(row0), /Reimu|Marisa|Sanae/);
-  assert.match(plain(row0), /▐ .+ ▌/);
+  assert.match(plain(row0), /▸ /);
 });
 
 test("a long name is cut rather than wrapping the row", () => {
@@ -92,8 +111,8 @@ test("a long name is cut rather than wrapping the row", () => {
 });
 
 test("it still draws a row for a case whose names never arrived", () => {
-  assert.match(plain(reelRow([], 0)), /▐/);
-  assert.match(plain(reelRow(undefined, 3)), /▐/);
+  assert.match(plain(reelRow([], 0)), /▸/);
+  assert.match(plain(reelRow(undefined, 3)), /▸/);
   assert.ok(buildStrip([], null).length >= WINDOW);
 });
 


### PR DESCRIPTION
## The prize came out grey

The payload was not the problem. I dumped exactly what we send for the row in the screenshot:

```
 <E>[31mRemilia<E>[0m │ <E>[1;35mAlice<E>[0m │▐ <E>[31mReisen<E>[0m ▌│ <E>[1;35mAlice<E>[0m │ <E>[1;35mEirin<E>[0m
```

Every cell asks for the right colour. `Remilia` and `Reisen` both ask for `31`; the client painted the first red and the third grey. `Alice` appears twice asking for `1;35`; one rendered pink, the other grey.

That row is **ten escape sequences in ninety characters on one line**, and Discord's highlighter silently dropped two of them. Grey is our own `37` fallback showing through where a sequence went missing. It is a limit in their parser, not something fixable from this side.

## The fix is the shape, not the codes

Stacked, one name per line:

```
     Junko
     Youmu
   ▸ Alice          <- lands
     Remilia
     Yuyuko
```

Every line now carries **exactly one set and one reset**. Verified: `line 1: 2, line 2: 2, line 3: 2, line 4: 2, line 5: 2`.

Two things come free. Names stop being cut at twelve characters, so `The Special Package` and `Yukari (Blue Archive)` read properly. And the prize climbs toward the marker instead of sliding, which is if anything closer to a reel.

The continuity from the last change is untouched: the prize is still seated where the final frame's marker lands, still walks in one place per frame.

## Tests

Bot 22 → 24. The one that matters asserts **no line asks Discord for more than one colour**, because this failure is silent and only shows up in a real client, which is exactly how it got shipped.