### PR TITLE
fix(web): recover a shell whose bundles the deploy already replaced

### DIFF
--- a/e2e/staleShell.spec.ts
+++ b/e2e/staleShell.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+// A deploy replaces the hashed bundles while cloudflare is still handing out the previous
+// html for up to five minutes. That shell asks for files the new build deleted, render
+// answers a missing /assets/ path with a redirect to "/", and the browser refuses html
+// where it wanted javascript. It took the site down for exactly that window once, and the
+// only visible symptom is a white screen, so the recovery is worth pinning down.
+test("a shell whose bundle no longer exists reloads itself onto one that does", async ({ page }) => {
+  let served = 0;
+
+  // the first request for the entry bundle gets what render actually returns for a path
+  // with no file behind it: the html of the site root, with an html content type
+  await page.route("**/assets/*.js", async (route) => {
+    served += 1;
+    if (served > 1) return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: "<!doctype html><html><body></body></html>",
+    });
+  });
+
+  await page.goto("/");
+
+  // it must come back on its own, without a second visit
+  await expect(page.locator("#root")).not.toBeEmpty({ timeout: 15000 });
+  expect(served).toBeGreaterThan(1);
+});
+
+// The guard spends one retry per tab. A page that is broken for some other reason must not
+// sit in a reload loop hammering the origin.
+test("a bundle that never loads is retried once and then left alone", async ({ page }) => {
+  let served = 0;
+  await page.route("**/assets/*.js", async (route) => {
+    served += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body: "<!doctype html><html><body></body></html>",
+    });
+  });
+
+  await page.goto("/");
+  await page.waitForTimeout(4000);
+
+  expect(served).toBe(2);
+});
+
+// the retry adds a cache-busting param to get past the edge copy, and that param has no
+// business staying in the address bar afterwards
+test("the cache-busting param is gone once the app is up", async ({ page }) => {
+  await page.route("**/cases**", (route) => route.fulfill({ json: [] }));
+  await page.route("**/topPlayers**", (route) => route.fulfill({ json: [] }));
+  await page.route("**/ranking**", (route) => route.fulfill({ json: { ranking: 0, users: [] } }));
+
+  await page.goto("/?r=1234567890");
+  await expect(page.locator("#root")).not.toBeEmpty();
+
+  await expect.poll(() => new URL(page.url()).searchParams.has("r")).toBe(false);
+});

--- a/index.html
+++ b/index.html
@@ -3,6 +3,33 @@
 
 <head>
 
+  <!-- a deploy replaces the hashed bundles, and cloudflare edge-caches this file for five
+       minutes, so for that window a browser can be handed an html shell that asks for
+       bundles the new build has already deleted. render answers a missing /assets/ path
+       with a redirect to "/", the browser refuses html where it wanted javascript, and the
+       page never boots: a white screen that lasts until the edge copy expires. the retry
+       below reloads once past the cache and lands on the shell that matches what is
+       deployed. the flag makes it once per tab, so a failure that is not this cannot loop. -->
+  <script>
+    (function () {
+      var KEY = "shellRetry";
+      window.addEventListener("error", function (event) {
+        var el = event.target;
+        if (!el || (el.tagName !== "SCRIPT" && el.tagName !== "LINK")) return;
+        if (String(el.src || el.href || "").indexOf("/assets/") === -1) return;
+        try {
+          if (sessionStorage.getItem(KEY)) return;
+          sessionStorage.setItem(KEY, "1");
+        } catch (e) {
+          return;
+        }
+        var url = new URL(location.href);
+        url.searchParams.set("r", Date.now());
+        location.replace(url.toString());
+      }, true);
+    })();
+  </script>
+
   <!-- analytics and ads, started once the page has finished loading rather than racing it.
        between them they are ~380 KiB of javascript that nothing on screen needs: in the
        head they competed with the app's own bundle and the case art for a phone's

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,3 +8,16 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <App />
   // </React.StrictMode>
 );
+
+// the shell booted, so clear the guard in index.html and drop the cache-busting param it
+// adds. leaving the flag set would spend the tab's one retry on a failure already survived
+try {
+  sessionStorage.removeItem("shellRetry");
+} catch {
+  // storage can be unavailable; the guard is a nicety either way
+}
+if (new URLSearchParams(window.location.search).has("r")) {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("r");
+  window.history.replaceState(null, "", url.pathname + url.search + url.hash);
+}


### PR DESCRIPTION
## Problem

The site went white for everyone whose edge node held a stale shell, for the length of Cloudflare's five minute HTML cache.

Cloudflare serves `index.html` with `s-maxage=300`. A deploy replaces the hashed bundles and deletes the old ones. For that window a browser gets a shell naming `/assets/index-6538ac74.js` while the deployed build only has `index-7ae0728c.js`. Render answers a path with no file behind it using the SPA rule, so the request comes back `301` to `/` with `Content-Type: text/html`, and the browser refuses it:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the
server responded with a MIME type of "text/html".
```

Nothing else was affected. `/images/*`, `/fonts/*`, `robots.txt` and every route stayed 200 throughout, and the API was never involved, so an API health check looks fine while the site is down.

## Change

A guard in `index.html` catches a failed `/assets/` script or stylesheet and reloads once past the cache, onto the shell that matches what is deployed. `main.tsx` clears the flag and strips the cache-busting param once the app is up.

One retry per tab, so a page broken for any other reason cannot sit in a reload loop.

This is a safety net. **The real fix is the Render header config, which is backwards today**: both the shell and the hashed bundles are served `public, max-age=0, s-maxage=300`, when the bundles are immutable by name and the shell is the one thing that must never be held. The exact settings are written up in the ops notes; that is dashboard config, not repo.

## Tests

`e2e/staleShell.spec.ts` covers the recovery, the one-retry loop guard, and the param cleanup, by serving html for the entry bundle exactly the way production did.

E2E 41 passed, unit 160 passed, lint and build clean.