### PR TITLE
feat(catalog): address a case and an item by name instead of by id

### DIFF
--- a/backend/__tests__/integration/catalogSlug.test.js
+++ b/backend/__tests__/integration/catalogSlug.test.js
@@ -1,0 +1,89 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const request = require("supertest");
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { makeApp, uniqueSuffix } = require("./helpers");
+
+const Case = require("../../models/Case");
+const Item = require("../../models/Item");
+
+let app;
+
+beforeAll(async () => {
+  await setupDb();
+  app = makeApp();
+});
+afterEach(clearDb);
+afterAll(teardownDb);
+
+const makeCase = (title, slug) =>
+  Case.create({ title, slug, price: 100, image: "c.png", items: [] });
+
+const makeItem = (name, slug, caseId) =>
+  Item.create({ name, slug, rarity: "1", image: "i.png", baseValue: 10, case: caseId });
+
+describe("a case addressed by slug", () => {
+  it("resolves by slug and by id alike", async () => {
+    const box = await makeCase(`Lunatic ${uniqueSuffix()}`, "lunatic-case");
+
+    const bySlug = await request(app).get("/cases/lunatic-case");
+    const byId = await request(app).get(`/cases/${box._id}`);
+
+    expect(bySlug.status).toBe(200);
+    expect(String(bySlug.body._id)).toBe(String(box._id));
+    expect(bySlug.body.slug).toBe("lunatic-case");
+    expect(String(byId.body._id)).toBe(String(box._id));
+  });
+
+  it("reports nothing for a slug nobody holds", async () => {
+    const res = await request(app).get("/cases/no-such-case");
+    expect(res.body).toBeNull();
+  });
+});
+
+describe("an item addressed by slug", () => {
+  it("serves its listings by slug, and says which item it is", async () => {
+    const box = await makeCase(`Box ${uniqueSuffix()}`, `box-${uniqueSuffix()}`);
+    const item = await makeItem(`Aya ${uniqueSuffix()}`, "aya", box._id);
+
+    const res = await request(app).get("/marketplace/item/aya");
+
+    expect(res.status).toBe(200);
+    expect(String(res.body.itemId)).toBe(String(item._id));
+    expect(res.body.slug).toBe("aya");
+  });
+
+  it("still serves them by id", async () => {
+    const box = await makeCase(`Box ${uniqueSuffix()}`, `box-${uniqueSuffix()}`);
+    const item = await makeItem(`Aya ${uniqueSuffix()}`, "aya", box._id);
+
+    const res = await request(app).get(`/marketplace/item/${item._id}`);
+
+    expect(res.status).toBe(200);
+    expect(String(res.body.itemId)).toBe(String(item._id));
+    expect(res.body.slug).toBe("aya");
+  });
+
+  it("serves the price history and the order book by slug too", async () => {
+    const box = await makeCase(`Box ${uniqueSuffix()}`, `box-${uniqueSuffix()}`);
+    await makeItem(`Aya ${uniqueSuffix()}`, "aya", box._id);
+
+    expect((await request(app).get("/marketplace/item/aya/history")).status).toBe(200);
+    expect((await request(app).get("/marketplace/item/aya/orders")).status).toBe(200);
+  });
+
+  it("404s a slug nobody holds instead of throwing", async () => {
+    expect((await request(app).get("/marketplace/item/no-such-item")).status).toBe(404);
+    expect((await request(app).get("/marketplace/item/no-such-item/history")).status).toBe(404);
+    expect((await request(app).get("/marketplace/item/no-such-item/orders")).status).toBe(404);
+  });
+
+  // the index is unique and sparse, so anything without a slug must still coexist
+  it("lets any number of items hold no slug", async () => {
+    await Item.init();
+    const box = await makeCase(`Box ${uniqueSuffix()}`, `box-${uniqueSuffix()}`);
+    await makeItem("One", undefined, box._id);
+    await makeItem("Two", undefined, box._id);
+    expect(await Item.countDocuments({ slug: { $exists: false } })).toBe(2);
+  });
+});

