### PR TITLE
fix(case): fit five prizes on one row on a 1366 screen

### DIFF
--- a/e2e/casePageMobile.spec.ts
+++ b/e2e/casePageMobile.spec.ts
@@ -99,6 +99,34 @@ test("a single prize is drawn big enough to see, with its name", async ({ page }
   await expect(page.getByText("Character With A Long Name 0").first()).toBeVisible();
 });
 
+// Reported from a 1366x768 screen: the fifth prize wrapped onto a second line and the row
+// grew a scrollbar, so only four were visible. The reel is md:w-[1100px] but sits between
+// two decorative arrows as a flex item, so at that width it shrinks to about 980 while the
+// prizes still asked for 5x192 plus gaps. This asserts one row at the sizes real monitors
+// come in rather than at the one the page was drawn on.
+for (const width of [1024, 1280, 1366, 1440, 1920]) {
+  test(`five prizes sit on one row at ${width}`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 768 });
+    await open(page, 5);
+    await expect(page.locator("#prize").first()).toBeVisible({ timeout: 15000 });
+    expect(await page.locator("#prize").count()).toBe(5);
+
+    const tops = await page.locator("#prize").evaluateAll((els) =>
+      els.map((el) => Math.round(el.getBoundingClientRect().top))
+    );
+    expect(new Set(tops).size).toBe(1);
+
+    // and the row is not hiding the overflow behind a scrollbar
+    const row = page.locator("#prize").first().locator("xpath=..");
+    const over = await row.evaluate((el) => ({
+      x: el.scrollWidth - el.clientWidth,
+      y: el.scrollHeight - el.clientHeight,
+    }));
+    expect(over).toEqual({ x: 0, y: 0 });
+    expect(await pastTheEdge(page)).toBeLessThanOrEqual(2);
+  });
+}
+
 // halving the slot for a phone without moving the animation with it sent the strip past
 // its own end: three of the five reels showed nothing for the rest of the spin
 for (const { label, viewport, quantity } of [

--- a/src/pages/CasePage/ShowPrize.tsx
+++ b/src/pages/CasePage/ShowPrize.tsx
@@ -14,20 +14,26 @@ const ShowPrize: React.FC<ShowPrizeProps> = ({ openedItems, showPrize, animation
     // the whole reel and is the thing the player actually came to look at
     const many = openedItems.length > 1;
 
+    // the reel is md:w-[1100px] but it is a flex item between two decorative arrows, so on a
+    // 1366 screen it shrinks to about 980 and five fixed 192px prizes no longer fit. they
+    // share the row instead, capped at the size they used to be, so the fifth stops wrapping
+    // onto a second line and taking a scrollbar with it
+    const slot = many ? "md:min-w-0 md:flex-1 md:max-w-[12rem]" : "";
+
     return (
-        <div className="flex w-full flex-wrap items-center justify-center gap-3 overflow-y-auto px-2 md:gap-8 md:px-0">
+        <div className="flex w-full flex-wrap items-center justify-center gap-3 overflow-y-auto px-2 md:flex-nowrap md:gap-8 md:px-0">
             {
                 openedItems.map((openedItem, index) => {
                     const rarity = Rarities.find((r) => r.id == openedItem.rarity);
 
                     return (
-                        <div key={index} id="prize" className={`animate-fade-in relative flex `}>
-                            <div className="flex flex-col gap-2 items-center">
+                        <div key={index} id="prize" className={`animate-fade-in relative flex ${slot}`}>
+                            <div className={`flex flex-col gap-2 items-center ${many ? "w-full" : ""}`}>
                                 <img
                                     src={openedItem.image}
                                     alt={openedItem.name}
-                                    className={`object-contain rounded md:w-48 md:h-48 ${showPrize ? "opacity-100" : "opacity-0"} 
-                                ${many ? "notched w-20 h-20" : "w-40 h-40"} `}
+                                    className={`object-contain rounded ${showPrize ? "opacity-100" : "opacity-0"} 
+                                ${many ? "notched w-20 h-20 md:h-auto md:w-full md:aspect-square" : "w-40 h-40 md:h-48 md:w-48"} `}
                                     style={{
                                         background: many && rarity?.color || "none"
                                     }}
@@ -37,7 +43,7 @@ const ShowPrize: React.FC<ShowPrizeProps> = ({ openedItems, showPrize, animation
                                 <span
                                     className={
                                         many
-                                            ? "max-w-[5rem] truncate text-xs md:max-w-none md:text-base"
+                                            ? "max-w-[5rem] truncate text-xs md:max-w-full md:text-base"
                                             : "text-base font-semibold md:hidden"
                                     }
                                 >


### PR DESCRIPTION
## Problem

Reported from a 1366x768 monitor: after opening 5x, the fifth prize wrapped onto a second line and the row grew a scrollbar, so only four results were visible.

The reel is `md:w-[1100px]`, but it is a flex item sitting between two decorative `reelEdge` arrows, so it shrinks to fit. At 1366 that leaves it about 980px wide, while the prizes still asked for five fixed 192px squares plus four 32px gaps, which is 1088px.

Measured against the current build, it wrapped at **every** desktop width, not just 1366:

| width | before | after |
|---|---|---|
| 1024 | 2 rows | 1 row, art 105px |
| 1280 | 3 rows | 1 row, art 156px |
| 1366 | 2 rows | 1 row, art 173px |
| 1440 | 2 rows | 1 row, art 188px |
| 1920 | 2 rows | 1 row, art 192px |

1088px never fitted 1100px once a name sat under the art, so even a full-width desktop was wrapping. The report just came from the screen where it was most obvious.

## Change

The five prizes share the row instead of each demanding 192px: `md:flex-1 md:min-w-0` with `md:max-w-[12rem]` so they never grow past the size they had, and the art becomes `md:w-full md:aspect-square`. The name is capped at the slot width rather than `md:max-w-none`, which could otherwise force a slot wider than its share.

The phone layout is untouched. It wraps on purpose there, and those tests still pass.

## Tests

Five new cases in `casePageMobile.spec.ts` open 5x at 1024, 1280, 1366, 1440 and 1920 and assert every prize shares one row top, that the row has no scroll in either axis, and that nothing runs past the viewport.

E2E 44 passed, unit 160 passed, lint and build clean.