### PR TITLE
fix(upgrade): only offer items the rarity gap can actually reach

### DIFF
--- a/backend/__tests__/integration/inventoryStacking.test.js
+++ b/backend/__tests__/integration/inventoryStacking.test.js
@@ -195,3 +195,44 @@ describe("selling a stack", () => {
     expect(after.inventory.every((e) => String(e._id) === String(b._id))).toBe(true);
   });
 });
+
+// the upgrade screen only offers what the rarity gap allows, so it asks for a set at once
+describe("the rarity filter", () => {
+  it("takes a single rarity", async () => {
+    const common = await makeItem({ rarity: "1" });
+    const epic = await makeItem({ rarity: "3" });
+    const user = await makeUserWith([...copies(common, 2), ...copies(epic, 1)]);
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true&rarity=3`);
+
+    expect(res.body.items.map((i) => String(i._id))).toEqual([String(epic._id)]);
+  });
+
+  it("takes a comma list and counts the pages against it", async () => {
+    const common = await makeItem({ rarity: "1" });
+    const rare = await makeItem({ rarity: "2" });
+    const epic = await makeItem({ rarity: "3" });
+    const unique = await makeItem({ rarity: "5" });
+    const user = await makeUserWith([
+      ...copies(common, 1),
+      ...copies(rare, 1),
+      ...copies(epic, 1),
+      ...copies(unique, 1),
+    ]);
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true&rarity=2,3`);
+
+    expect(res.body.items.map((i) => i.rarity).sort()).toEqual(["2", "3"]);
+    expect(res.body.totalPages).toBe(1);
+  });
+
+  it("returns nothing when the list matches nothing", async () => {
+    const common = await makeItem({ rarity: "1" });
+    const user = await makeUserWith(copies(common, 3));
+
+    const res = await request(app).get(`/users/inventory/${user._id}?grouped=true&rarity=4,5`);
+
+    expect(res.body.items).toEqual([]);
+    expect(res.body.totalPages).toBe(0);
+  });
+});

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -803,6 +803,10 @@ router.get("/inventory/:userId", async (req, res) => {
 
     // guard optional filters so malformed input can't throw
     const caseFilter = caseId && ObjectId.isValid(caseId) ? new ObjectId(caseId) : null;
+    // the upgrade screen asks for the set of rarities a stake may legally come from, so a
+    // comma list is accepted alongside the single value every other screen sends
+    const rarityList = String(rarity || "").split(",").map((r) => r.trim()).filter(Boolean);
+    const rarityMatch = rarityList.length ? { "inventory.rarity": { $in: rarityList } } : null;
     const nameRegex = name
       ? new RegExp(String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i")
       : null;
@@ -828,8 +832,8 @@ router.get("/inventory/:userId", async (req, res) => {
     if (idFilter) {
       countPipeline.push({ $match: { "inventory._id": { $in: idFilter } } });
     }
-    if (rarity) {
-      countPipeline.push({ $match: { "inventory.rarity": rarity } });
+    if (rarityMatch) {
+      countPipeline.push({ $match: rarityMatch });
     }
 
     // grouped mode stacks duplicates into one row, so a page is a page of distinct
@@ -857,8 +861,8 @@ router.get("/inventory/:userId", async (req, res) => {
     if (idFilter) {
       pipeline.push({ $match: { "inventory._id": { $in: idFilter } } });
     }
-    if (rarity) {
-      pipeline.push({ $match: { "inventory.rarity": rarity } });
+    if (rarityMatch) {
+      pipeline.push({ $match: rarityMatch });
     }
 
     // only known sort keys: an arbitrary one would be interpolated into the sort

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -896,6 +896,8 @@
     "newest": "Neueste",
     "noItemsFound": "Keine Gegenstände gefunden",
     "oldest": "Älteste",
+    "onlyWhatFits": "Nur Gegenstände, die du für dieses Upgrade einsetzen kannst.",
+    "onlyWhatYouReach": "Nur Gegenstände, die deine Auswahl erreichen kann.",
     "rarity": "Seltenheit",
     "rarityHighToLow": "Seltenheit: hoch nach niedrig",
     "rarityLowToHigh": "Seltenheit: niedrig nach hoch",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -896,6 +896,8 @@
     "newest": "Newest",
     "noItemsFound": "No items found",
     "oldest": "Oldest",
+    "onlyWhatFits": "Only items you can put into this upgrade.",
+    "onlyWhatYouReach": "Only items your selection can reach.",
     "rarity": "Rarity",
     "rarityHighToLow": "Rarity: high to low",
     "rarityLowToHigh": "Rarity: low to high",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -896,6 +896,8 @@
     "newest": "Más nuevos",
     "noItemsFound": "No se encontraron objetos",
     "oldest": "Más antiguos",
+    "onlyWhatFits": "Solo objetos que puedes usar en esta mejora.",
+    "onlyWhatYouReach": "Solo objetos que tu selección puede alcanzar.",
     "rarity": "Rareza",
     "rarityHighToLow": "Rareza: de mayor a menor",
     "rarityLowToHigh": "Rareza: de menor a mayor",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -896,6 +896,8 @@
     "newest": "Les plus récents",
     "noItemsFound": "Aucun objet trouvé",
     "oldest": "Les plus anciens",
+    "onlyWhatFits": "Uniquement les objets utilisables pour cette amélioration.",
+    "onlyWhatYouReach": "Uniquement les objets que votre sélection peut atteindre.",
     "rarity": "Rareté",
     "rarityHighToLow": "Rareté : de la plus haute à la plus basse",
     "rarityLowToHigh": "Rareté : de la plus basse à la plus haute",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -896,6 +896,8 @@
     "newest": "Barusan",
     "noItemsFound": "Ga ketemu",
     "oldest": "Terlama",
+    "onlyWhatFits": "Hanya item yang bisa kamu pakai untuk upgrade ini.",
+    "onlyWhatYouReach": "Hanya item yang bisa dicapai oleh pilihanmu.",
     "rarity": "Kelangkaan",
     "rarityHighToLow": "Langka ke B aja",
     "rarityLowToHigh": "B aja ke Langka",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -896,6 +896,8 @@
     "newest": "Più recenti",
     "noItemsFound": "Nessun oggetto trovato",
     "oldest": "Più vecchi",
+    "onlyWhatFits": "Solo oggetti che puoi usare per questo upgrade.",
+    "onlyWhatYouReach": "Solo oggetti che la tua selezione può raggiungere.",
     "rarity": "Rarità",
     "rarityHighToLow": "Rarità: dalla più alta alla più bassa",
     "rarityLowToHigh": "Rarità: dalla più bassa alla più alta",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -896,6 +896,8 @@
     "newest": "新しい順",
     "noItemsFound": "アイテムが見つかりません",
     "oldest": "古い順",
+    "onlyWhatFits": "このアップグレードに使えるアイテムのみ表示しています。",
+    "onlyWhatYouReach": "選んだアイテムで狙えるものだけを表示しています。",
     "rarity": "レアリティ",
     "rarityHighToLow": "レアリティ：高い順",
     "rarityLowToHigh": "レアリティ：低い順",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -896,6 +896,8 @@
     "newest": "최신순",
     "noItemsFound": "아이템을 찾을 수 없습니다",
     "oldest": "오래된 순",
+    "onlyWhatFits": "이 업그레이드에 넣을 수 있는 아이템만 표시합니다.",
+    "onlyWhatYouReach": "선택한 아이템으로 노릴 수 있는 것만 표시합니다.",
     "rarity": "등급",
     "rarityHighToLow": "등급: 높은 순",
     "rarityLowToHigh": "등급: 낮은 순",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -896,6 +896,8 @@
     "newest": "Mais novos",
     "noItemsFound": "Nenhum item encontrado",
     "oldest": "Mais antigos",
+    "onlyWhatFits": "Apenas itens que você pode usar neste upgrade.",
+    "onlyWhatYouReach": "Apenas itens que a sua seleção consegue alcançar.",
     "rarity": "Raridade",
     "rarityHighToLow": "Raridade: da maior para a menor",
     "rarityLowToHigh": "Raridade: da menor para a maior",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -896,6 +896,8 @@
     "newest": "Mới nhất",
     "noItemsFound": "Không tìm thấy vật phẩm",
     "oldest": "Cũ nhất",
+    "onlyWhatFits": "Chỉ những vật phẩm bạn có thể dùng cho lần nâng cấp này.",
+    "onlyWhatYouReach": "Chỉ những vật phẩm lựa chọn của bạn có thể đạt tới.",
     "rarity": "Độ hiếm",
     "rarityHighToLow": "Độ hiếm: cao xuống thấp",
     "rarityLowToHigh": "Độ hiếm: thấp lên cao",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -896,6 +896,8 @@
     "newest": "最新",
     "noItemsFound": "未找到物品",
     "oldest": "最早",
+    "onlyWhatFits": "仅显示可以用于本次升级的物品。",
+    "onlyWhatYouReach": "仅显示当前选择能够升到的物品。",
     "rarity": "稀有度",
     "rarityHighToLow": "稀有度：从高到低",
     "rarityLowToHigh": "稀有度：从低到高",

--- a/src/pages/Upgrade/ChooseUpgradeItems.tsx
+++ b/src/pages/Upgrade/ChooseUpgradeItems.tsx
@@ -5,9 +5,11 @@ import { getCases, getCase } from "../../services/cases/CaseServices";
 import Item from "../../components/Item";  // Import your Item component if you have one
 import Skeleton from "react-loading-skeleton";
 import { AiOutlineClose } from "react-icons/ai";
+import { targetRarities, ALL_RARITIES } from "./upgradeRules";
 import i18n from "../../i18n";
 
 interface ChooseUpgradeItems {
+    selectedItems: any[];
     setSelectedItems: React.Dispatch<React.SetStateAction<any>>;
     selectedCase: any;
     setSelectedCase: React.Dispatch<React.SetStateAction<any>>;
@@ -15,7 +17,7 @@ interface ChooseUpgradeItems {
     setSelectedTarget: React.Dispatch<React.SetStateAction<any>>;
 }
 
-const ChooseUpgradeItems: React.FC<ChooseUpgradeItems> = ({ setSelectedItems, selectedCase, setSelectedCase, selectedTarget, setSelectedTarget }) => {
+const ChooseUpgradeItems: React.FC<ChooseUpgradeItems> = ({ selectedItems, setSelectedItems, selectedCase, setSelectedCase, selectedTarget, setSelectedTarget }) => {
     const [allCases, setAllCases] = useState<any[]>([]);
     const [selectedCaseItems, setSelectedCaseItems] = useState<any[]>([]);
     const [loadingItems, setLoadingItems] = useState<boolean>(true);
@@ -26,6 +28,11 @@ const ChooseUpgradeItems: React.FC<ChooseUpgradeItems> = ({ setSelectedItems, se
         order: 'asc'
     });
     const { userData } = useContext(UserContext);
+
+    // an item the pile cannot reach is not an outcome, so it is not offered
+    const reachableRarities = targetRarities(selectedItems);
+    const restricted = reachableRarities.length < ALL_RARITIES.length;
+    const reachableItems = selectedCaseItems.filter((item: any) => reachableRarities.includes(Number(item.rarity)));
 
     const getAllItemsInfo = async () => {
         setLoadingItems(true);
@@ -72,7 +79,12 @@ const ChooseUpgradeItems: React.FC<ChooseUpgradeItems> = ({ setSelectedItems, se
     return (
         <div className="flex flex-col md:w-1/2 gap-2 ">
             <div className="flex w-full items-center justify-between bg-[#1C1A33] rounded px-6 h-24">
-                <span>{i18n.t("upgrade.getOneItem")}</span>
+                <div className="flex flex-col">
+                    <span>{i18n.t("upgrade.getOneItem")}</span>
+                    {selectedCase !== null && restricted && (
+                        <span className="text-xs text-gray-400">{i18n.t("upgrade.onlyWhatYouReach")}</span>
+                    )}
+                </div>
                 <div className="flex gap-4">
                     {
                         selectedCase !== null && (
@@ -142,8 +154,12 @@ const ChooseUpgradeItems: React.FC<ChooseUpgradeItems> = ({ setSelectedItems, se
                                     </div>
                                 )
                             })
+                        ) : reachableItems.length === 0 ? (
+                            <div className="flex items-center justify-center">
+                                <span className="font-semibold text-gray-400">{i18n.t("upgrade.noItemsFound")}</span>
+                            </div>
                         ) : (
-                            selectedCaseItems.map((item: any, index: number) => {
+                            reachableItems.map((item: any, index: number) => {
                                 return (
                                     <div key={index} className={`cursor-pointer border-2 h-min ${selectedTarget?._id === item._id ? ' border-[#606bc7]' : 'border-transparent'}`} onClick={() => {
                                         if (selectedTarget?._id === item._id) {

--- a/src/pages/Upgrade/Items.tsx
+++ b/src/pages/Upgrade/Items.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect } from "react";
 import UserContext from "../../UserContext";
 import UserItems from "./UserItems";
 import ChooseUpgradeItems from "./ChooseUpgradeItems";
+import { calculateSuccessRate } from "./upgradeRules";
 import i18n from "../../i18n";
 
 interface Inventory {
@@ -20,39 +21,10 @@ interface Inventory {
 const Items: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedTarget, setSelectedTarget, selectedCase, setSelectedCase, setSuccessRate, toggleReload, setFinished, spinning }) => {
     const { userData } = useContext(UserContext);
 
-
-    // mirrors backend/games/upgrade.js exactly, so the rate on screen is the rate the
-    // server rolls: p = RTP(targetRarity) * staked / target, capped by the rarity ceiling.
-    // upgradeConstants.test.ts reads both files and fails if these two ever disagree.
-    const UPGRADE_RTP_BY_RARITY: { [k: string]: number } = { "1": 0.9, "2": 0.9, "3": 0.85, "4": 0.75, "5": 0.3 };
-    const UPGRADE_CEILING: { [k: string]: number } = { "1": 0.9, "2": 0.7, "3": 0.45, "4": 0.25, "5": 0.12 };
-    const UPGRADE_MAX_RARITY_GAP = 2;
-
-    const calculateSuccessRate = (items: any, target: any) => {
-        const stakedValue = items.reduce(
-            (sum: number, selected: any) => sum + (selected.item?.baseValue || 0),
-            0
-        );
-        const targetValue = target?.baseValue || 0;
-        if (stakedValue <= 0 || targetValue <= 0) return 0;
-        // the server refuses this combination, so quoting a rate for it would be a lie
-        const tooFar = items.some(
-            (selected: any) =>
-                Number(target?.rarity) - Number(selected.item?.rarity) > UPGRADE_MAX_RARITY_GAP ||
-                Number(selected.item?.rarity) > Number(target?.rarity)
-        );
-        if (tooFar) return 0;
-        const rtp = UPGRADE_RTP_BY_RARITY[String(target?.rarity)] || 0.9;
-        const ceiling = UPGRADE_CEILING[String(target?.rarity)] || 0.9;
-        return Math.min((rtp * stakedValue) / targetValue, ceiling);
-    };
-
     useEffect(() => {
         if (selectedTarget && selectedItems.length > 0) {
             setFinished(false)
-            const rate = calculateSuccessRate(selectedItems, selectedTarget);
-            setSuccessRate(rate);
-
+            setSuccessRate(calculateSuccessRate(selectedItems, selectedTarget));
         } else {
             setSuccessRate(0);
         }
@@ -62,8 +34,8 @@ const Items: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedT
     if (userData) {
         return (
             <div className={`flex flex-col md:flex-row items-center justify-around gap-4 px-14 ${spinning && "pointer-events-none"}`} >
-                <UserItems selectedItems={selectedItems} setSelectedItems={setSelectedItems} selectedCase={selectedCase} setSelectedCase={setSelectedCase} toggleReload={toggleReload} setSelectedTarget={setSelectedTarget} />
-                <ChooseUpgradeItems setSelectedItems={setSelectedItems} selectedCase={selectedCase} setSelectedCase={setSelectedCase} selectedTarget={selectedTarget} setSelectedTarget={setSelectedTarget} />
+                <UserItems selectedItems={selectedItems} setSelectedItems={setSelectedItems} selectedCase={selectedCase} setSelectedCase={setSelectedCase} toggleReload={toggleReload} selectedTarget={selectedTarget} setSelectedTarget={setSelectedTarget} />
+                <ChooseUpgradeItems setSelectedItems={setSelectedItems} selectedItems={selectedItems} selectedCase={selectedCase} setSelectedCase={setSelectedCase} selectedTarget={selectedTarget} setSelectedTarget={setSelectedTarget} />
             </div >
         )
     } else {

--- a/src/pages/Upgrade/UserItems.tsx
+++ b/src/pages/Upgrade/UserItems.tsx
@@ -6,6 +6,7 @@ import Item from "../../components/Item";
 import UserContext from "../../UserContext";
 import { getInventory } from "../../services/users/UserServices";
 import Rarities from "../../components/Rarities";
+import { sourceRarities, ALL_RARITIES } from "./upgradeRules";
 import i18n from "../../i18n";
 
 interface Inventory {
@@ -14,6 +15,7 @@ interface Inventory {
     selectedCase: any;
     setSelectedCase: React.Dispatch<React.SetStateAction<any>>;
     toggleReload: boolean;
+    selectedTarget: any;
     setSelectedTarget: React.Dispatch<React.SetStateAction<any>>;
 }
 
@@ -24,7 +26,7 @@ const sortOptions = () => [
     { value: "mostCommon", label: i18n.t("upgrade.rarityLowToHigh") },
 ];
 
-const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedCase, setSelectedCase, toggleReload, setSelectedTarget }) => {
+const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selectedCase, setSelectedCase, toggleReload, selectedTarget, setSelectedTarget }) => {
     const [inventory, setInventory] = useState<any>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [pageLimit, setPageLimit] = useState<number>(0);
@@ -38,6 +40,12 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
         caseId: "",
     });
     const { userData } = useContext(UserContext);
+
+    // the target and the pile between them decide what is still legal to stake, so anything
+    // the server would refuse never reaches the grid
+    const allowedRarities = sourceRarities(selectedItems, selectedTarget);
+    const restricted = allowedRarities.length < ALL_RARITIES.length;
+    const allowedKey = allowedRarities.join(",");
 
     // any filter/sort change goes back to the first page
     const updateFilters = (patch: Partial<typeof inventoryFilters>) => {
@@ -62,6 +70,13 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                 if (selectedCase) {
                     newFilters.caseId = selectedCase;
                 }
+                // the dropdown narrows the allowed set, it never widens it
+                newFilters.rarity =
+                    newFilters.rarity && allowedRarities.includes(Number(newFilters.rarity))
+                        ? newFilters.rarity
+                        : restricted
+                            ? allowedKey
+                            : "";
                 const inventory = await getInventory(userData.id, currentPage, {
                     ...newFilters,
                     grouped: true,
@@ -110,8 +125,15 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
     };
 
     useEffect(() => {
+        setCurrentPage(1);
+        setInventoryFilters((prev) =>
+            prev.rarity && !allowedRarities.includes(Number(prev.rarity)) ? { ...prev, rarity: "" } : prev
+        );
+    }, [allowedKey]);
+
+    useEffect(() => {
         getInventoryInfo();
-    }, [currentPage, inventoryFilters, userData, selectedCase, toggleReload]);
+    }, [currentPage, inventoryFilters, userData, selectedCase, toggleReload, allowedKey]);
 
     const selectClass = "bg-[#19172D] border border-gray-700 rounded px-2 py-1 text-sm focus:outline-none focus:border-[#606bc7]";
 
@@ -119,7 +141,12 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
         <div className="flex flex-col md:w-1/2 gap-2">
             <div className="flex flex-col gap-3 bg-[#1C1A33] rounded px-6 py-4">
                 <div className="flex items-center justify-between">
-                    <span className="font-semibold">{i18n.t("profile.inventory")}</span>
+                    <div className="flex flex-col">
+                        <span className="font-semibold">{i18n.t("profile.inventory")}</span>
+                        {restricted && (
+                            <span className="text-xs text-gray-400">{i18n.t("upgrade.onlyWhatFits")}</span>
+                        )}
+                    </div>
                     {selectedCase && (
                         <div
                             className="flex items-center gap-1 cursor-pointer border-b border-gray-500 text-gray-400 hover:text-white"
@@ -159,7 +186,7 @@ const UserItems: React.FC<Inventory> = ({ selectedItems, setSelectedItems, selec
                         className={selectClass}
                     >
                         <option value="">{i18n.t("market.allRarities")}</option>
-                        {Rarities.map((r) => (
+                        {Rarities.filter((r) => allowedRarities.includes(r.id)).map((r) => (
                             <option key={r.id} value={String(r.id)}>{r.name}</option>
                         ))}
                     </select>

--- a/src/pages/Upgrade/upgradeConstants.test.ts
+++ b/src/pages/Upgrade/upgradeConstants.test.ts
@@ -16,7 +16,7 @@ const table = (source: string, name: string) => {
 };
 
 const backend = read("..", "..", "..", "backend", "games", "upgrade.js");
-const frontend = read("Items.tsx");
+const frontend = read("upgradeRules.ts");
 
 describe("the upgrade constants on both sides", () => {
   it("quote the same return per rarity", () => {

--- a/src/pages/Upgrade/upgradeRules.test.ts
+++ b/src/pages/Upgrade/upgradeRules.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { sourceRarities, targetRarities, calculateSuccessRate } from "./upgradeRules";
+
+const staked = (...rarities: number[]) => rarities.map((rarity) => ({ item: { rarity: String(rarity), baseValue: 100 } }));
+const target = (rarity: number, baseValue = 1000) => ({ rarity: String(rarity), baseValue });
+
+describe("what the upgrade screen is allowed to offer", () => {
+  it("offers every rarity while nothing is picked", () => {
+    expect(targetRarities([])).toEqual([1, 2, 3, 4, 5]);
+    expect(sourceRarities([], null)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("caps the outcome at two rarities above what is staked", () => {
+    expect(targetRarities(staked(1))).toEqual([1, 2, 3]);
+    expect(targetRarities(staked(3))).toEqual([3, 4, 5]);
+    expect(targetRarities(staked(5))).toEqual([5]);
+  });
+
+  it("narrows the outcome to what the whole pile can reach", () => {
+    expect(targetRarities(staked(1, 3))).toEqual([3]);
+    expect(targetRarities(staked(2, 3))).toEqual([3, 4]);
+  });
+
+  it("stakes only what sits inside the gap under the target", () => {
+    expect(sourceRarities([], target(5))).toEqual([3, 4, 5]);
+    expect(sourceRarities([], target(2))).toEqual([1, 2]);
+  });
+
+  it("keeps a further pick compatible with the pile even before a target is chosen", () => {
+    expect(sourceRarities(staked(1), null)).toEqual([1, 2, 3]);
+    expect(sourceRarities(staked(4), target(5))).toEqual([3, 4, 5]);
+  });
+
+  it("quotes nothing for a combination the server would refuse", () => {
+    expect(calculateSuccessRate(staked(1), target(5))).toBe(0);
+    expect(calculateSuccessRate(staked(5), target(4))).toBe(0);
+    expect(calculateSuccessRate(staked(3), target(5))).toBeGreaterThan(0);
+  });
+});

--- a/src/pages/Upgrade/upgradeRules.ts
+++ b/src/pages/Upgrade/upgradeRules.ts
@@ -1,0 +1,62 @@
+// mirrors backend/games/upgrade.js exactly, so the rate on screen is the rate the server
+// rolls: p = RTP(targetRarity) * staked / target, capped by the rarity ceiling.
+// upgradeConstants.test.ts reads both files and fails if these two ever disagree.
+export const UPGRADE_RTP_BY_RARITY: { [k: string]: number } = { "1": 0.9, "2": 0.9, "3": 0.85, "4": 0.75, "5": 0.3 };
+export const UPGRADE_CEILING: { [k: string]: number } = { "1": 0.9, "2": 0.7, "3": 0.45, "4": 0.25, "5": 0.12 };
+export const UPGRADE_MAX_RARITY_GAP = 2;
+
+export const ALL_RARITIES = [1, 2, 3, 4, 5];
+
+const between = (lo: number, hi: number) => ALL_RARITIES.filter((r) => r >= lo && r <= hi);
+
+const rarityOf = (thing: any) => Number(thing?.item?.rarity ?? thing?.rarity) || 0;
+
+// a staked item has to sit at or below the target and no further than the gap under it, so
+// the pile pins the target to [highest staked, lowest staked + gap]
+export const targetRarities = (selectedItems: any[]): number[] => {
+    let lo = 1;
+    let hi = 5;
+    for (const selected of selectedItems) {
+        const rarity = rarityOf(selected);
+        if (!rarity) continue;
+        lo = Math.max(lo, rarity);
+        hi = Math.min(hi, rarity + UPGRADE_MAX_RARITY_GAP);
+    }
+    return between(lo, hi);
+};
+
+// the same rule read backwards: what may still be staked, given the target if one is picked
+// and whatever is already in the pile
+export const sourceRarities = (selectedItems: any[], selectedTarget: any): number[] => {
+    let lo = 1;
+    let hi = 5;
+    const target = rarityOf(selectedTarget);
+    if (target) {
+        lo = Math.max(lo, target - UPGRADE_MAX_RARITY_GAP);
+        hi = Math.min(hi, target);
+    }
+    for (const selected of selectedItems) {
+        const rarity = rarityOf(selected);
+        if (!rarity) continue;
+        // whatever joins has to leave a target the whole pile can still reach
+        lo = Math.max(lo, rarity - UPGRADE_MAX_RARITY_GAP);
+        hi = Math.min(hi, rarity + UPGRADE_MAX_RARITY_GAP);
+    }
+    const allowed = between(lo, hi);
+    return allowed.length ? allowed : ALL_RARITIES;
+};
+
+export const calculateSuccessRate = (selectedItems: any[], target: any) => {
+    const stakedValue = selectedItems.reduce(
+        (sum: number, selected: any) => sum + (selected.item?.baseValue || 0),
+        0
+    );
+    const targetValue = target?.baseValue || 0;
+    if (stakedValue <= 0 || targetValue <= 0) return 0;
+    // the server refuses this combination, so quoting a rate for it would be a lie
+    const reachable = targetRarities(selectedItems);
+    if (!reachable.includes(Number(target?.rarity))) return 0;
+    const rtp = UPGRADE_RTP_BY_RARITY[String(target?.rarity)] || 0.9;
+    const ceiling = UPGRADE_CEILING[String(target?.rarity)] || 0.9;
+    return Math.min((rtp * stakedValue) / targetValue, ceiling);
+};


### PR DESCRIPTION
**Problem.** An item can only be aimed at something within two rarities of itself, but the upgrade screen kept offering everything. Pick a blue item and the ultra rares and uniques were still on the right, clickable, and picking one quoted a 0% chance with no reason given. Same in reverse: pick a unique as the target and the whole inventory was still offered, including the items that could never be staked at it.

**Change.** Both panels derive what they show from the same rule the server enforces, in a new `upgradeRules.ts` shared with the success-rate quote:

- a pile of stakes pins the outcome to `[highest staked, lowest staked + gap]`
- a chosen target pins the inventory to `[target - gap, target]`
- clearing a pick widens the range back
- the inventory rarity dropdown offers only the reachable tiers, and a line under each panel title says why the list is short

The inventory grid is paged in mongo, so filtering client-side would have left short pages and wrong page counts. `GET /users/inventory/:userId?rarity=` now takes a comma list as well as a single value; every other caller is unaffected.

**Tests.** `upgradeRules.test.ts` covers the ranges in both directions and that an illegal pair still quotes 0. Three cases added to `inventoryStacking.test.js` for the single value, the comma list with its page count, and a list that matches nothing. Backend jest, `npm run test:unit`, `eslint`, `tsc` and `npm run build` all pass.