### PR TITLE
feat(profile): address a profile by name instead of by id

### DIFF
--- a/backend/__tests__/integration/api.test.js
+++ b/backend/__tests__/integration/api.test.js
@@ -343,9 +343,12 @@ describe("case battles", () => {
 });
 
 describe("input guards", () => {
-  test("GET /users/:id with a non-ObjectId returns 404, not a 500", async () => {
+  // the path param is a slug now, so any string is a real lookup. a name nobody holds
+  // reports nothing, exactly as a missing or hidden account already did, and never 500s
+  test("GET /users/:id with a name nobody holds reports nothing, not a 500", async () => {
     const res = await request(app).get("/users/undefined");
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
   });
 
   test("GET /users/inventory/:userId with a bad id returns 404, not a 500", async () => {

--- a/backend/__tests__/integration/userSlug.test.js
+++ b/backend/__tests__/integration/userSlug.test.js
@@ -1,0 +1,130 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const User = require("../../models/User");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeUser = (username, extra = {}) =>
+  User.create({
+    username,
+    email: `${uniqueSuffix()}@example.com`,
+    password: "x",
+    ...extra,
+  });
+
+describe("a profile addressed by slug", () => {
+  it("resolves by slug", async () => {
+    const user = await makeUser("Reimu", { slug: "reimu" });
+
+    const res = await request(app).get("/users/reimu");
+
+    expect(res.status).toBe(200);
+    expect(String(res.body._id)).toBe(String(user._id));
+    expect(res.body.slug).toBe("reimu");
+  });
+
+  it("still resolves by id, so every link ever shared keeps working", async () => {
+    const user = await makeUser("Reimu", { slug: "reimu" });
+
+    const res = await request(app).get(`/users/${user._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe("Reimu");
+  });
+
+  // ObjectId.isValid() passes any 12-character string, so a naive resolver would send
+  // these into findById and 404 them
+  it("resolves a 12-character username instead of mistaking it for an id", async () => {
+    await makeUser("koishitivity", { slug: "koishitivity" });
+
+    const res = await request(app).get("/users/koishitivity");
+
+    expect(res.status).toBe(200);
+    expect(res.body.username).toBe("koishitivity");
+  });
+
+  it("serves the inventory by slug as well as by id", async () => {
+    const user = await makeUser("Reimu", { slug: "reimu" });
+
+    const bySlug = await request(app).get("/users/inventory/reimu?grouped=true");
+    const byId = await request(app).get(`/users/inventory/${user._id}?grouped=true`);
+
+    expect(bySlug.status).toBe(200);
+    expect(byId.status).toBe(200);
+    expect(bySlug.body.totalPages).toBe(byId.body.totalPages);
+  });
+
+  it("hands back nothing for a slug nobody holds", async () => {
+    const res = await request(app).get("/users/nobody-by-that-name");
+    expect(res.body).toBeNull();
+  });
+
+  it("keeps a disabled account hidden whichever way it is addressed", async () => {
+    const user = await makeUser("Ghost", { slug: "ghost", disabled: true });
+
+    expect((await request(app).get("/users/ghost")).body).toBeNull();
+    expect((await request(app).get(`/users/${user._id}`)).body).toBeNull();
+  });
+});
+
+describe("registration", () => {
+  const register = (username) =>
+    request(app).post("/users/register").send({
+      username,
+      email: `${uniqueSuffix()}@example.com`,
+      password: "password123",
+    });
+
+  it("mints a slug for a new account", async () => {
+    await register("Marisa");
+    const user = await User.findOne({ username: "Marisa" }).lean();
+    expect(user.slug).toBe("marisa");
+  });
+
+  it("refuses a name that only differs by case, so one url has one owner", async () => {
+    await register("Sakuya");
+    const second = await register("sakuya");
+    expect(second.status).toBe(400);
+  });
+
+  it("refuses a name that only differs by punctuation", async () => {
+    await register("LTA_BR");
+    const second = await register("LTA BR");
+    expect(second.status).toBe(400);
+  });
+
+  it("gives no slug to a name it cannot make one from, and still creates the account", async () => {
+    const res = await register("오정남");
+    expect(res.status).toBe(200);
+    const user = await User.findOne({ username: "오정남" }).lean();
+    expect(user.slug).toBeUndefined();
+  });
+
+  // the index is unique AND sparse: 59 accounts on file can have no slug at all, and a
+  // plain unique index would let only one of them exist
+  it("lets any number of accounts hold no slug", async () => {
+    await User.init();
+    const first = await register("오정남");
+    const second = await register("Иван Курапов");
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(await User.countDocuments({ slug: { $exists: false } })).toBe(2);
+  });
+
+  it("never lets a slug take an api path the server already owns", async () => {
+    await register("me");
+    const user = await User.findOne({ username: "me" }).lean();
+    expect(user.slug).toBe("me-2");
+  });
+});

--- a/backend/__tests__/unit/slugs.test.js
+++ b/backend/__tests__/unit/slugs.test.js
@@ -1,0 +1,64 @@
+const { slugify, baseSlugFor, looksLikeId, RESERVED } = require("../../utils/slugs");
+
+describe("slugify", () => {
+  it("folds case, accents and punctuation into one form", () => {
+    expect(slugify("Shiki")).toBe("shiki");
+    expect(slugify("shiki")).toBe("shiki");
+    expect(slugify("José Araújo")).toBe("jose-araujo");
+    expect(slugify("LTA_BR")).toBe("lta-br");
+    expect(slugify("LTA BR")).toBe("lta-br");
+    expect(slugify("Nate ")).toBe("nate");
+    expect(slugify("A.")).toBe("a");
+  });
+
+  it("gives nothing back for a name with no latin letters in it", () => {
+    expect(slugify("오정남")).toBe("");
+    expect(slugify("Иван")).toBe("");
+    expect(slugify(":)")).toBe("");
+    expect(slugify("")).toBe("");
+    expect(slugify(undefined)).toBe("");
+  });
+
+  it("never ends on a hyphen, even when the cut lands on one", () => {
+    const long = slugify("a".repeat(59) + " tail");
+    expect(long.endsWith("-")).toBe(false);
+    expect(long.length).toBeLessThanOrEqual(60);
+  });
+});
+
+describe("looksLikeId", () => {
+  it("accepts a real object id", () => {
+    expect(looksLikeId("658b3735f85dd4546b36cf1f")).toBe(true);
+  });
+
+  // ObjectId.isValid() says true for any 12-character string, which is 172 of the
+  // usernames on file. this check must not.
+  it("rejects the 12-character usernames that fool ObjectId.isValid", () => {
+    expect(looksLikeId("Amanda Meyer")).toBe(false);
+    expect(looksLikeId("koishitivity")).toBe(false);
+    expect(looksLikeId("totallynotxy")).toBe(false);
+    expect(looksLikeId("aya")).toBe(false);
+  });
+});
+
+describe("baseSlugFor", () => {
+  it("hands back the slug for an ordinary name", () => {
+    expect(baseSlugFor("Reimu")).toBe("reimu");
+  });
+
+  it("refuses a name the filter rejects, so no slur reaches a url", () => {
+    expect(baseSlugFor("Nigger")).toBeUndefined();
+  });
+
+  it("refuses a name that slugifies to nothing", () => {
+    expect(baseSlugFor("오정남")).toBeUndefined();
+  });
+});
+
+describe("reserved words", () => {
+  it("holds the api's own segments", () => {
+    for (const word of ["me", "inventory", "transactions", "badges", "notifications"]) {
+      expect(RESERVED.has(word)).toBe(true);
+    }
+  });
+});

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -10,6 +10,11 @@ const UserSchema = new mongoose.Schema({
     required: true,
     unique: true,
   },
+  // the profile url. minted from the username at signup and never rewritten, so a link
+  // keeps working. absent when the name has no latin letters in it, and the id is used then.
+  slug: {
+    type: String,
+  },
   email: {
     type: String,
     required: true,
@@ -223,6 +228,7 @@ const UserSchema = new mongoose.Schema({
 
 });
 
+UserSchema.index({ slug: 1 }, { unique: true, sparse: true }); // profile url lookup
 UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });
 UserSchema.index({ referredBy: 1 }, { sparse: true });
 UserSchema.index({ weeklyWinnings: -1 }); // leaderboard, ranking window, weekly cron

--- a/backend/routes/discordRoutes.js
+++ b/backend/routes/discordRoutes.js
@@ -33,6 +33,7 @@ const MAX_GUILDS = 25;
 // 21k entries, and everything these cards show is already summarised on the document.
 const CARD_FIELDS = {
   username: 1,
+  slug: 1,
   level: 1,
   xp: 1,
   profilePicture: 1,
@@ -75,6 +76,7 @@ const botOnly = (req, res, next) => {
 
 const publicCard = (user) => ({
   userId: user._id,
+  slug: user.slug || null,
   username: user.username,
   level: user.level || 0,
   xp: user.xp || 0,

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -24,6 +24,7 @@ const { OAuth2Client } = require('google-auth-library');
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const { resolvePassword } = require("../utils/password");
 const nameFilter = require("../utils/nameFilter");
+const { slugify, mintSlug, looksLikeId } = require("../utils/slugs");
 const { visible, isVisible } = require("../utils/visibility");
 const realtime = require("../utils/realtime");
 
@@ -56,7 +57,13 @@ router.post(
       if (userMail) {
         return res.status(400).json({ message: "Email already registered" });
       }
-      let userName = await User.exists({ username });
+      // the slug check is what makes this case-insensitive: "Shiki" and "shiki" reduce to the
+      // same url, so the second one is refused rather than being handed "shiki-2" forever.
+      // both lookups are indexed; a case-insensitive regex would scan every inventory on file.
+      const nameSlug = slugify(username);
+      let userName = await User.exists(
+        nameSlug ? { $or: [{ username }, { slug: nameSlug }] } : { username }
+      );
       if (userName) {
         return res.status(400).json({ message: "Username already registered" });
       }
@@ -79,6 +86,7 @@ router.post(
       user = new User({
         email,
         username,
+        slug: await mintSlug(User, username),
         profilePicture: placeholder,
         basePicture: placeholder,
         isAdmin: false,
@@ -198,11 +206,16 @@ router.post('/googlelogin', registerLimiter, registerDailyLimiter, async (req, r
     let user = await User.findOne({ email: googlePayload.email }).select("googleId disabled tokenVersion");
     if (!user) {
       let username = nameFilter.safeUsername(googlePayload.name, googlePayload.sub);
-      let existingUser = await User.exists({ username });
+      // a google name that only differs by case is still a conflict, since both want one url
+      const nameTaken = (name) => {
+        const taken = slugify(name);
+        return User.exists(taken ? { $or: [{ username: name }, { slug: taken }] } : { username: name });
+      };
+      let existingUser = await nameTaken(username);
       while (existingUser) {
         // Handle username conflict
         username = googlePayload.name + Math.floor(Math.random() * 1000);
-        existingUser = await User.exists({ username });
+        existingUser = await nameTaken(username);
       }
       // a referral only counts at account creation, never on a later login
       const referrer = referralCode ? await findReferrer(referralCode) : null;
@@ -213,6 +226,7 @@ router.post('/googlelogin', registerLimiter, registerDailyLimiter, async (req, r
         googleId: googlePayload.sub,
         email: googlePayload.email,
         username: username,
+        slug: await mintSlug(User, username),
         profilePicture: googlePayload.picture,
         basePicture: googlePayload.picture,
         marketingOptIn: consented,
@@ -286,6 +300,7 @@ router.get("/me", authMiddleware.isAuthenticated, async (req, res) => {
     const {
       _id: id,
       username,
+      slug,
       profilePicture,
       xp,
       level,
@@ -302,7 +317,7 @@ router.get("/me", authMiddleware.isAuthenticated, async (req, res) => {
 
     // isAdmin is the caller's own flag; the public /:id profile keeps hiding it
     res.json({
-      id, username, profilePicture, xp, level, walletBalance, nextBonus, hasUnreadNotifications,
+      id, username, slug: slug || null, profilePicture, xp, level, walletBalance, nextBonus, hasUnreadNotifications,
       isAdmin: !!isAdmin, fanRank, fixedItem,
       badges: badges.heldBadges(req.user),
       selectedBadge: req.user.selectedBadge || null,
@@ -758,14 +773,16 @@ router.post('/logout-all', authMiddleware.isAuthenticated, async (req, res) => {
 });
 
 
-// Get user by id (public profile: only non-sensitive fields)
+// a profile is addressed by slug now, but every id ever shared still has to resolve, so
+// both are accepted on the same route. the id test is strict 24-hex: ObjectId.isValid()
+// also passes any 12-character string, which is 172 of the usernames on file.
+const userFilter = (param) => (looksLikeId(param) ? { _id: param } : { slug: param });
+
+// Get user by id or slug (public profile: only non-sensitive fields)
 router.get("/:id", async (req, res) => {
   try {
-    if (!ObjectId.isValid(req.params.id)) {
-      return res.status(404).json({ message: "User not found" });
-    }
-    const user = await User.findById(req.params.id)
-      .select("username profilePicture xp level fixedItem fanRank collectionRank nextBonus weeklyWinnings selectedBadge badges disabled")
+    const user = await User.findOne(userFilter(req.params.id))
+      .select("username slug profilePicture xp level fixedItem fanRank collectionRank nextBonus weeklyWinnings selectedBadge badges disabled")
       .lean();
     if (!isVisible(user)) return res.json(null);
     res.json({ ...user, badges: badges.heldBadges(user), badge: badges.wornBadge(user) });
@@ -789,12 +806,8 @@ router.get("/inventory/:userId", async (req, res) => {
     const { name, rarity, sortBy, caseId } = req.query;
     const page = Math.max(1, Math.floor(Number(req.query.page)) || 1);
 
-    if (!ObjectId.isValid(userId)) {
-      return res.status(404).json({ message: "User not found" });
-    }
-
     // the visibility check needs a flag, not 12k inventory entries
-    const user = await User.findById(userId).select("disabled");
+    const user = await User.findOne(userFilter(userId)).select("disabled");
     if (!isVisible(user)) {
       return res.status(404).json({ message: "User not found" });
     }

--- a/backend/scripts/backfillUserSlug.js
+++ b/backend/scripts/backfillUserSlug.js
@@ -1,0 +1,70 @@
+require("dotenv").config();
+const mongoose = require("mongoose");
+const User = require("../models/User");
+const { slugify, baseSlugFor, RESERVED } = require("../utils/slugs");
+
+// gives every account its profile url. the oldest account holding a name keeps the bare
+// slug and later ones get -2, -3, so whoever has been linked to longest keeps their link.
+// a username with no latin letters in it gets no slug at all and keeps its id url; that is
+// deliberate, since the alternative is inventing a name for somebody. a name the filter
+// rejects keeps its id url too, so no slur ends up in a shareable link.
+//
+// usage:
+//   node scripts/backfillUserSlug.js --dry
+//   node scripts/backfillUserSlug.js
+async function backfill({ dry = false } = {}) {
+  // only the two fields, never the inventories: this collection is tens of megabytes
+  const users = await User.find({}, { username: 1, slug: 1 }).sort({ _id: 1 }).lean();
+
+  const taken = new Set(users.filter((u) => u.slug).map((u) => u.slug));
+  const plan = [];
+  let skipped = 0;
+  let unslugabble = 0;
+
+  for (const user of users) {
+    if (user.slug) {
+      skipped++;
+      continue;
+    }
+    const base = baseSlugFor(user.username);
+    if (!base) {
+      unslugabble++;
+      continue;
+    }
+    let slug = base;
+    for (let n = 2; taken.has(slug) || RESERVED.has(slug); n++) slug = `${base}-${n}`;
+    taken.add(slug);
+    plan.push({ _id: user._id, username: user.username, slug });
+  }
+
+  console.log(`${users.length} accounts | ${skipped} already had a slug | ${unslugabble} cannot have one`);
+  console.log(`${plan.length} to write`);
+  const suffixed = plan.filter((p) => /-\d+$/.test(p.slug) && slugify(p.username) !== p.slug);
+  console.log(`${suffixed.length} had to take a suffix:`);
+  suffixed.slice(0, 40).forEach((p) => console.log(`   ${p.username} -> ${p.slug}`));
+
+  if (dry) return plan;
+
+  for (let i = 0; i < plan.length; i += 500) {
+    const chunk = plan.slice(i, i + 500);
+    await User.bulkWrite(
+      chunk.map((p) => ({ updateOne: { filter: { _id: p._id }, update: { $set: { slug: p.slug } } } }))
+    );
+    console.log(`wrote ${Math.min(i + 500, plan.length)}/${plan.length}`);
+  }
+  return plan;
+}
+
+if (require.main === module) {
+  const dry = process.argv.includes("--dry");
+  mongoose
+    .connect(process.env.MONGO_URI)
+    .then(() => backfill({ dry }))
+    .then(() => mongoose.disconnect())
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = backfill;

--- a/backend/utils/slugs.js
+++ b/backend/utils/slugs.js
@@ -1,0 +1,55 @@
+const nameFilter = require("./nameFilter");
+
+// the url-safe form of a name. a name with no latin letters in it reduces to nothing, and
+// the caller decides what to do about that rather than being handed an invented slug.
+const slugify = (value) =>
+  String(value || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .slice(0, 60)
+    .replace(/^-+|-+$/g, "");
+
+// a 24-hex string is an id and nothing else. ObjectId.isValid() also accepts any 12-char
+// string, which would swallow 172 real usernames, so the check has to be this one.
+const looksLikeId = (value) => /^[0-9a-f]{24}$/i.test(String(value || ""));
+
+// segments the api already owns: /users/me must stay the logged-in player, not whoever
+// registered the name "me" first
+const RESERVED = new Set([
+  "register", "login", "logout", "logout-all", "googlelogin", "me", "notifications",
+  "transactions", "ranking", "topplayers", "inventory", "wallet", "badge", "badges",
+  "avatar", "avatars", "card-style", "fixeditem", "claimbonus", "profilepicture",
+  "admin", "api", "new", "edit", "search", "item", "orders", "buy", "sell",
+]);
+
+// the slug a name is entitled to, or undefined when it gets none. a name with no latin
+// letters has nothing to make one from, and a name the filter rejects keeps its id url: a
+// slur in an opaque id is one thing, the same slur in a shareable indexed url is another.
+const baseSlugFor = (name) => {
+  const base = slugify(name);
+  if (!base) return undefined;
+  if (nameFilter.findSlur(String(name)) || nameFilter.findSlur(base)) return undefined;
+  return base;
+};
+
+// the first free slug for this name: "shiki", then "shiki-2", the way a market gets one.
+// returns undefined when the name yields nothing usable, and the caller falls back to the id.
+async function mintSlug(Model, name, { ignoreId } = {}) {
+  const base = baseSlugFor(name);
+  if (!base) return undefined;
+  const free = async (slug) => {
+    if (RESERVED.has(slug)) return false;
+    const clash = await Model.exists(ignoreId ? { slug, _id: { $ne: ignoreId } } : { slug });
+    return !clash;
+  };
+  if (await free(base)) return base;
+  for (let n = 2; n < 1000; n++) {
+    const candidate = `${base}-${n}`;
+    if (await free(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+module.exports = { slugify, baseSlugFor, looksLikeId, mintSlug, RESERVED };

--- a/bot/src/embeds.js
+++ b/bot/src/embeds.js
@@ -16,14 +16,15 @@ const colorOf = (rarity) => RARITY[String(rarity)] || NEUTRAL;
 const num = (value) => Number(value || 0).toLocaleString("en-US");
 const medal = (index) => ["1.", "2.", "3."][index] || `${index + 1}.`;
 
-const profileUrl = (userId) => `${SITE}/profile/${userId}`;
+// the slug when the account has one, the id otherwise: both resolve, one reads better
+const profileUrl = (card) => `${SITE}/profile/${card.slug || card.userId}`;
 const boardUrl = (name) => `${SITE}/fandom/${encodeURIComponent(name)}`;
 
 function showcaseEmbed(card) {
   const embed = new EmbedBuilder()
     .setColor(colorOf(card.pinned && card.pinned.rarity))
     .setTitle(card.username)
-    .setURL(profileUrl(card.userId))
+    .setURL(profileUrl(card))
     .setFooter({ text: "kanicasino.com" });
 
   if (card.profilePicture) embed.setThumbnail(card.profilePicture);

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { getUser, getInventory } from "../../services/users/UserServices";
 import { FiFilter } from 'react-icons/fi'
 import UserInfo from "./UserInfo";
@@ -56,6 +56,15 @@ const Profile = () => {
     order: 'asc',
   });
   const delayDebounceFn = useRef<NodeJS.Timeout | null>(null);
+  const navigate = useNavigate();
+  // the url param may be a slug, so anything that speaks to the api by id waits for the
+  // resolved one off the loaded profile
+  const resolvedId = (user as any)?._id as string | undefined;
+  const canonical = (user as any)?.slug as string | undefined;
+  const profileId = resolvedId ?? id;
+  // an id link still resolves, but the address bar becomes the slug once the profile is
+  // known, so whatever a player copies from here carries their name
+  const sameProfile = Boolean(user) && (id === canonical || id === resolvedId);
 
   useEffect(() => {
     if (invItems?.length > 0) {
@@ -85,7 +94,7 @@ const Profile = () => {
     setLoadingInventory(true);
     try {
       const response = await getInventory(
-        id as string,
+        resolvedId as string,
         page,
         { ...filters, grouped: true }
       );
@@ -110,8 +119,8 @@ const Profile = () => {
   };
 
   useEffect(() => {
-    setIsSameUser(userData?.id == id);
-  }, [id, userData]);
+    setIsSameUser(Boolean(userData?.id) && userData.id == profileId);
+  }, [profileId, userData]);
 
   useEffect(() => {
     if (refresh) {
@@ -126,6 +135,14 @@ const Profile = () => {
   }, [userRefresh]);
 
   useEffect(() => {
+    if (!canonical || !id || id === canonical) return;
+    const query = searchParams.toString();
+    navigate(`/profile/${canonical}${query ? `?${query}` : ""}`, { replace: true });
+  }, [canonical, id]);
+
+  useEffect(() => {
+    // the param turning from an id into the slug is the same profile, so nothing reloads
+    if (sameProfile) return;
     setInvItems([]);
     setPage(1);
     getUserInfo();
@@ -150,9 +167,11 @@ const Profile = () => {
     localStorage.setItem(`kani.tabSeen.${userData.id}`, JSON.stringify(next));
   }, [activeTab, isSameUser, userData?.id, seenTabs]);
 
+  // keyed on the resolved id, so the canonical swap never costs a second aggregation
   useEffect(() => {
+    if (!resolvedId) return;
     getInventoryInfo();
-  }, [page, id]);
+  }, [page, resolvedId]);
 
 
   const tabs: { key: Tab; label: string }[] = [
@@ -190,7 +209,7 @@ const Profile = () => {
                 isSameUser={isSameUser}
                 setRefresh={refreshUser}
               />
-              <FriendButton profileId={id as string} isSameUser={isSameUser} />
+              <FriendButton profileId={profileId as string} isSameUser={isSameUser} />
             </div>
           )
         )}
@@ -240,7 +259,7 @@ const Profile = () => {
           {activeTab === "history" ? (
             <BalanceHistory />
           ) : activeTab === "missions" ? (
-            <MissionsPanel userId={id as string} isOwner={isSameUser} />
+            <MissionsPanel userId={profileId as string} isOwner={isSameUser} />
           ) : activeTab === "affiliates" ? (
             <AffiliatesPanel isOwner={isSameUser} />
           ) : activeTab === "predictions" ? (
@@ -248,7 +267,7 @@ const Profile = () => {
           ) : activeTab === "settings" ? (
             <EmailSettings />
           ) : activeTab === "collections" ? (
-            <CollectionsPanel userId={id as string} isOwner={isSameUser} />
+            <CollectionsPanel userId={profileId as string} isOwner={isSameUser} />
           ) : (
           <>
           <div className="flex flex-col w-full items-end mr-[70px] gap-4 -mt-10">
@@ -303,7 +322,7 @@ const Profile = () => {
 
       {openItem && (
         <ItemCopiesModal
-          userId={id as string}
+          userId={profileId as string}
           item={openItem}
           isOwner={isSameUser}
           open={!!openItem}


### PR DESCRIPTION
**Problem.** `/profile/658b3735f85dd4546b36cf1f` tells a player nothing and is not worth sharing.

**Change.** A `slug` on the user, minted from the username at signup and stored, so a lookup is an indexed hit rather than a scan. It is never rewritten, so a link keeps working.

`/profile/player` and `/profile/658b...` both resolve on the same route, so every id ever shared, posted to Discord or indexed by Google keeps working with no redirect. Once a profile loads by id the address bar swaps to the slug, so whatever a player copies carries their name.

**The id test is `/^[0-9a-f]{24}$/i`, not `ObjectId.isValid()`.** `ObjectId.isValid()` returns true for *any* 12-character string, which is **172 of the usernames on file** (`Amanda Meyer`, `koishitivity`, `totallynotxy`...). A naive resolver would route those into `findById` and 404 them. There is a test pinning this.

**Collisions,** measured against production: 29 slugs were contested by 59 accounts, almost all case pairs (`Shiki`/`shiki`, `Cirno`/`cirno`).

- The oldest account holding a name keeps the bare slug; later ones take `-2`. 32 accounts take a suffix.
- Registration now refuses a name that reduces to a slug somebody already holds, so no new pair can appear. That check is an **indexed slug lookup**; a case-insensitive regex on `username` would have read every inventory on file on every signup.
- 48 usernames have no latin letters (`오정남`, `Иван Курапов`, `:)`) and get no slug — inventing one is worse than keeping the id.
- 11 usernames trip the name filter and get no slug either. A slur behind an opaque id is one thing; the same slur in a shareable, indexable URL is another.

The index is unique **and sparse**, since 59 accounts hold no slug at all; a plain unique index would allow only one of them. Pinned by a test.

**Cost.** One indexed `findOne` per profile view, replacing an indexed `findById`. The canonical swap is keyed on the resolved id, so it does not re-run the inventory aggregation. Registration does one extra `exists` on an indexed field.

**Deploy.** Ship, then `node scripts/backfillUserSlug.js` (`--dry` first). It projects two fields, never inventories. Dry run against production: 2,881 accounts, 2,822 get a slug, 32 take a suffix, 59 keep their id.

**Tests.** 21 new (9 unit on the helpers, 12 integration on routing, registration and the sparse index). Full backend suite 1067 passing, frontend 170, `tsc`, `eslint` and `npm run build` clean. One existing guard test was updated: `GET /users/undefined` used to 404 from a format check that no longer applies, and now reports `null` like any other unknown or hidden account.

Items get the same treatment in a follow-up.