### PR TITLE
fix(discord): a common asked Discord for a colour it does not draw

### DIFF
--- a/backend/__tests__/integration/discordOpen.test.js
+++ b/backend/__tests__/integration/discordOpen.test.js
@@ -91,6 +91,9 @@ describe("opening a case from discord", () => {
     expect(res.body.walletBalance).toBe(4400);
     expect(res.body.items).toHaveLength(2);
     expect(res.body.items[0].rollId).toEqual(expect.any(String));
+    // the bot paints the prize by this, and a missing one renders as plain white
+    expect(res.body.items[0].rarity).toMatch(/^[1-5]$/);
+    expect(res.body.reel[0]).toMatchObject({ name: expect.any(String), rarity: expect.stringMatching(/^[1-5]$/) });
 
     const after = await User.findById(user._id).lean();
     expect(after.walletBalance).toBe(4400);

--- a/bot/src/spin.js
+++ b/bot/src/spin.js
@@ -21,7 +21,14 @@ const SPINNING = 0x4a4a5a;
 // colour into the reel. as near the site's five as eight colours allow, so a gold name
 // walking toward the marker reads the way a gold reads on the site. a client that does not
 // render ansi shows the plain name, which is what it showed before.
-const ANSI = { "1": "34", "2": "35", "3": "1;35", "4": "31", "5": "1;33" };
+// bold everywhere it is not already, because bold is the form discord has been seen to
+// render. a common came out plain white: it asked for bare "34" and got nothing, while
+// "31", "1;33" and "1;35" all painted correctly on the same line. the reels of these cases
+// hold nothing under rarity 3, so bare "34" and "35" had never actually been drawn before.
+//
+// cyan for rare rather than the site's purple: ansi has no purple, and pink is spent on
+// epic, so telling one from the other matters more here than matching the hex.
+const ANSI = { "1": "1;34", "2": "1;36", "3": "1;35", "4": "31", "5": "1;33" };
 const ESC = String.fromCharCode(27);
 const paint = (text, rarity) => `${ESC}[${ANSI[String(rarity)] || "37"}m${text}${ESC}[0m`;
 

--- a/bot/src/spin.test.js
+++ b/bot/src/spin.test.js
@@ -70,6 +70,21 @@ test("two spins of one case do not scroll the same order", () => {
   assert.ok(many.size > 1, "the strip is shuffled per spin");
 });
 
+// a common landed plain white: it asked for bare "34", which discord drew as nothing,
+// while "31", "1;33" and "1;35" painted correctly on the same line. every rarity has to
+// use a form that has been seen to render, and every one has to differ from the others.
+test("every rarity asks for a code discord has been seen to render", () => {
+  const seen = ["31", "1;31", "1;33", "1;34", "1;35", "1;36"];
+  const codes = new Set();
+  for (const rarity of ["1", "2", "3", "4", "5"]) {
+    const line = reelRow([{ name: "X", rarity }], 0).split("\n")[1];
+    const code = (line.match(new RegExp(ESC + "\\[([0-9;]+)m")) || [])[1];
+    assert.ok(seen.includes(code), `rarity ${rarity} asks for ${code}, which has never been seen to render`);
+    codes.add(code);
+  }
+  assert.strictEqual(codes.size, 5, "two rarities would look the same");
+});
+
 test("each name is painted by its own rarity", () => {
   const row0 = reelRow(buildStrip(POOL, WON), 0);
   assert.ok(row0.includes(ESC + "["), "colour is in the payload");


### PR DESCRIPTION
## Not the data this time

I checked before changing anything. `Minoriko` sits at **position 46 of 61** in the Nuclear Case with rarity `"1"`, and the reel only sends the first 16, so it was never reel filler. It was the prize, which is the one entry that does not come from the reel.

The backend is fine, and there is now a test proving it: `/discord/open` returns a rarity on the item and on every reel entry, all matching `^[1-5]$`.

## It is the code we asked for

Line up what your screenshots have actually shown Discord render:

| rarity | code | result |
| --- | --- | --- |
| 4 (Junko, Yuyuko) | `31` | red, correct |
| 5 (Youmu) | `1;33` | gold, correct |
| 3 (Okuu, Alice) | `1;35` | pink, correct |
| 1 (Minoriko) | `34` | **plain white** |
| 2 | `35` | never once drawn |

Every code that has worked is either `31` or a **bold** `1;XX`. The one failure is a bare code that is not `31`.

And this went unnoticed because **these cases hold nothing below rarity 3 in the sixteen items the reel sends** — the Nuclear Case's first 16 are all 3, 4 and 5. So bare `34` and `35` had never been drawn at all until a common turned up as a prize.

## Change

Every rarity uses a bold form, which is what has been seen to work. The three confirmed codes keep rendering the same way.

```
1  1;34  bold blue     (was 34, drew nothing)
2  1;36  bold cyan     (was 35, never tested)
3  1;35  bold pink     confirmed
4  31    red           confirmed
5  1;33  bold gold     confirmed
```

Rare goes cyan rather than the site's purple: ANSI has no purple, pink is spent on epic, and telling the two apart at a glance matters more here than matching the hex.

## Tests

Bot 24 → 25, backend assertion added. The new guard checks every rarity asks for a code from the seen-to-render set, and that no two rarities resolve to the same one.

## Worth saying plainly

Rarity 1 and 2 are still **unverified in a real client**. I can prove the payload and the code path, but not how Discord draws it. A common or rare landing is what confirms it, and the cheap cases are where those live.