### PR TITLE
feat(profile): a contextual hint, first pointed at wearing a badge

### DIFF
--- a/src/components/Hint.test.tsx
+++ b/src/components/Hint.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import Hint from "./Hint";
+
+// A hint that comes back after a player has closed it is a nag, and a hint stored under
+// the wrong key follows the wrong account. Both are quiet failures until somebody
+// complains, so they are pinned here rather than trusted.
+beforeEach(() => localStorage.clear());
+
+describe("a hint", () => {
+  it("shows only while the caller says it is relevant", () => {
+    const { rerender } = render(<Hint id="wear-badge" userId="u1" text="Pick one to wear." show />);
+    expect(screen.getByText("Pick one to wear.")).toBeTruthy();
+
+    rerender(<Hint id="wear-badge" userId="u1" text="Pick one to wear." show={false} />);
+    expect(screen.queryByText("Pick one to wear.")).toBeNull();
+  });
+
+  it("stays gone once closed, even though the condition still holds", () => {
+    const { unmount } = render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByText("Pick one.")).toBeNull();
+
+    unmount();
+    render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
+    expect(screen.queryByText("Pick one.")).toBeNull();
+  });
+
+  it("keeps one player's dismissals off another's account", () => {
+    render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
+    fireEvent.click(screen.getByRole("button"));
+
+    render(<Hint id="wear-badge" userId="u2" text="Pick one." show />);
+    expect(screen.getByText("Pick one.")).toBeTruthy();
+  });
+
+  it("keeps one hint's dismissal off another hint", () => {
+    render(<Hint id="wear-badge" userId="u1" text="Wear it." show />);
+    fireEvent.click(screen.getByRole("button"));
+
+    render(<Hint id="open-case" userId="u1" text="Open one." show />);
+    expect(screen.getByText("Open one.")).toBeTruthy();
+  });
+
+  // storage is blocked in some browsers and the profile must still render
+  it("survives storage it cannot read or write", () => {
+    const real = Object.getOwnPropertyDescriptor(window, "localStorage");
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked");
+      },
+    });
+
+    render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
+    expect(screen.getByText("Pick one.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByText("Pick one.")).toBeNull();
+
+    if (real) Object.defineProperty(window, "localStorage", real);
+  });
+});

--- a/src/components/Hint.test.tsx
+++ b/src/components/Hint.test.tsx
@@ -2,47 +2,66 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
 import Hint from "./Hint";
 
-// A hint that comes back after a player has closed it is a nag, and a hint stored under
-// the wrong key follows the wrong account. Both are quiet failures until somebody
-// complains, so they are pinned here rather than trusted.
+// Shown once, on the first visit after the player earned something. The failure modes are
+// quiet in both directions: a hint that comes back is a nag, and one that never re-arms
+// means the second badge is never mentioned. Both are pinned here.
 beforeEach(() => localStorage.clear());
 
