### PR TITLE
feat(bot): a case menu that does not go through the slash picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,22 @@ jobs:
       - run: npm run build
       - run: npm run test:unit
 
+  bot:
+    name: Bot tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bot
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: bot/package-lock.json
+      - run: npm ci
+      - run: npm test
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/backend/__tests__/integration/discordBot.test.js
+++ b/backend/__tests__/integration/discordBot.test.js
@@ -6,6 +6,7 @@ const request = require("supertest");
 const { setupDb, clearDb, teardownDb } = require("./db");
 const { makeApp, tokenFor, uniqueSuffix } = require("./helpers");
 
+const Case = require("../../models/Case");
 const User = require("../../models/User");
 const DiscordLink = require("../../models/DiscordLink");
 const FanBoard = require("../../models/FanBoard");
@@ -452,4 +453,98 @@ describe("where a failed link sends the player", () => {
     expect(res.headers.location).toContain("/profile/me?tab=settings&discord=expired");
     expect(res.headers.location).not.toContain("aaaaaaaaaaaaaaaaaaaaaaaa");
   });
+
+// The menu asks for shelves, then for a page of one shelf. Both are new surfaces on a route
+// the autocomplete already depended on, so what matters is that the shelf page is a stable
+// slice and that the autocomplete path is untouched by any of it.
+describe("the case menu", () => {
+  const CAP = 20000;
+  const makeCase = (title, price, category) =>
+    Case.create({ title, price, category, image: "https://example.test/c.png", items: [] });
+
+  const categories = () => bot(request(app).get("/discord/categories"));
+  const shelf = (category, offset) =>
+    bot(request(app).get("/discord/cases").query(offset === undefined ? { category } : { category, offset }));
+
+  beforeEach(async () => {
+    for (let i = 0; i < 30; i += 1) await makeCase(`CS ${String(i).padStart(2, "0")}`, 10 + i, "Counter-Strike");
+    await makeCase("Kivotos", 30, "Blue Archive");
+    await makeCase("Millennium", 40, "Blue Archive");
+  });
+
+  it("needs the bot secret like everything else here", async () => {
+    expect((await request(app).get("/discord/categories")).status).toBe(403);
+  });
+
+  it("lists a shelf per category, with its size and its cheapest case", async () => {
+    const res = await categories();
+    expect(res.status).toBe(200);
+    const byName = Object.fromEntries(res.body.categories.map((one) => [one.name, one]));
+    expect(byName["Counter-Strike"]).toMatchObject({ count: 30, from: 10 });
+    expect(byName["Blue Archive"]).toMatchObject({ count: 2, from: 30 });
+  });
+
+  // the menu must never offer what /open would then refuse to open
+  it("leaves a case dearer than the cap off the shelf entirely", async () => {
+    await makeCase("Katowice Legends", CAP + 1, "Souvenir");
+    const names = (await categories()).body.categories.map((one) => one.name);
+    expect(names).not.toContain("Souvenir");
+    expect((await shelf("Counter-Strike")).body.total).toBe(30);
+  });
+
+  it("gives a case with no category a shelf that has a usable name", async () => {
+    await makeCase("Loose", 25, "");
+    const found = (await categories()).body.categories.find((one) => one.name === "~none");
+    expect(found).toMatchObject({ count: 1 });
+    expect((await shelf("~none")).body.cases.map((one) => one.title)).toEqual(["Loose"]);
+  });
+
+  it("returns one shelf, cheapest first, capped at what a select can hold", async () => {
+    const res = await shelf("Counter-Strike");
+    expect(res.body.cases).toHaveLength(25);
+    expect(res.body.total).toBe(30);
+    expect(res.body.cases.every((one) => one.category === "Counter-Strike")).toBe(true);
+    const prices = res.body.cases.map((one) => one.price);
+    expect([...prices]).toEqual([...prices].sort((a, b) => a - b));
+  });
+
+  // a page that reshuffles between clicks shows one case twice and hides another, which is
+  // the whole reason this path does not get the autocomplete's per-player reordering
+  it("pages without repeating or dropping a case", async () => {
+    const first = await shelf("Counter-Strike", 0);
+    const second = await shelf("Counter-Strike", 25);
+    expect(second.body.cases).toHaveLength(5);
+    expect(second.body.offset).toBe(25);
+    const ids = [...first.body.cases, ...second.body.cases].map((one) => one.id);
+    expect(new Set(ids).size).toBe(30);
+  });
+
+  it("hands back an empty page rather than failing past the end", async () => {
+    const res = await shelf("Counter-Strike", 500);
+    expect(res.status).toBe(200);
+    expect(res.body.cases).toEqual([]);
+    expect(res.body.total).toBe(30);
+  });
+
+  it("treats a shelf that does not exist as empty, not as an error", async () => {
+    const res = await shelf("Nothing Here");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ cases: [], total: 0 });
+  });
+
+  // the autocomplete asked for this route first and must keep the behaviour it had
+  it("still answers the autocomplete with no category, unpaged", async () => {
+    const res = bot(request(app).get("/discord/cases"));
+    const body = (await res).body;
+    expect(body.cases.length).toBe(25);
+    expect(body.total).toBeUndefined();
+    expect(body.maxPrice).toBe(CAP);
+  });
+
+  it("still searches by title and by series when asked to", async () => {
+    const res = await bot(request(app).get("/discord/cases").query({ q: "Blue Archive" }));
+    expect(res.body.cases.map((one) => one.title).sort()).toEqual(["Kivotos", "Millennium"]);
+  });
+});
+
 });

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -352,12 +352,70 @@ const publicCase = (one) => ({
   category: one.category || "",
 });
 