--- a/backend/__tests__/unit/slugs.test.js
+++ b/backend/__tests__/unit/slugs.test.js
@@ -1,4 +1,4 @@
-const { slugify, baseSlugFor, looksLikeId, RESERVED } = require("../../utils/slugs");
+const { slugify, baseSlugFor, qualifiedSlug, looksLikeId, RESERVED } = require("../../utils/slugs");
 
 describe("slugify", () => {
   it("folds case, accents and punctuation into one form", () => {
@@ -60,5 +60,25 @@ describe("reserved words", () => {
     for (const word of ["me", "inventory", "transactions", "badges", "notifications"]) {
       expect(RESERVED.has(word)).toBe(true);
     }
+  });
+});
+
+describe("qualifiedSlug", () => {
+  // two cases hold a character of the same name, and the case is what tells them apart
+  it("names the case when two items share a name", () => {
+    expect(qualifiedSlug("Saki", "Kivotos Case")).toBe("saki-kivotos-case");
+    expect(qualifiedSlug("Hina", "Gehenna Case")).toBe("hina-gehenna-case");
+  });
+
+  // a qualifier cut mid-word names nothing, so the caller falls back to a number
+  it("refuses a qualifier that would not fit", () => {
+    expect(
+      qualifiedSlug("Souvenir AWP | Dragon Lore", "Boston 2018 Cobblestone Souvenir Package")
+    ).toBeNull();
+  });
+
+  it("refuses to qualify when there is nothing to qualify with", () => {
+    expect(qualifiedSlug("Saki", null)).toBeNull();
+    expect(qualifiedSlug("Saki", undefined)).toBeNull();
   });
 });

--- a/backend/models/Case.js
+++ b/backend/models/Case.js
@@ -6,6 +6,10 @@ const CaseSchema = new mongoose.Schema({
     required: true,
   },
   image: String,
+  // the shelf url. minted from the title and never rewritten, so a link keeps working.
+  slug: {
+    type: String,
+  },
   price: {
     type: Number,
     required: true,
@@ -47,5 +51,7 @@ const CaseSchema = new mongoose.Schema({
     },
   ],
 });
+
+CaseSchema.index({ slug: 1 }, { unique: true, sparse: true }); // url lookup
 
 module.exports = mongoose.model("Case", CaseSchema);

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -10,6 +10,10 @@ const ItemSchema = new mongoose.Schema({
     maxlength: 200,
   },
   image: String,
+  // the shelf url. minted from the name and never rewritten, so a link keeps working.
+  slug: {
+    type: String,
+  },
   rarity: {
     type: String,
     required: true,
@@ -50,5 +54,7 @@ const WRITE_HOOKS = [
   "deleteMany",
 ];
 for (const hook of WRITE_HOOKS) ItemSchema.post(hook, invalidateCatalog);
+
+ItemSchema.index({ slug: 1 }, { unique: true, sparse: true }); // url lookup
 
 module.exports = mongoose.model("Item", ItemSchema);

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -9,6 +9,7 @@ const Item = require("../models/Item");
 const { recomputeCaseValues } = require("../utils/itemValue");
 const { recordTransaction, runAtomic, TX } = require("../utils/economy");
 const adminStats = require("../utils/adminStats");
+const { slugify, mintSlug } = require("../utils/slugs");
 
 // the backoffice dashboard: everything is derived from the ledger, ?days= windows it
 router.get("/stats/overview", isAuthenticated, isAdmin, async (req, res) => {
@@ -90,7 +91,7 @@ router.get("/users", isAuthenticated, isAdmin, async (req, res) => {
 //create case
 router.post("/cases", isAuthenticated, isAdmin, async (req, res) => {
   const { title, image, price, items, category } = req.body;
-  const newCase = new Case({ title, image, price, items, category });
+  const newCase = new Case({ title, image, price, items, category, slug: await mintSlug(Case, title) });
 
   try {
     const savedCase = await newCase.save();
@@ -140,7 +141,7 @@ router.delete("/cases/:id", isAuthenticated, isAdmin, async (req, res) => {
 //new item
 router.post("/items", isAuthenticated, isAdmin, async (req, res) => {
   const { name, description, rarity, image } = req.body;
-  const newItem = new Item({ name, description, rarity, image });
+  const newItem = new Item({ name, description, rarity, image, slug: await mintSlug(Item, name) });
 
   try {
     const savedItem = await newItem.save();
@@ -301,15 +302,6 @@ const Prediction = require("../models/Prediction");
 const PredictionPosition = require("../models/PredictionPosition");
 const settlement = require("../utils/predictionSettlement");
 const { DEFAULT_VIG_BPS, DEFAULT_IMPACT_BPS } = require("../utils/predictionMath");
-
-const slugify = (title) =>
-  String(title)
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 60);
 
 // a market the admin writes is still text a player reads, so it goes through the filter
 function cleanText(...parts) {

--- a/backend/routes/caseRoutes.js
+++ b/backend/routes/caseRoutes.js
@@ -7,6 +7,7 @@ const { isAuthenticated, isAdmin } = require("../middleware/authMiddleware");
 const { recomputeCaseValues } = require("../utils/itemValue");
 const { TX } = require("../utils/economy");
 const { publicCache, TTL } = require("../utils/httpCache");
+const { looksLikeId, mintSlug } = require("../utils/slugs");
 
 router.get("/", async (req, res) => {
   try {
@@ -30,6 +31,7 @@ router.post("/", isAuthenticated, isAdmin, async (req, res) => {
     price: req.body.price,
     items: req.body.items,
     category: req.body.category,
+    slug: await mintSlug(Case, req.body.title),
   });
 
   try {
@@ -76,7 +78,10 @@ router.get("/most-opened", async (req, res) => {
 
 router.get("/:id", async (req, res) => {
   try {
-    const caseData = await Case.findById(req.params.id)
+    // a case is addressed by slug now; every id ever shared still resolves on this route
+    const caseData = await Case.findOne(
+      looksLikeId(req.params.id) ? { _id: req.params.id } : { slug: String(req.params.id) }
+    )
       .select("-rangeTable")
       .populate({
         path: "items",

--- a/backend/routes/itemRoutes.js
+++ b/backend/routes/itemRoutes.js
@@ -8,6 +8,7 @@ const { publicCache, TTL } = require("../utils/httpCache");
 const itemCatalog = require("../utils/itemCatalog");
 const artProxy = require("../utils/artProxy");
 const { artLimiter } = require("../middleware/rateLimit");
+const { mintSlug } = require("../utils/slugs");
 
 router.get("/", async (req, res) => {
   try {
@@ -48,11 +49,14 @@ router.get("/art", isAuthenticated, artLimiter, async (req, res) => {
 });
 
 router.post("/", isAuthenticated, isAdmin, async (req, res) => {
+  // two cases can hold a character of the same name, and the case is what tells them apart
+  const parentCase = req.body.case ? await Case.findById(req.body.case, { title: 1 }).lean() : null;
   const newItem = new Item({
     name: req.body.name,
     image: req.body.image,
     rarity: req.body.rarity,
     case: req.body.case,
+    slug: await mintSlug(Item, req.body.name, { qualifier: parentCase && parentCase.title }),
   });
 
   try {

--- a/backend/routes/marketplaceRoutes.js
+++ b/backend/routes/marketplaceRoutes.js
@@ -16,8 +16,23 @@ const market = require("../utils/market");
 const fandom = require("../utils/fandom");
 const itemCatalog = require("../utils/itemCatalog");
 const { isRealMoneyMode } = require("../utils/mode");
+const { looksLikeId } = require("../utils/slugs");
 
 const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// an item is addressed by slug now, but every id ever shared still has to resolve. a slug
+// costs one indexed lookup; an id costs nothing, which is the common case from inside the app.
+const resolveItem = async (param) => {
+  const found = await Item.findOne(
+    looksLikeId(param) ? { _id: param } : { slug: String(param) },
+    { slug: 1 }
+  ).lean();
+  return found ? { id: String(found._id), slug: found.slug || null } : null;
+};
+const resolveItemId = async (param) => {
+  const found = await resolveItem(param);
+  return found ? found.id : null;
+};
 const isValidId = (id) => mongoose.Types.ObjectId.isValid(id);
 
 // headroom over the priciest item in the game. the katowice 2014 capsules put a rarity-5
@@ -470,8 +485,8 @@ module.exports = (io) => {
   // the price-history series + everything a seller needs to price an item
   router.get("/item/:itemId/history", async (req, res) => {
     try {
-      const { itemId } = req.params;
-      if (!isValidId(itemId)) return res.status(404).json({ message: "Item not found" });
+      const itemId = await resolveItemId(req.params.itemId);
+      if (!itemId) return res.status(404).json({ message: "Item not found" });
 
       // hasOwnProperty, so ?range=toString can't match an inherited prototype key
       const asked = String(req.query.range);
@@ -537,8 +552,8 @@ module.exports = (io) => {
   // the buy-order book for an item, aggregated by price
   router.get("/item/:itemId/orders", async (req, res) => {
     try {
-      const { itemId } = req.params;
-      if (!isValidId(itemId)) return res.status(404).json({ message: "Item not found" });
+      const itemId = await resolveItemId(req.params.itemId);
+      if (!itemId) return res.status(404).json({ message: "Item not found" });
       const rows = await BuyOrder.aggregate([
         {
           $match: {
@@ -561,10 +576,11 @@ module.exports = (io) => {
   // Get listings for a specific item
   router.get("/item/:itemId", async (req, res) => {
     try {
-      const { itemId } = req.params;
-      if (!isValidId(itemId)) {
+      const found = await resolveItem(req.params.itemId);
+      if (!found) {
         return res.status(404).json({ message: "Item not found" });
       }
+      const itemId = found.id;
 
       const page = Math.max(1, Math.floor(Number(req.query.page)) || 1);
       const limit = Math.min(Math.max(1, Math.floor(Number(req.query.limit)) || 30), 100);
@@ -579,6 +595,8 @@ module.exports = (io) => {
         .limit(limit);
 
       res.json({
+        itemId,
+        slug: found.slug,
         totalPages: Math.ceil(total / limit),
         currentPage: page,
         items,

--- a/backend/scripts/backfillCatalogSlug.js
+++ b/backend/scripts/backfillCatalogSlug.js
@@ -1,0 +1,91 @@
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Case = require("../models/Case");
+const Item = require("../models/Item");
+const { baseSlugFor, qualifiedSlug, RESERVED } = require("../utils/slugs");
+
+// gives every case and every item its shelf url. a name that repeats belongs to more than
+// one case, so the case is what tells them apart: "saki" and "saki-kivotos-case" rather
+// than "saki" and "saki-2", which would say nothing about which Saki it is.
+//
+// usage:
+//   node scripts/backfillCatalogSlug.js --dry
+//   node scripts/backfillCatalogSlug.js
+async function backfill({ dry = false } = {}) {
+  const cases = await Case.find({}, { title: 1, slug: 1 }).sort({ _id: 1 }).lean();
+  const items = await Item.find({}, { name: 1, case: 1, slug: 1 }).sort({ _id: 1 }).lean();
+  const caseTitle = new Map(cases.map((c) => [String(c._id), c.title]));
+
+  const plan = (rows, nameOf, qualifierOf) => {
+    const taken = new Set(rows.filter((r) => r.slug).map((r) => r.slug));
+    const out = [];
+    let skipped = 0;
+    let none = 0;
+    for (const row of rows) {
+      if (row.slug) {
+        skipped++;
+        continue;
+      }
+      const base = baseSlugFor(nameOf(row));
+      if (!base) {
+        none++;
+        continue;
+      }
+      let slug = base;
+      if (taken.has(slug) || RESERVED.has(slug)) {
+        const qualifier = qualifierOf ? qualifierOf(row) : null;
+        const qualified = qualifiedSlug(nameOf(row), qualifier);
+        slug = qualified && qualified !== base && !taken.has(qualified) ? qualified : null;
+        if (!slug) {
+          for (let n = 2; ; n++) {
+            const candidate = `${base}-${n}`;
+            if (!taken.has(candidate) && !RESERVED.has(candidate)) {
+              slug = candidate;
+              break;
+            }
+          }
+        }
+      }
+      taken.add(slug);
+      out.push({ _id: row._id, name: nameOf(row), slug, base });
+    }
+    return { out, skipped, none };
+  };
+
+  const casePlan = plan(cases, (c) => c.title);
+  const itemPlan = plan(items, (i) => i.name, (i) => caseTitle.get(String(i.case)));
+
+  for (const [label, rows, p] of [["cases", cases, casePlan], ["items", items, itemPlan]]) {
+    console.log(`${label}: ${rows.length} total | ${p.skipped} already had one | ${p.none} cannot have one | ${p.out.length} to write`);
+    const moved = p.out.filter((r) => r.slug !== r.base);
+    console.log(`   ${moved.length} had to be qualified:`);
+    moved.slice(0, 30).forEach((r) => console.log(`      ${r.name} -> ${r.slug}`));
+  }
+
+  if (dry) return { casePlan, itemPlan };
+
+  for (const [Model, p] of [[Case, casePlan], [Item, itemPlan]]) {
+    for (let i = 0; i < p.out.length; i += 500) {
+      const chunk = p.out.slice(i, i + 500);
+      await Model.bulkWrite(
+        chunk.map((r) => ({ updateOne: { filter: { _id: r._id }, update: { $set: { slug: r.slug } } } }))
+      );
+      console.log(`${Model.modelName}: wrote ${Math.min(i + 500, p.out.length)}/${p.out.length}`);
+    }
+  }
+  return { casePlan, itemPlan };
+}
+
+if (require.main === module) {
+  const dry = process.argv.includes("--dry");
+  mongoose
+    .connect(process.env.MONGO_URI)
+    .then(() => backfill({ dry }))
+    .then(() => mongoose.disconnect())
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+module.exports = backfill;

--- a/backend/utils/slugs.js
+++ b/backend/utils/slugs.js
@@ -2,14 +2,24 @@ const nameFilter = require("./nameFilter");
 
 // the url-safe form of a name. a name with no latin letters in it reduces to nothing, and
 // the caller decides what to do about that rather than being handed an invented slug.
-const slugify = (value) =>
+const MAX = 60;
+
+const slugify = (value, limit = MAX) =>
   String(value || "")
     .toLowerCase()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
-    .slice(0, 60)
+    .slice(0, limit)
     .replace(/^-+|-+$/g, "");
+
+// "saki-kivotos-case" tells you which Saki. the same trick on a souvenir package runs past
+// the limit and gets cut mid-word, which names nothing, so it is only used when it fits.
+const qualifiedSlug = (name, qualifier) => {
+  if (!qualifier) return null;
+  const full = slugify(`${name} ${qualifier}`, Infinity);
+  return full.length <= MAX ? full : null;
+};
 
 // a 24-hex string is an id and nothing else. ObjectId.isValid() also accepts any 12-char
 // string, which would swallow 172 real usernames, so the check has to be this one.
@@ -35,16 +45,20 @@ const baseSlugFor = (name) => {
 };
 
 // the first free slug for this name: "shiki", then "shiki-2", the way a market gets one.
-// returns undefined when the name yields nothing usable, and the caller falls back to the id.
-async function mintSlug(Model, name, { ignoreId } = {}) {
+// a qualifier is tried before the number, because "saki-kivotos-case" says which Saki it is
+// and "saki-2" says nothing. returns undefined when the name yields nothing usable, and the
+// caller falls back to the id.
+async function mintSlug(Model, name, { ignoreId, qualifier } = {}) {
   const base = baseSlugFor(name);
   if (!base) return undefined;
   const free = async (slug) => {
-    if (RESERVED.has(slug)) return false;
+    if (!slug || RESERVED.has(slug)) return false;
     const clash = await Model.exists(ignoreId ? { slug, _id: { $ne: ignoreId } } : { slug });
     return !clash;
   };
   if (await free(base)) return base;
+  const qualified = qualifiedSlug(name, qualifier);
+  if (qualified && qualified !== base && (await free(qualified))) return qualified;
   for (let n = 2; n < 1000; n++) {
     const candidate = `${base}-${n}`;
     if (await free(candidate)) return candidate;
@@ -52,4 +66,4 @@ async function mintSlug(Model, name, { ignoreId } = {}) {
   return undefined;
 }
 
-module.exports = { slugify, baseSlugFor, looksLikeId, mintSlug, RESERVED };
+module.exports = { slugify, baseSlugFor, qualifiedSlug, looksLikeId, mintSlug, RESERVED, MAX };

--- a/src/pages/CasePage/CasePage.tsx
+++ b/src/pages/CasePage/CasePage.tsx
@@ -39,6 +39,9 @@ const CasePage = () => {
 
   //get id from url
   const id = window.location.pathname.split("/")[2];
+  // the url may carry a slug, so anything that speaks to the api uses the resolved id
+  const caseId = (data as any)?._id ?? id;
+  const canonical = (data as any)?.slug as string | undefined;
 
   const getCaseInfo = async () => {
     getCase(id)
@@ -56,8 +59,8 @@ const CasePage = () => {
   // a daily-gift grant pays for this case, so the page has to know about it before the
   // open button decides whether it is charging anything
   const getGrant = () => {
-    if (!userData?.id) return setGrant(null);
-    getGrants(id)
+    if (!userData?.id || !(data as any)?._id) return setGrant(null);
+    getGrants(caseId)
       .then((gs) => setGrant(gs[0] || null))
       .catch(() => setGrant(null));
   };
@@ -68,14 +71,20 @@ const CasePage = () => {
     window.scrollTo(0, 0);
   }, []);
 
-  useEffect(getGrant, [userData?.id, id]);
+  useEffect(getGrant, [userData?.id, (data as any)?._id]);
+
+  // an id link becomes the slug once the case is known, so a shared link carries its name
+  useEffect(() => {
+    if (!canonical || !id || id === canonical) return;
+    navigate(`/case/${canonical}`, { replace: true });
+  }, [canonical, id]);
 
   // prerender bakes the real name into the html; PageMeta's generic /case/ entry would
   // overwrite it on hydration, so put it back once the case itself has loaded
   useEffect(() => {
     if (!data?.title) return;
     const { title, description } = caseMeta(data);
-    applyMeta(title, description, `/case/${data._id || id}`);
+    applyMeta(title, description, `/case/${(data as any).slug || data._id || id}`);
   }, [data, id]);
 
   const resetProps = () => {
@@ -136,7 +145,7 @@ const CasePage = () => {
     setLoadingButton(true);
 
     try {
-      const response = await openBox(id, quantity, freeNow ? grant?.grantId : undefined);
+      const response = await openBox(caseId, quantity, freeNow ? grant?.grantId : undefined);
       setOpenedItems(response.items);
       if (freeNow) getGrant();
     } catch (error: any) {

--- a/src/pages/Market/ItemPage.tsx
+++ b/src/pages/Market/ItemPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import {
   getItemListings,
@@ -62,6 +62,7 @@ const Stat: React.FC<{ label: string; value: React.ReactNode; hint?: string; acc
 
 const ItemPage: React.FC = () => {
   const { itemId } = useParams<{ itemId: string }>();
+  const navigate = useNavigate();
   const [items, setItems] = useState<ItemData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [page, setPage] = useState<number>(1);
@@ -78,6 +79,9 @@ const ItemPage: React.FC = () => {
   const [range, setRange] = useState<string>("week");
   const [book, setBook] = useState<{ price: number; quantity: number }[]>([]);
   const [myOrders, setMyOrders] = useState<BuyOrder[]>([]);
+  // the url may carry a slug, so the id to compare against comes from the payload
+  const resolvedId = (items as any)?.itemId as string | undefined;
+  const canonical = (items as any)?.slug as string | undefined;
 
   const fetchItemListings = useCallback(async () => {
     setLoading(true);
@@ -112,11 +116,16 @@ const ItemPage: React.FC = () => {
     // my orders only exist when logged in; a failure here is not an error state
     try {
       const mine = await getMyOrders();
-      setMyOrders((mine.orders || []).filter((o) => String(o.item) === String(itemId)));
+      setMyOrders((mine.orders || []).filter((o) => String(o.item) === String(resolvedId ?? itemId)));
     } catch {
       setMyOrders([]);
     }
-  }, [itemId, range]);
+  }, [itemId, range, resolvedId]);
+
+  useEffect(() => {
+    if (!canonical || !itemId || itemId === canonical) return;
+    navigate(`/marketplace/item/${canonical}`, { replace: true });
+  }, [canonical, itemId]);
 
   useEffect(() => {
     if (refresh) {


### PR DESCRIPTION
Follows #272, same mechanism applied to the two catalog collections.

`/case/658b...` becomes `/case/lunatic-case`, `/marketplace/item/6469...` becomes `/marketplace/item/aya`. Minted on create, stored, indexed, never rewritten. Every id ever shared still resolves on the same route, and a page that loads by id swaps the address bar to the slug.

**Cases needed nothing special.** 64 of them, no two titles collide, none unslugabble. One trips the name filter and keeps its id, same rule as users.

**Items needed a real decision.** 22 names are held by two items each, and every pair is the same character appearing in two cases:

| | |
| --- | --- |
| `Saki` | Lunatic Case, Kivotos Case |
| `Junko` | Nuclear Case, Gehenna Case |
| `Yuuka` | Nuclear Case, Millennium Case |
| `Souvenir AWP \| Dragon Lore` | two Cobblestone souvenir packages |

So the case is the tiebreak, not a number: `saki` and `saki-kivotos-case`, because `saki-2` tells a player nothing about which Saki they are looking at.

**But only when it fits.** The CS:GO souvenir packages have titles long enough that qualifying blows past the 60-character cap and truncates mid-word — `souvenir-scar-20-storm-boston-2018-cobblestone-souvenir-pack` is not a name. When the qualifier does not fit, the number is the honest answer: `souvenir-scar-20-storm-2`. Both paths are tested.

**One payload change.** `GET /marketplace/item/:itemId` now returns `itemId` and `slug` alongside the listings. The page read its item out of the listings array, so an item with zero listings could not learn its own canonical URL, and the my-orders filter was comparing `String(o.item)` against whatever was in the path — which a slug would have silently broken.

`adminRoutes` had its own copy of `slugify`; it now uses the shared one, which also fixes a latent bug there where a >60-char title could end on a hyphen.

**Deploy.** Ship, then `node scripts/backfillCatalogSlug.js` (`--dry` first). Dry run against production: 63 of 64 cases and all 1,372 items get a slug; 22 items are qualified, 7 by case name and 15 by number.

**Tests.** 15 new (3 unit on the qualifier, 12 integration on case and item routing plus the sparse index). Backend 1078 passing, frontend 170, `tsc`, `eslint`, `build` clean.