-describe("a hint", () => {
-  it("shows only while the caller says it is relevant", () => {
-    const { rerender } = render(<Hint id="wear-badge" userId="u1" text="Pick one to wear." show />);
-    expect(screen.getByText("Pick one to wear.")).toBeTruthy();
+const shelf = (token: string, show = true) => (
+  <Hint id="wear-badge" userId="u1" text="Pick one to wear." show={show} token={token} />
+);
 
-    rerender(<Hint id="wear-badge" userId="u1" text="Pick one to wear." show={false} />);
+describe("a hint", () => {
+  it("shows on the first visit and never again for the same thing", () => {
+    const first = render(shelf("contributor"));
+    expect(screen.getByText("Pick one to wear.")).toBeTruthy();
+    first.unmount();
+
+    render(shelf("contributor"));
     expect(screen.queryByText("Pick one to wear.")).toBeNull();
   });
 
-  it("stays gone once closed, even though the condition still holds", () => {
-    const { unmount } = render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
-    fireEvent.click(screen.getByRole("button"));
-    expect(screen.queryByText("Pick one.")).toBeNull();
+  it("comes back once when the player earns another", () => {
+    render(shelf("contributor")).unmount();
 
-    unmount();
-    render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
-    expect(screen.queryByText("Pick one.")).toBeNull();
+    render(shelf("connected,contributor"));
+    expect(screen.getByText("Pick one to wear.")).toBeTruthy();
   });
 
-  it("keeps one player's dismissals off another's account", () => {
-    render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
-    fireEvent.click(screen.getByRole("button"));
+  it("stays away while the caller says it is not relevant, and is not spent either", () => {
+    render(shelf("contributor", false)).unmount();
+    expect(screen.queryByText("Pick one to wear.")).toBeNull();
 
-    render(<Hint id="wear-badge" userId="u2" text="Pick one." show />);
+    render(shelf("contributor", true));
+    expect(screen.getByText("Pick one to wear.")).toBeTruthy();
+  });
+
+  it("closes on the button and does not return", () => {
+    const open = render(shelf("contributor"));
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByText("Pick one to wear.")).toBeNull();
+    open.unmount();
+
+    render(shelf("contributor"));
+    expect(screen.queryByText("Pick one to wear.")).toBeNull();
+  });
+
+  it("keeps one player's history off another's account", () => {
+    render(<Hint id="wear-badge" userId="u1" text="Pick one." show token="a" />).unmount();
+
+    render(<Hint id="wear-badge" userId="u2" text="Pick one." show token="a" />);
     expect(screen.getByText("Pick one.")).toBeTruthy();
   });
 
-  it("keeps one hint's dismissal off another hint", () => {
-    render(<Hint id="wear-badge" userId="u1" text="Wear it." show />);
-    fireEvent.click(screen.getByRole("button"));
+  it("keeps one hint's history off another hint", () => {
+    render(<Hint id="wear-badge" userId="u1" text="Wear it." show token="a" />).unmount();
 
-    render(<Hint id="open-case" userId="u1" text="Open one." show />);
+    render(<Hint id="open-case" userId="u1" text="Open one." show token="a" />);
     expect(screen.getByText("Open one.")).toBeTruthy();
   });
 
-  // storage is blocked in some browsers and the profile must still render
+  // storage is blocked in some browsers, and the profile has to render either way. it
+  // cannot be remembered there, so it shows again rather than never showing at all.
   it("survives storage it cannot read or write", () => {
     const real = Object.getOwnPropertyDescriptor(window, "localStorage");
     Object.defineProperty(window, "localStorage", {
@@ -52,10 +71,8 @@ describe("a hint", () => {
       },
     });
 
-    render(<Hint id="wear-badge" userId="u1" text="Pick one." show />);
-    expect(screen.getByText("Pick one.")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button"));
-    expect(screen.queryByText("Pick one.")).toBeNull();
+    render(shelf("contributor"));
+    expect(screen.getByText("Pick one to wear.")).toBeTruthy();
 
     if (real) Object.defineProperty(window, "localStorage", real);
   });

--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { AiOutlineArrowUp } from "react-icons/ai";
+import { IoMdClose } from "react-icons/io";
+import i18n from "../i18n";
+
+interface HintProps {
+  // identifies this hint for the dismissal, so a player who closes one keeps the rest
+  id: string;
+  userId?: string;
+  text: string;
+  // the caller decides whether the hint is relevant right now. it should be a condition
+  // the player's own next action clears, so the hint retires itself and nothing has to
+  // remember that it was shown.
+  show: boolean;
+}
+
+const key = (id: string, userId?: string) => `kani.hint.${userId || "anon"}.${id}`;
+
+// One line, one arrow, pointing at the thing above it. Deliberately not a tour: a player
+// who has just found the site does not need a guided sequence, they need the one control
+// they are standing next to explained. Never show two at once on a screen.
+const Hint: React.FC<HintProps> = ({ id, userId, text, show }) => {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return !!localStorage.getItem(key(id, userId));
+    } catch {
+      return false;
+    }
+  });
+
+  const dismiss = () => {
+    setDismissed(true);
+    try {
+      localStorage.setItem(key(id, userId), "1");
+    } catch {
+      // storage can be unavailable; the hint still goes away for the session
+    }
+  };
+
+  if (!show || dismissed) return null;
+
+  return (
+    <div className="animate-fade-in flex w-fit items-center gap-2 border-l-2 border-accent-gold bg-surface-raised py-1.5 pl-2 pr-1.5">
+      <AiOutlineArrowUp className="animate-bounce shrink-0 text-accent-gold" />
+      <span className="text-xs font-semibold text-white">{text}</span>
+      <button
+        onClick={dismiss}
+        aria-label={i18n.t("common.dismissHint")}
+        className="rounded-none border-0 bg-transparent p-0 text-base leading-none text-ink-muted outline-none transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-accent-light"
+      >
+        <IoMdClose />
+      </button>
+    </div>
+  );
+};
+
+export default Hint;

--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -1,50 +1,61 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AiOutlineArrowUp } from "react-icons/ai";
 import { IoMdClose } from "react-icons/io";
 import i18n from "../i18n";
 
 interface HintProps {
-  // identifies this hint for the dismissal, so a player who closes one keeps the rest
+  // identifies this hint in storage, so a player who has seen one still gets the rest
   id: string;
   userId?: string;
   text: string;
-  // the caller decides whether the hint is relevant right now. it should be a condition
-  // the player's own next action clears, so the hint retires itself and nothing has to
-  // remember that it was shown.
+  // whether the hint is relevant at all. it is checked once, the first time it is true.
   show: boolean;
+  // what the hint is about, as a string. it is shown once per distinct value, so a token
+  // that changes when the player earns something new arms it again and nothing else does.
+  token: string;
 }
 
-const key = (id: string, userId?: string) => `kani.hint.${userId || "anon"}.${id}`;
+const storageKey = (id: string, userId?: string) => `kani.hint.${userId || "anon"}.${id}`;
 
 // One line, one arrow, pointing at the thing above it. Deliberately not a tour: a player
 // who has just found the site does not need a guided sequence, they need the one control
-// they are standing next to explained. Never show two at once on a screen.
-const Hint: React.FC<HintProps> = ({ id, userId, text, show }) => {
-  const [dismissed, setDismissed] = useState<boolean>(() => {
-    try {
-      return !!localStorage.getItem(key(id, userId));
-    } catch {
-      return false;
-    }
-  });
+// they are standing next to explained, once. Never show two at once on a screen.
+const Hint: React.FC<HintProps> = ({ id, userId, text, show, token }) => {
+  const [visible, setVisible] = useState(false);
+  // the decision is made once per mount: without this, a re-render between the read and
+  // the write would show the hint twice and record it once
+  const decided = useRef(false);
 
-  const dismiss = () => {
-    setDismissed(true);
-    try {
-      localStorage.setItem(key(id, userId), "1");
-    } catch {
-      // storage can be unavailable; the hint still goes away for the session
-    }
-  };
+  useEffect(() => {
+    if (!show || decided.current) return;
+    decided.current = true;
 
-  if (!show || dismissed) return null;
+    let seen: string | null = null;
+    try {
+      seen = localStorage.getItem(storageKey(id, userId));
+    } catch {
+      // storage blocked: nothing was recorded, so nothing has been seen
+    }
+    if (seen === token) return;
+
+    // marked on the way in rather than on dismissal, because closing the tab is the most
+    // common way to leave and that still counts as having been shown
+    try {
+      localStorage.setItem(storageKey(id, userId), token);
+    } catch {
+      // it cannot be remembered, so it comes back next visit. better than never showing.
+    }
+    setVisible(true);
+  }, [show, token, id, userId]);
+
+  if (!visible) return null;
 
   return (
     <div className="animate-fade-in flex w-fit items-center gap-2 border-l-2 border-accent-gold bg-surface-raised py-1.5 pl-2 pr-1.5">
       <AiOutlineArrowUp className="animate-bounce shrink-0 text-accent-gold" />
       <span className="text-xs font-semibold text-white">{text}</span>
       <button
-        onClick={dismiss}
+        onClick={() => setVisible(false)}
         aria-label={i18n.t("common.dismissHint")}
         className="rounded-none border-0 bg-transparent p-0 text-base leading-none text-ink-muted outline-none transition-colors hover:text-white focus-visible:ring-2 focus-visible:ring-accent-light"
       >

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -251,6 +251,7 @@
     "complete": "KOMPLETT",
     "couldNotSellItem": "Gegenstand konnte nicht verkauft werden",
     "descending": "Absteigend",
+    "dismissHint": "Hinweis ausblenden",
     "emptyOnCash": "Keine Münzen mehr?",
     "everythingHereRunsOn": "Hier läuft alles mit K₽, einer erfundenen Münze. Das ist kein echtes Geld, also spiel so viel du willst.",
     "gotItLetS": "Alles klar, los geht's!",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -251,6 +251,7 @@
     "complete": "COMPLETE",
     "couldNotSellItem": "Could not sell item",
     "descending": "Descending",
+    "dismissHint": "dismiss hint",
     "emptyOnCash": "Empty on cash?",
     "everythingHereRunsOn": "Everything here runs on K₽, a fictional coin. It is not real money, so play as much as you want.",
     "gotItLetS": "Got it, let's play!",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -251,6 +251,7 @@
     "complete": "COMPLETA",
     "couldNotSellItem": "No se pudo vender el objeto",
     "descending": "Descendente",
+    "dismissHint": "descartar sugerencia",
     "emptyOnCash": "¿Sin monedas?",
     "everythingHereRunsOn": "Aquí todo funciona con K₽, una moneda ficticia. No es dinero real, así que juega todo lo que quieras.",
     "gotItLetS": "¡Entendido, a jugar!",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -251,6 +251,7 @@
     "complete": "COMPLÈTE",
     "couldNotSellItem": "Impossible de vendre l'objet",
     "descending": "Décroissant",
+    "dismissHint": "masquer l'astuce",
     "emptyOnCash": "Plus de pièces ?",
     "everythingHereRunsOn": "Tout ici fonctionne avec des K₽, une monnaie fictive. Ce n'est pas de l'argent réel, alors jouez autant que vous voulez.",
     "gotItLetS": "Compris, on joue !",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -251,6 +251,7 @@
     "complete": "BERES",
     "couldNotSellItem": "Item tidak bisa dijual",
     "descending": "Menurun",
+    "dismissHint": "tutup petunjuk",
     "emptyOnCash": "Kehabisan uang?",
     "everythingHereRunsOn": "Semua yang ada di sini berjalan menggunakan K₽, sebuah mata uang fiktif. Ini bukan uang sungguhan, jadi main suka-suka kamu.",
     "gotItLetS": "Oke, ayo main!",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -251,6 +251,7 @@
     "complete": "COMPLETA",
     "couldNotSellItem": "Impossibile vendere l'oggetto",
     "descending": "Decrescente",
+    "dismissHint": "chiudi il suggerimento",
     "emptyOnCash": "Senza monete?",
     "everythingHereRunsOn": "Qui gira tutto in K₽, una moneta immaginaria. Non sono soldi veri, quindi gioca quanto vuoi.",
     "gotItLetS": "Capito, si gioca!",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -251,6 +251,7 @@
     "complete": "コンプリート",
     "couldNotSellItem": "アイテムを売却できませんでした",
     "descending": "降順",
+    "dismissHint": "ヒントを閉じる",
     "emptyOnCash": "コインが足りない？",
     "everythingHereRunsOn": "ここではすべて K₽ という架空のコインで動いています。実際のお金ではないので、好きなだけ遊んでください。",
     "gotItLetS": "了解、遊ぼう！",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -251,6 +251,7 @@
     "complete": "완성",
     "couldNotSellItem": "아이템을 판매하지 못했습니다",
     "descending": "내림차순",
+    "dismissHint": "힌트 닫기",
     "emptyOnCash": "코인이 없나요?",
     "everythingHereRunsOn": "여기서는 모든 것이 가상 화폐 K₽로 돌아갑니다. 실제 돈이 아니니 마음껏 즐기세요.",
     "gotItLetS": "알겠어요, 플레이할게요!",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -251,6 +251,7 @@
     "complete": "COMPLETA",
     "couldNotSellItem": "Não foi possível vender o item",
     "descending": "Decrescente",
+    "dismissHint": "dispensar dica",
     "emptyOnCash": "Sem moedas?",
     "everythingHereRunsOn": "Tudo aqui funciona com K₽, uma moeda fictícia. Não é dinheiro de verdade, então jogue à vontade.",
     "gotItLetS": "Entendi, vamos jogar!",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -251,6 +251,7 @@
     "complete": "HOÀN THÀNH",
     "couldNotSellItem": "Không bán được vật phẩm",
     "descending": "Giảm dần",
+    "dismissHint": "bỏ qua gợi ý",
     "emptyOnCash": "Hết xu rồi?",
     "everythingHereRunsOn": "Mọi thứ ở đây chạy bằng K₽, một loại tiền hư cấu. Đó không phải tiền thật, nên cứ chơi thoải mái.",
     "gotItLetS": "Hiểu rồi, chơi thôi!",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -251,6 +251,7 @@
     "complete": "已集齐",
     "couldNotSellItem": "无法出售该物品",
     "descending": "降序",
+    "dismissHint": "关闭提示",
     "emptyOnCash": "没钱了？",
     "everythingHereRunsOn": "这里的一切都以 K₽ 结算，那是一种虚构货币，不是真钱，所以尽情玩吧。",
     "gotItLetS": "知道了，开始玩吧！",

--- a/src/pages/Profile/BadgeShelf.tsx
+++ b/src/pages/Profile/BadgeShelf.tsx
@@ -23,6 +23,9 @@ const BadgeShelf: React.FC<BadgeShelfProps> = ({ badges, selectedBadge, isSameUs
   const [showAll, setShowAll] = useState(false);
 
   const held = badges || [];
+  // what the hint is about: earning a badge changes it and arms the hint again, nothing
+  // else does. sorted so the order the api happens to return them in cannot re-fire it.
+  const heldToken = held.map((badge) => badge.key).sort().join(",");
 
   const choose = async (key: BadgeKey) => {
     if (!isSameUser || saving) return;
@@ -79,13 +82,14 @@ const BadgeShelf: React.FC<BadgeShelfProps> = ({ badges, selectedBadge, isSameUs
             (worn ? (
               <p className="text-[11px] text-[#625F7E]">{i18n.t("badge.clearHint")}</p>
             ) : (
-              // holding a badge and wearing none is the whole trigger: putting one on is
-              // what clears it, so nothing has to record that the player was told
+              // once, on the first look at your own profile after earning one. a player
+              // who has already put one on is not shown it at all, because they know.
               <Hint
                 id="wear-badge"
                 userId={userData?.id}
                 text={i18n.t("badge.chooseHint")}
-                show
+                show={held.length > 0}
+                token={heldToken}
               />
             ))}
         </>

--- a/src/pages/Profile/BadgeShelf.tsx
+++ b/src/pages/Profile/BadgeShelf.tsx
@@ -2,6 +2,7 @@ import { useContext, useState } from "react";
 import { toast } from "react-toastify";
 import UserContext from "../../UserContext";
 import Badge, { badgeName } from "../../components/Badge";
+import Hint from "../../components/Hint";
 import BadgeCatalog from "./BadgeCatalog";
 import { Badge as BadgeData, BadgeKey, setWornBadge } from "../../services/badges/BadgeService";
 import i18n from "../../i18n";
@@ -74,11 +75,19 @@ const BadgeShelf: React.FC<BadgeShelfProps> = ({ badges, selectedBadge, isSameUs
               </button>
             ))}
           </div>
-          {isSameUser && (
-            <p className="text-[11px] text-[#625F7E]">
-              {worn ? i18n.t("badge.clearHint") : i18n.t("badge.chooseHint")}
-            </p>
-          )}
+          {isSameUser &&
+            (worn ? (
+              <p className="text-[11px] text-[#625F7E]">{i18n.t("badge.clearHint")}</p>
+            ) : (
+              // holding a badge and wearing none is the whole trigger: putting one on is
+              // what clears it, so nothing has to record that the player was told
+              <Hint
+                id="wear-badge"
+                userId={userData?.id}
+                text={i18n.t("badge.chooseHint")}
+                show
+              />
+            ))}
         </>
       )}
 


### PR DESCRIPTION
## Problem

Players are not aware of most of what the site does. A tour up front is the wrong answer: it arrives before any of it means anything, and it is the thing people click through without reading.

## Change

A `Hint`: one line, one arrow, pointing at the control the player is already standing next to. Deliberately not a tour, and the rule that keeps it from being a bombardment is that a caller shows at most one at a time.

**Shown once**, on the first visit to your own profile after earning a badge. The hint carries a token of what it is about, the badges held, and fires only when that token is one the player has not been shown. Earning another changes the token and arms it again; nothing else does.

It is marked as shown on the way in rather than on dismissal, because closing the tab is the most common way to leave a page and that still counts.

A player already wearing a badge is never shown it, because they have clearly worked it out.

The badge shelf is the first use because it is harmless. It replaces the quiet grey `badge.chooseHint` line that already said the same thing and that nobody reads.

## On the storage

The record is `localStorage`, keyed per player and per hint, so a hint shown once on one machine can be shown once more on another. For the bigger flows (the never-opened-a-case and referral prompts) that state belongs on the user document instead, which is what the mission engine already does.

## Not final

The visual is a placeholder. The behaviour is the part this PR is settling.

## Tests

`Hint.test.tsx` covers: shown once and never again for the same badges, re-armed by earning another, not spent while the caller says it is irrelevant, closing, no leakage between players or between hints, and a browser with storage blocked still rendering the profile.

Unit 167 passed, e2e 39 passed, lint and build clean.