+// a case with no category is its own shelf, and an empty string cannot be a select value
+const NO_CATEGORY = "~none";
+const categoryFilter = (name) =>
+  name === NO_CATEGORY ? { $in: ["", null] } : name;
+
+// the shelves the menu opens with. one grouped pass over a collection of tens of documents,
+// behind the same price cap the case list uses, so the menu never offers what /open refuses.
+router.get("/categories", botOnly, async (req, res) => {
+  try {
+    const rows = await Case.aggregate([
+      { $match: { price: { $lte: MAX_CASE_PRICE } } },
+      {
+        $group: {
+          _id: { $ifNull: ["$category", ""] },
+          count: { $sum: 1 },
+          from: { $min: "$price" },
+        },
+      },
+      { $sort: { count: -1, _id: 1 } },
+    ]);
+    res.json({
+      categories: rows.map((row) => ({
+        name: row._id || NO_CATEGORY,
+        count: row.count,
+        from: row.from || 0,
+      })),
+    });
+  } catch (err) {
+    console.error("discord categories:", err.message);
+    res.status(500).json({ message: "Could not load the categories" });
+  }
+});
+
 // what the bot offers in autocomplete. with an empty box it leads with the cases this
 // player last opened, which is what makes opening the same one again quick to type.
+// `category` instead switches it to a stable page of one shelf, for the menu.
 router.get("/cases", botOnly, async (req, res) => {
   try {
     const search = String(req.query.q || "").trim();
+    const category = String(req.query.category || "").trim();
+    const offset = Math.max(0, parseInt(req.query.offset, 10) || 0);
     const filter = { price: { $lte: MAX_CASE_PRICE } };
+
+    // a page has to be the same slice every time it is asked for, so this path is counted
+    // and skipped in mongo and never gets the per-player reshuffle below: a list that
+    // reorders between pages shows the same case twice and hides another entirely
+    if (category) {
+      filter.category = categoryFilter(category);
+      const [page, total] = await Promise.all([
+        Case.find(filter, { title: 1, price: 1, image: 1, category: 1 })
+          .sort({ price: 1, _id: 1 })
+          .skip(offset)
+          .limit(CASE_CHOICES)
+          .lean(),
+        Case.countDocuments(filter),
+      ]);
+      return res.json({
+        cases: page.map(publicCase),
+        total,
+        offset,
+        maxPrice: MAX_CASE_PRICE,
+      });
+    }
+
     // the category is how players ask for these: not one case is called "Touhou", they are
     // Lunatic and Nuclear and The Special Package, and typing the series has to find them
     if (search) {

--- a/bot/package.json
+++ b/bot/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "register": "node src/register.js",
-    "test": "node --test src/messages.test.js src/spin.test.js"
+    "test": "node --test src/messages.test.js src/spin.test.js src/menu.test.js"
   },
   "dependencies": {
     "discord.js": "^14.16.3",

--- a/bot/src/api.js
+++ b/bot/src/api.js
@@ -57,10 +57,16 @@ module.exports = {
   seen: (discordId, guildId) =>
     post("/discord/seen", { discordId, guildId }).catch(() => {}),
 
-  cases: (query, discordId) => {
+  categories: () => get("/discord/categories"),
+
+  // `category` switches the backend to a stable page of one shelf; without it this is the
+  // autocomplete list, which is ordered per player and must not be paged
+  cases: (query, discordId, page) => {
     const params = new URLSearchParams();
     if (query) params.set("q", query);
     if (discordId) params.set("discordId", discordId);
+    if (page && page.category) params.set("category", page.category);
+    if (page && page.offset) params.set("offset", String(page.offset));
     const suffix = params.toString();
     return get("/discord/cases" + (suffix ? `?${suffix}` : ""));
   },

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, MessageFlags, ContainerBuilder, TextDisplayBuilder 
 const api = require("./api");
 const { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE } = require("./embeds");
 const { buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS } = require("./spin");
+const { categoryFrame, caseFrame, tokenOf } = require("./menu");
 
 // rejected in the bot's own memory, before any http call. spamming a command costs a map
 // lookup here rather than a query on a link that carries about 100 KB/s.
@@ -39,13 +40,63 @@ const OPENING = () =>
     .setAccentColor(0x4a4a5a)
     .addTextDisplayComponents(new TextDisplayBuilder().setContent("Opening…"));
 
-// shared by the command and by the "open another" button, which is the quickest way to
-// open the same case again and the reason the command only has to be typed once
-async function runOpen(interaction, caseId) {
-  if (!interaction.replied && !interaction.deferred) {
+// the two menus, built here because both of them are a read plus a frame and the mention
+// handler, the bare /open and the select all want the same payload
+async function seriesMenu() {
+  const { categories } = await api.categories();
+  return { components: [categoryFrame(categories)], ...V2 };
+}
+
+// the pager carries a digest rather than the name, so a page click resolves it against the
+// shelf list first. that is the same small grouped read the series menu already does.
+async function categoryFor(token) {
+  const { categories } = await api.categories();
+  const found = (categories || []).find((one) => tokenOf(one.name) === token);
+  return found ? found.name : null;
+}
+
+async function casesMenu(category, offset) {
+  const page = await api.cases("", null, { category, offset });
+  return {
+    components: [
+      caseFrame({ category, cases: page.cases || [], total: page.total || 0, offset: page.offset || 0 }),
+    ],
+    ...V2,
+  };
+}
+
+// shared by the command, the menu and the "open another" button, which is the quickest way
+// to open the same case again and the reason the command only has to be typed once.
+// `channel` is for the menu: that interaction is spent closing the select, so the spin is
+// posted as its own message and edited in place rather than being the interaction's reply.
+async function runOpen(interaction, caseId, { channel } = {}) {
+  const post = channel ? await channel.send({ components: [OPENING()], ...V2 }) : null;
+  const draw = post ? (payload) => post.edit(payload) : (payload) => interaction.editReply(payload);
+
+  if (!post && !interaction.replied && !interaction.deferred) {
     await interaction.reply({ components: [OPENING()], ...V2 });
   }
+  // a spin the menu started is its own message, so the handler upstream cannot turn it into
+  // the error the way it does for a reply. without this, "Opening…" sits there for good.
+  if (post) return spin(interaction, caseId, draw).catch(async (err) => {
+    await draw({ components: [failedFrame(err)], ...V2 }).catch(() => {});
+    throw err;
+  });
+  return spin(interaction, caseId, draw);
+}
 
+// what the site said, when it said anything a player can act on; the wording matches the
+// interaction handler so the two routes into a spin fail identically
+function failedFrame(err) {
+  const said = err && (err.status === 403 || err.status === 409) && err.message;
+  return new ContainerBuilder()
+    .setAccentColor(0x4a4a5a)
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(said || "The site did not answer. Try again in a moment.")
+    );
+}
+
+async function spin(interaction, caseId, draw) {
   let opened = null;
   let demo = null;
   try {
@@ -65,7 +116,7 @@ async function runOpen(interaction, caseId) {
   // than being swapped out mid-spin for a card that came from nowhere
   for (let frame = 0; frame < FRAMES; frame += 1) {
     const landing = frame === FRAMES - 1;
-    await interaction.editReply({
+    await draw({
       components: [spinningFrame(caseTitle, strip, frame, landing ? won.name : null, won.rarity)],
       ...V2,
     });
@@ -73,11 +124,11 @@ async function runOpen(interaction, caseId) {
   }
 
   if (demo) {
-    await interaction.editReply({ components: [demoFrame({ item: demo.item, caseTitle })], ...V2 });
+    await draw({ components: [demoFrame({ item: demo.item, caseTitle })], ...V2 });
     return;
   }
 
-  await interaction.editReply({
+  await draw({
     components: [
       revealFrame({
         item: won,
@@ -122,8 +173,8 @@ const commands = [
       .addStringOption((option) =>
         option
           .setName("case")
-          .setDescription("Which case. Start typing, or pick the one you opened last.")
-          .setRequired(true)
+          .setDescription("Which case. Leave it empty to pick from a menu.")
+          .setRequired(false)
           .setAutocomplete(true)
       ),
     // 64 cases is well past discord's 25 choice cap, so the list is filtered server side.
@@ -144,7 +195,11 @@ const commands = [
       );
     },
     async run(interaction) {
-      await runOpen(interaction, interaction.options.getString("case"));
+      const caseId = interaction.options.getString("case");
+      // no case named is not an error: it is the menu, which is the whole point of not
+      // making a player know a case id before they can open one
+      if (!caseId) return interaction.reply(await seriesMenu());
+      await runOpen(interaction, caseId);
     },
   },
   {
@@ -225,4 +280,4 @@ const commands = [
   },
 ];
 
-module.exports = { commands, onCooldown, runOpen };
+module.exports = { commands, onCooldown, runOpen, seriesMenu, casesMenu, categoryFor, failedFrame };

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -3,7 +3,8 @@ require("dotenv").config();
 const { Client, Events, GatewayIntentBits, MessageFlags } = require("discord.js");
 const api = require("./api");
 const { noticeEmbed } = require("./embeds");
-const { commands, onCooldown, runOpen } = require("./commands");
+const { commands, onCooldown, runOpen, seriesMenu, casesMenu, categoryFor } = require("./commands");
+const { isMenu, parseMenu, chosenFrame } = require("./menu");
 
 const REQUIRED = ["DISCORD_BOT_TOKEN", "DISCORD_BOT_SECRET", "API_KEY"];
 const missing = REQUIRED.filter((key) => !process.env[key]);
@@ -12,9 +13,10 @@ if (missing.length) {
   process.exit(1);
 }
 
-// Guilds is the only intent this needs. slash commands arrive as interactions, so nothing
-// here reads messages or member lists, and no privileged intent has to be requested.
-const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+// GuildMessages is here for the mention, which is the only way in that does not go through
+// the slash picker. neither intent is privileged: a bare mention is read off the mentions
+// list, and message content stays empty, which is all this needs and nothing more.
+const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 
 const byName = new Map(commands.map((command) => [command.data.name, command]));
 
@@ -37,6 +39,37 @@ async function suggest(interaction) {
   } catch (err) {
     await interaction.respond([]).catch(() => {});
   }
+}
+
+// the menu charges whoever clicked, on the case they just picked themselves, so it needs
+// no owner check: a second player using someone else's open menu spins on their own balance
+async function navigated(interaction) {
+  const { kind, token, offset } = parseMenu(interaction.customId);
+  if (kind === "back") return interaction.update(await seriesMenu());
+  if (kind === "cat") return interaction.update(await casesMenu(interaction.values[0], 0));
+  if (kind === "page") {
+    // the shelf can be renamed or emptied between the render and the click, and paging a
+    // category that no longer exists should land somewhere real rather than on nothing
+    const category = await categoryFor(token);
+    return interaction.update(category ? await casesMenu(category, offset) : await seriesMenu());
+  }
+  if (kind !== "case") return;
+
+  const wait = onCooldown(interaction.user.id, "open");
+  if (wait) {
+    return interaction.reply({
+      embeds: [noticeEmbed(`Give it ${wait}s.`)],
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+  // close the select first: the interaction has three seconds and the spin takes longer,
+  // and a live select under a running spin is a second charge waiting to happen
+  const chosen = interaction.component.options.find((one) => one.value === interaction.values[0]);
+  await interaction.update({
+    components: [chosenFrame(chosen ? chosen.label : "it")],
+    flags: MessageFlags.IsComponentsV2,
+  });
+  await runOpen(interaction, interaction.values[0], { channel: interaction.channel });
 }
 
 // "open another" on somebody else's reveal would charge the clicker for a case they did
@@ -63,6 +96,7 @@ async function pressed(interaction) {
 client.on(Events.InteractionCreate, async (interaction) => {
   try {
     if (interaction.isAutocomplete()) return await suggest(interaction);
+    if (isMenu(interaction.customId)) return await navigated(interaction);
     if (interaction.isButton()) return await pressed(interaction);
   } catch (err) {
     console.error("bot interaction:", err.message);
@@ -90,6 +124,25 @@ client.on(Events.InteractionCreate, async (interaction) => {
     if (err.status === 403 || err.status === 409) return reply(interaction, err.message);
     console.error(`bot ${interaction.commandName}:`, err.message);
     reply(interaction, "The site did not answer. Try again in a moment.");
+  }
+});
+
+// the way in for a player who does not know the commands exist: they type the bot's name,
+// which is the one thing everybody already knows how to do. a bare mention is enough, so
+// the message content stays unread and the privileged intent stays unrequested.
+client.on(Events.MessageCreate, async (message) => {
+  if (message.author.bot || !message.guildId) return;
+  if (!message.mentions.has(client.user, { ignoreEveryone: true, ignoreRoles: true, ignoreRepliedUser: true })) return;
+
+  const wait = onCooldown(message.author.id, "menu");
+  if (wait) return;
+
+  try {
+    await api.seen(message.author.id, message.guildId);
+    await message.reply(await seriesMenu());
+  } catch (err) {
+    console.error("bot mention:", err.message);
+    await message.reply({ embeds: [noticeEmbed("The site did not answer. Try again in a moment.")] }).catch(() => {});
   }
 });
 

--- a/bot/src/menu.js
+++ b/bot/src/menu.js
@@ -1,0 +1,151 @@
+const crypto = require("node:crypto");
+const {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ContainerBuilder,
+  SeparatorBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+  TextDisplayBuilder,
+} = require("discord.js");
+const { SITE, colorOf } = require("./spin");
+
+// discord's own ceiling on a select, and the same number the backend pages by
+const PER_PAGE = 25;
+const NO_CATEGORY = "~none";
+const ACCENT = 0xf0287a;
+
+const num = (value) => Number(value || 0).toLocaleString("en-US");
+const label = (name) => (name === NO_CATEGORY ? "Other" : name);
+
+// a category name is free text with no length limit and a custom id has a hard 100
+// character one, so the id carries a digest of the name and a click resolves it back
+// against the shelf list. the name itself only ever travels as a select value.
+const tokenOf = (name) => crypto.createHash("sha1").update(String(name || "")).digest("hex").slice(0, 10);
+
+const ID = {
+  category: "menu|cat",
+  cases: (category, offset) => `menu|case|${tokenOf(category)}|${offset}`,
+  page: (category, offset) => `menu|page|${tokenOf(category)}|${offset}`,
+  back: "menu|back",
+};
+
+// every menu id starts here, so index.js can route the whole family on one prefix
+const isMenu = (customId) => String(customId || "").startsWith("menu|");
+
+function parseMenu(customId) {
+  const [, kind, token, offset] = String(customId || "").split("|");
+  return { kind, token: token || "", offset: Math.max(0, parseInt(offset, 10) || 0) };
+}
+
+const row = (component) => new ActionRowBuilder().addComponents(component);
+
+function categoryFrame(categories) {
+  const container = new ContainerBuilder()
+    .setAccentColor(ACCENT)
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent("### Open a case"))
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent("Pick a series, then pick a case. No command to remember.")
+    )
+    .addSeparatorComponents(new SeparatorBuilder());
+
+  if (!categories.length) {
+    return container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent("No cases are open in Discord right now.")
+    );
+  }
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(ID.category)
+    .setPlaceholder("Choose a series")
+    .addOptions(
+      categories.slice(0, PER_PAGE).map((one) =>
+        new StringSelectMenuOptionBuilder()
+          .setLabel(label(one.name).slice(0, 100))
+          .setValue(String(one.name).slice(0, 100))
+          .setDescription(`${num(one.count)} cases · from K₽ ${num(one.from)}`.slice(0, 100))
+      )
+    );
+
+  return container.addActionRowComponents(row(select));
+}
+
+function caseFrame({ category, cases, total, offset }) {
+  const first = offset + 1;
+  const last = offset + cases.length;
+  const paged = total > cases.length;
+
+  const container = new ContainerBuilder()
+    .setAccentColor(ACCENT)
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`### ${label(category)}`))
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        paged ? `${num(total)} cases · showing ${num(first)}-${num(last)}` : `${num(total)} cases`
+      )
+    )
+    .addSeparatorComponents(new SeparatorBuilder());
+
+  if (!cases.length) {
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent("Nothing on this shelf opens in Discord.")
+    );
+  } else {
+    const select = new StringSelectMenuBuilder()
+      .setCustomId(ID.cases(category, offset))
+      .setPlaceholder("Choose a case")
+      .addOptions(
+        cases.map((one) =>
+          new StringSelectMenuOptionBuilder()
+            .setLabel(String(one.title).slice(0, 100))
+            .setValue(String(one.id).slice(0, 100))
+            .setDescription(`K₽ ${num(one.price)}`.slice(0, 100))
+        )
+      );
+    container.addActionRowComponents(row(select));
+  }
+
+  const controls = [
+    new ButtonBuilder().setCustomId(ID.back).setLabel("Series").setStyle(ButtonStyle.Secondary),
+  ];
+  if (offset > 0) {
+    controls.push(
+      new ButtonBuilder()
+        .setCustomId(ID.page(category, Math.max(0, offset - PER_PAGE)))
+        .setLabel("Previous")
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+  if (last < total) {
+    controls.push(
+      new ButtonBuilder()
+        .setCustomId(ID.page(category, offset + PER_PAGE))
+        .setLabel("Next")
+        .setStyle(ButtonStyle.Secondary)
+    );
+  }
+  controls.push(new ButtonBuilder().setLabel("See them on the site").setStyle(ButtonStyle.Link).setURL(SITE));
+
+  return container.addActionRowComponents(new ActionRowBuilder().addComponents(...controls));
+}
+
+// what the menu turns into once a case has been picked: the spin is its own message, so
+// leaving the select live would let a stray second pick charge for a case nobody chose
+function chosenFrame(title) {
+  return new ContainerBuilder()
+    .setAccentColor(colorOf(null))
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${title}** below.`));
+}
+
+module.exports = {
+  ID,
+  tokenOf,
+  PER_PAGE,
+  NO_CATEGORY,
+  isMenu,
+  parseMenu,
+  categoryFrame,
+  caseFrame,
+  chosenFrame,
+  label,
+};

--- a/bot/src/menu.test.js
+++ b/bot/src/menu.test.js
@@ -1,0 +1,133 @@
+// The menu is the way in for a player who does not know the commands exist, so the shapes
+// it builds have to be valid before a player finds out otherwise: discord rejects a select
+// with an empty value or a custom id over 100 characters at the moment somebody clicks it,
+// not when it is built.
+process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+
+const test = require("node:test");
+const assert = require("node:assert");
+const { ID, PER_PAGE, NO_CATEGORY, isMenu, parseMenu, categoryFrame, caseFrame, label, tokenOf } = require("./menu");
+
+const json = (frame) => frame.toJSON();
+const rows = (frame) => json(frame).components.filter((c) => c.type === 1);
+const select = (frame) => rows(frame).flatMap((r) => r.components).find((c) => c.type === 3);
+const buttons = (frame) => rows(frame).flatMap((r) => r.components).filter((c) => c.type === 2);
+const text = (frame) => json(frame).components.filter((c) => c.type === 10).map((c) => c.content).join("\n");
+
+const CATEGORIES = [
+  { name: "Counter-Strike", count: 42, from: 15 },
+  { name: "Blue Archive", count: 8, from: 30 },
+];
+const cases = (n, offset = 0) =>
+  Array.from({ length: n }, (_, i) => ({ id: `case${offset + i}`, title: `Case ${offset + i}`, price: (offset + i + 1) * 10 }));
+
+test("a category resolves back out of a custom id, punctuation and all", () => {
+  for (const name of ["Counter-Strike", "Re:Zero", "Uma Musume", "a|b", NO_CATEGORY]) {
+    const parsed = parseMenu(ID.cases(name, 25));
+    assert.equal(parsed.token, tokenOf(name));
+    assert.equal(parsed.offset, 25);
+    assert.equal(parsed.kind, "case");
+  }
+});
+
+// two shelves resolving to the same token would page one and render the other
+test("distinct categories get distinct tokens", () => {
+  const names = ["Counter-Strike", "Blue Archive", "Uma Musume", "Touhou", "Animals", NO_CATEGORY, ""];
+  assert.equal(new Set(names.map(tokenOf)).size, names.length);
+});
+
+// discord refuses a custom id over 100 characters, and a category is free text with no
+// length limit of its own, so the id must not grow with the name
+test("a custom id stays inside discord's 100 character limit whatever the name", () => {
+  const long = "A very long series name that somebody could plausibly type into the admin panel one day".repeat(4);
+  assert.ok(ID.cases(long, 100).length <= 100, ID.cases(long, 100).length + " characters");
+  assert.ok(ID.page(long, 100).length <= 100);
+});
+
+test("every menu id is routable on the one prefix", () => {
+  assert.ok(isMenu(ID.category));
+  assert.ok(isMenu(ID.back));
+  assert.ok(isMenu(ID.cases("Touhou", 0)));
+  assert.ok(isMenu(ID.page("Touhou", 25)));
+  assert.equal(isMenu("open:abc:123"), false);
+  assert.equal(isMenu(undefined), false);
+});
+
+test("the series menu offers one option per shelf, with its count", () => {
+  const options = select(categoryFrame(CATEGORIES)).options;
+  assert.equal(options.length, 2);
+  assert.equal(options[0].value, "Counter-Strike");
+  assert.match(options[0].description, /42 cases/);
+});
+
+test("an uncategorised shelf is called Other and still carries a usable value", () => {
+  const options = select(categoryFrame([{ name: NO_CATEGORY, count: 2, from: 30 }])).options;
+  assert.equal(options[0].label, "Other");
+  assert.ok(options[0].value.length > 0);
+  assert.equal(label(NO_CATEGORY), "Other");
+});
+
+// a site with no cases under the discord price cap must not build a select with no options
+test("no shelves renders a message rather than an empty select", () => {
+  const frame = categoryFrame([]);
+  assert.equal(select(frame), undefined);
+  assert.match(text(frame), /No cases/i);
+});
+
+test("a shelf that fits on one page offers no pager", () => {
+  const labels = buttons(caseFrame({ category: "Touhou", cases: cases(3), total: 3, offset: 0 })).map((b) => b.label);
+  assert.deepEqual(labels.filter((l) => l === "Next" || l === "Previous"), []);
+  assert.ok(labels.includes("Series"));
+});
+
+test("the first page of a long shelf offers Next and not Previous", () => {
+  const frame = caseFrame({ category: "Counter-Strike", cases: cases(PER_PAGE), total: 42, offset: 0 });
+  const labels = buttons(frame).map((b) => b.label);
+  assert.ok(labels.includes("Next"));
+  assert.ok(!labels.includes("Previous"));
+  assert.match(text(frame), /showing 1-25/);
+});
+
+test("the last page offers Previous and not Next", () => {
+  const frame = caseFrame({ category: "Counter-Strike", cases: cases(17, 25), total: 42, offset: 25 });
+  const labels = buttons(frame).map((b) => b.label);
+  assert.ok(labels.includes("Previous"));
+  assert.ok(!labels.includes("Next"));
+  assert.match(text(frame), /showing 26-42/);
+});
+
+// paging backwards from the second page has to land on 0, not on a negative offset
+test("Previous never pages past the start", () => {
+  const back = buttons(caseFrame({ category: "Counter-Strike", cases: cases(17, 25), total: 42, offset: 25 }))
+    .find((b) => b.label === "Previous");
+  assert.equal(parseMenu(back.custom_id).offset, 0);
+  assert.equal(parseMenu(back.custom_id).token, tokenOf("Counter-Strike"));
+});
+
+test("a case option carries the id as its value, which is what gets opened", () => {
+  const options = select(caseFrame({ category: "Touhou", cases: cases(2), total: 2, offset: 0 })).options;
+  assert.deepEqual(options.map((o) => o.value), ["case0", "case1"]);
+});
+
+// an empty shelf can only happen if the catalogue changes between the two clicks, and a
+// select with no options is rejected by discord rather than ignored
+test("a shelf that empties between clicks renders without a select", () => {
+  const frame = caseFrame({ category: "Touhou", cases: [], total: 0, offset: 0 });
+  assert.equal(select(frame), undefined);
+  assert.ok(buttons(frame).some((b) => b.label === "Series"));
+});
+
+// A spin the menu started is its own message, so nothing upstream can rewrite it into the
+// error. If this frame is wrong the player is left watching "Opening…" forever.
+const { failedFrame } = require("./commands");
+
+test("a refusal the player can act on is repeated verbatim", () => {
+  const frame = failedFrame({ status: 403, message: "That costs K₽ 500 and you have K₽ 12." });
+  assert.match(text(frame), /you have/);
+});
+
+test("anything else says the site is unwell rather than leaking it", () => {
+  for (const err of [{ status: 500, message: "ECONNREFUSED 127.0.0.1:5001" }, undefined]) {
+    assert.match(text(failedFrame(err)), /did not answer/i);
+  }
+});

--- a/bot/src/messages.test.js
+++ b/bot/src/messages.test.js
@@ -12,7 +12,7 @@ const assert = require("node:assert");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const SOURCES = ["commands.js", "embeds.js", "index.js"];
+const SOURCES = ["commands.js", "embeds.js", "index.js", "menu.js"];
 
 // only the lines that state an account is missing. "Link your account" and "No account
 // yet? Sign up first" are the instruction itself, and must not be caught by their own rule.


### PR DESCRIPTION
## Problem

A player typed `/open` as literal text and pressed enter. That sends a message, not a command, so the bot never heard it. The command was registered and usable in that server, and permissions were fine; the slash picker is just easy to miss, especially on mobile. Nothing about it is fixable from inside the slash system.

## Change

Two ways in that skip the picker:

- **`@Daisu-chan`**, a bare mention.
- **`/open` with no case**, which used to be a required option and is now optional.

Both open the same two-step select, series then case, and both end in the same `runOpen` that the command and the "open another" button already share. Existing commands are otherwise untouched.

`GuildMessages` is the only new intent and it is not privileged: a bare mention is read off the mentions list, so message content is never touched and Message Content stays unrequested.

Backend gains `GET /discord/categories` for the shelves and `?category=` on the case list for a stable page of one shelf. That page is counted and skipped in mongo on its own path rather than reusing the autocomplete's per-player ordering, because paging a list that reorders between clicks shows one case twice and hides another. The autocomplete path is unchanged.

Three things the tests pin down, each of which discord only complains about at click time:

- The custom id carries a **digest** of the series name, not the name. Discord caps a custom id at 100 characters and a category is free text; a long name overflowed it at 131.
- The select is **closed before the spin starts**. An interaction has three seconds and a spin takes longer, so the menu answers the click and the spin is posted as its own message. A live select under a running spin is a second charge waiting.
- A spin the menu started owns its message, so a failed call **rewrites it** instead of leaving "Opening…" in the channel for good.

## Tests

`bot/src/menu.test.js` is new: custom-id round trip and length ceiling, digest collisions, pager boundaries, the uncategorised shelf, and the empty-select cases. `discordBot.test.js` gains ten covering the shelf list, the price cap, stable paging, and that the autocomplete path still answers as it did.

Bot 40 passed, backend 1033 passed across 103 suites.

CI never ran the bot tests, so this adds a job for them.

## Deploying

`npm run register` after merge: `/open` changed its option from required to optional and discord caches command definitions.