### PR TITLE
feat(games): a session tracker for profit, wagered and the win/loss count

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const AppRoutes = lazy(() => import("./Routes"));
 const environment = import.meta.env.VITE_NODE_ENV || "";
 import { User } from './components/Types'
 import i18n from "./i18n";
+import { SessionStatsProvider } from "./stats/SessionStatsContext";
 
 interface userDataSocketProps {
   walletBalance: number;
@@ -217,6 +218,7 @@ function App() {
           toogleUserFlow
         }}
       >
+        <SessionStatsProvider>
         <Suspense fallback={<BootLoader />}>
             <Router>
               <SkeletonTheme highlightColor="#161427" baseColor="#1c1a31">
@@ -247,6 +249,7 @@ function App() {
               </SkeletonTheme>
             </Router>
         </Suspense>
+        </SessionStatsProvider>
 
       </UserContext.Provider>
     </div>

--- a/src/components/LiveStats/LiveStats.tsx
+++ b/src/components/LiveStats/LiveStats.tsx
@@ -1,0 +1,83 @@
+import { AiOutlineClose } from "react-icons/ai";
+import { MdOutlineShowChart, MdRefresh } from "react-icons/md";
+import Monetary from "../Monetary";
+import Sparkline from "./Sparkline";
+import { useDraggable } from "./useDraggable";
+import { useSessionStats } from "../../stats/SessionStatsContext";
+import { profitOf } from "../../stats/sessionStats";
+import i18n from "../../i18n";
+
+const Figure = ({ label, value }: { label: string; value: React.ReactNode }) => (
+    <div className="flex flex-col gap-0.5 min-w-0">
+        <span className="text-xs font-medium text-ink-muted">{label}</span>
+        <span className="text-base font-bold truncate">{value}</span>
+    </div>
+);
+
+// the panel is opened from the game bar and dragged by its header. closing only hides it:
+// the tally is reset by the button that says so, or by closing the tab.
+const LiveStats = () => {
+    const { stats, reset, open, setOpen, position, setPosition } = useSessionStats();
+    const { ref, point, handlers } = useDraggable(position, setPosition);
+    const profit = profitOf(stats);
+
+    if (!open) return null;
+
+    const profitTone = profit > 0 ? "text-green-400" : profit < 0 ? "text-red-400" : "text-ink";
+
+    return (
+        <div
+            ref={ref}
+            style={point ? { left: point.x, top: point.y } : { right: 16, bottom: 16 }}
+            className="fixed z-overlay w-[19rem] max-w-[calc(100vw-2rem)] select-none rounded-xl border border-line bg-surface-nav shadow-2xl"
+        >
+            <div
+                {...handlers}
+                className="flex cursor-move touch-none items-center gap-2 px-4 py-3"
+            >
+                <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-surface-raised text-secondary-light">
+                    <MdOutlineShowChart className="text-base" />
+                </span>
+                <span className="flex-1 text-sm font-bold">{i18n.t("liveStats.title")}</span>
+                <button
+                    onClick={reset}
+                    aria-label={i18n.t("liveStats.reset")}
+                    title={i18n.t("liveStats.reset")}
+                    className="rounded-lg border-0 bg-transparent p-1.5 text-lg text-ink-faint transition-colors hover:bg-surface hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary-light"
+                >
+                    <MdRefresh />
+                </button>
+                <button
+                    onClick={() => setOpen(false)}
+                    aria-label={i18n.t("liveStats.hide")}
+                    title={i18n.t("liveStats.hide")}
+                    className="rounded-lg border-0 bg-transparent p-1.5 text-base text-ink-faint transition-colors hover:bg-surface hover:text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary-light"
+                >
+                    <AiOutlineClose />
+                </button>
+            </div>
+
+            <div className="flex flex-col gap-3 px-3 pb-3">
+                <div className="grid grid-cols-2 gap-x-4 gap-y-3 rounded-lg bg-surface p-4">
+                    <Figure label={i18n.t("liveStats.profit")} value={<span className={profitTone}><Monetary value={profit} /></span>} />
+                    <Figure label={i18n.t("liveStats.wins")} value={<span className="text-green-400">{stats.wins}</span>} />
+                    <Figure label={i18n.t("liveStats.wagered")} value={<Monetary value={stats.wagered} />} />
+                    <Figure label={i18n.t("liveStats.losses")} value={<span className="text-red-400">{stats.losses}</span>} />
+                </div>
+
+                <div className="flex h-32 items-center justify-center rounded-lg bg-surface p-3">
+                    {stats.rounds === 0 ? (
+                        <div className="flex w-full flex-col items-center gap-3">
+                            <span className="h-px w-2/3 bg-line-strong" />
+                            <span className="px-2 text-center text-xs text-ink-muted">{i18n.t("liveStats.empty")}</span>
+                        </div>
+                    ) : (
+                        <Sparkline points={stats.points} />
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default LiveStats;

--- a/src/components/LiveStats/LiveStatsButton.tsx
+++ b/src/components/LiveStats/LiveStatsButton.tsx
@@ -1,0 +1,19 @@
+import { MdOutlineShowChart } from "react-icons/md";
+import { GameBarButton } from "../game/GameBar";
+import LiveStats from "./LiveStats";
+import { useSessionStats } from "../../stats/SessionStatsContext";
+import i18n from "../../i18n";
+
+const LiveStatsButton = () => {
+    const { open, setOpen } = useSessionStats();
+    return (
+        <>
+            <GameBarButton onClick={() => setOpen(!open)} label={i18n.t("liveStats.title")} active={open}>
+                <MdOutlineShowChart />
+            </GameBarButton>
+            <LiveStats />
+        </>
+    );
+};
+
+export default LiveStatsButton;

--- a/src/components/LiveStats/Sparkline.tsx
+++ b/src/components/LiveStats/Sparkline.tsx
@@ -1,0 +1,31 @@
+const WIDTH = 260;
+const HEIGHT = 96;
+
+// cumulative profit over the session, one point per round. the baseline is zero, so the
+// fill reads as ground gained or lost rather than as a range of values.
+const Sparkline = ({ points }: { points: number[] }) => {
+    if (points.length < 2) return null;
+
+    const high = Math.max(0, ...points);
+    const low = Math.min(0, ...points);
+    // a flat run at zero would divide by nothing
+    const span = high - low || 1;
+    const x = (i: number) => (i / (points.length - 1)) * WIDTH;
+    const y = (value: number) => HEIGHT - ((value - low) / span) * HEIGHT;
+    const zero = y(0);
+
+    const line = points.map((value, i) => `${i === 0 ? "M" : "L"}${x(i).toFixed(1)},${y(value).toFixed(1)}`).join(" ");
+    const area = `${line} L${WIDTH},${zero.toFixed(1)} L0,${zero.toFixed(1)} Z`;
+    const up = points[points.length - 1] >= 0;
+    const stroke = up ? "#4ade80" : "#f87171";
+
+    return (
+        <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="h-full w-full" preserveAspectRatio="none" aria-hidden="true">
+            <path d={area} fill={stroke} fillOpacity="0.15" />
+            <line x1="0" y1={zero} x2={WIDTH} y2={zero} stroke="#3A365A" strokeWidth="1" strokeDasharray="3 3" />
+            <path d={line} fill="none" stroke={stroke} strokeWidth="2" vectorEffect="non-scaling-stroke" />
+        </svg>
+    );
+};
+
+export default Sparkline;

--- a/src/components/LiveStats/useDraggable.ts
+++ b/src/components/LiveStats/useDraggable.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Point } from "../../stats/sessionStats";
+
+const MARGIN = 16;
+
+// keeps the panel on screen: a window that shrinks after the panel was dragged to the
+// far edge would otherwise strand it somewhere the player cannot reach
+const clamp = (point: Point, size: { w: number; h: number }): Point => ({
+    x: Math.min(Math.max(MARGIN, point.x), Math.max(MARGIN, window.innerWidth - size.w - MARGIN)),
+    y: Math.min(Math.max(MARGIN, point.y), Math.max(MARGIN, window.innerHeight - size.h - MARGIN)),
+});
+
+export const useDraggable = (stored: Point | null, commit: (point: Point) => void) => {
+    const ref = useRef<HTMLDivElement | null>(null);
+    const grab = useRef<Point | null>(null);
+    const [point, setPoint] = useState<Point | null>(stored);
+
+    // the resting place before the player has moved it: the bottom right corner
+    useEffect(() => {
+        if (point || !ref.current) return;
+        const { width, height } = ref.current.getBoundingClientRect();
+        setPoint({ x: window.innerWidth - width - MARGIN, y: window.innerHeight - height - MARGIN });
+    }, [point]);
+
+    useEffect(() => {
+        const onResize = () => {
+            const el = ref.current;
+            if (!el || !point) return;
+            const { width, height } = el.getBoundingClientRect();
+            setPoint((p) => (p ? clamp(p, { w: width, h: height }) : p));
+        };
+        window.addEventListener("resize", onResize);
+        return () => window.removeEventListener("resize", onResize);
+    }, [point]);
+
+    const onPointerDown = useCallback((event: React.PointerEvent) => {
+        const el = ref.current;
+        if (!el || event.button !== 0) return;
+        // the close and reset buttons live in the drag handle, and preventDefault below
+        // would swallow their click: a press on a control is never the start of a drag
+        if ((event.target as HTMLElement).closest("button")) return;
+        const rect = el.getBoundingClientRect();
+        grab.current = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+        (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+        event.preventDefault();
+    }, []);
+
+    const onPointerMove = useCallback((event: React.PointerEvent) => {
+        const el = ref.current;
+        const offset = grab.current;
+        if (!el || !offset) return;
+        const { width, height } = el.getBoundingClientRect();
+        setPoint(clamp({ x: event.clientX - offset.x, y: event.clientY - offset.y }, { w: width, h: height }));
+    }, []);
+
+    const onPointerUp = useCallback(
+        (event: React.PointerEvent) => {
+            if (!grab.current) return;
+            grab.current = null;
+            (event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId);
+            if (point) commit(point);
+        },
+        [point, commit]
+    );
+
+    return { ref, point, dragging: grab.current !== null, handlers: { onPointerDown, onPointerMove, onPointerUp } };
+};

--- a/src/components/game/GameBar.tsx
+++ b/src/components/game/GameBar.tsx
@@ -1,0 +1,32 @@
+// the strip along the bottom of the game container, the way stake puts its controls
+// under the canvas rather than floating them over the page. one home for the icons that
+// belong to the game itself; more can sit beside the first.
+const GameBar = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex items-center gap-1 border-t border-line px-3 py-2">{children}</div>
+);
+
+export const GameBarButton = ({
+  onClick,
+  label,
+  active = false,
+  children,
+}: {
+  onClick: () => void;
+  label: string;
+  active?: boolean;
+  children: React.ReactNode;
+}) => (
+  <button
+    onClick={onClick}
+    aria-label={label}
+    title={label}
+    aria-pressed={active}
+    className={`rounded-none border-0 bg-transparent p-2 text-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary-light ${
+      active ? "text-ink" : "text-ink-faint hover:text-ink-soft"
+    }`}
+  >
+    {children}
+  </button>
+);
+
+export default GameBar;

--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -5,22 +5,28 @@ interface GameLayoutProps {
   panel: React.ReactNode;
   children: React.ReactNode;
   footer?: React.ReactNode;
+  // the strip under the canvas. opt-in, so a game that migrates into this shell later
+  // does not silently inherit controls it cannot feed.
+  bar?: React.ReactNode;
 }
 
 // the shared shell every game page sits in: one container holding the controls and the board.
 // the board comes first on phones, so the game is on screen without scrolling past a tall
 // stack of controls to reach it.
-const GameLayout: React.FC<GameLayoutProps> = ({ title, panel, children, footer }) => (
+const GameLayout: React.FC<GameLayoutProps> = ({ title, panel, children, footer, bar }) => (
   <div className="w-full flex flex-col items-center gap-6 px-3 sm:px-4 pt-4 pb-10">
     {title && <Title title={title} compact />}
 
-    <div className="w-full max-w-[1200px] flex flex-col-reverse lg:flex-row bg-surface rounded-lg overflow-hidden border border-line">
-      <div className="w-full lg:w-[320px] shrink-0 flex flex-col gap-3 p-4 sm:p-5 border-t lg:border-t-0 lg:border-r border-line">
-        {panel}
+    <div className="w-full max-w-[1200px] flex flex-col bg-surface rounded-lg overflow-hidden border border-line">
+      <div className="flex flex-col-reverse lg:flex-row">
+        <div className="w-full lg:w-[320px] shrink-0 flex flex-col gap-3 p-4 sm:p-5 border-t lg:border-t-0 lg:border-r border-line">
+          {panel}
+        </div>
+        <div className="flex-1 min-w-0 flex items-center justify-center p-3 sm:p-6">
+          {children}
+        </div>
       </div>
-      <div className="flex-1 min-w-0 flex items-center justify-center p-3 sm:p-6">
-        {children}
-      </div>
+      {bar}
     </div>
 
     {footer}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "Was gerade alle öffnen.",
     "winnings": "Gewinne"
   },
+  "liveStats": {
+    "empty": "Spiele eine Runde und das füllt sich. Gilt nur für diesen Tab.",
+    "hide": "Ausblenden",
+    "losses": "Niederlagen",
+    "profit": "Gewinn",
+    "reset": "Zurücksetzen",
+    "title": "Live-Statistik",
+    "wagered": "Eingesetzt",
+    "wins": "Siege"
+  },
   "market": {
     "allRarities": "Alle Seltenheiten",
     "anythingAlreadyListedAt": "Alles, was schon zu deinem Gebot oder darunter angeboten wird, wird sofort gekauft (ausgegeben, nicht erstattbar). Nur der offene Rest wird als Sicherheit gehalten und bei Stornierung erstattet.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "What everyone is opening right now.",
     "winnings": "Winnings"
   },
+  "liveStats": {
+    "empty": "Play a round and it fills in. Kept for this tab only.",
+    "hide": "Hide",
+    "losses": "Losses",
+    "profit": "Profit",
+    "reset": "Reset",
+    "title": "Live stats",
+    "wagered": "Wagered",
+    "wins": "Wins"
+  },
   "market": {
     "allRarities": "All rarities",
     "anythingAlreadyListedAt": "Anything already listed at or below your bid is bought immediately (spent, not refundable). Only the unfilled rest is held as escrow and refunded if you cancel.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "Lo que todo el mundo está abriendo ahora.",
     "winnings": "Ganancias"
   },
+  "liveStats": {
+    "empty": "Juega una ronda y esto se llena. Solo se guarda en esta pestaña.",
+    "hide": "Ocultar",
+    "losses": "Derrotas",
+    "profit": "Beneficio",
+    "reset": "Reiniciar",
+    "title": "Estadísticas en vivo",
+    "wagered": "Apostado",
+    "wins": "Victorias"
+  },
   "market": {
     "allRarities": "Todas las rarezas",
     "anythingAlreadyListedAt": "Todo lo que ya esté a la venta por tu puja o menos se compra al instante (gastado, sin reembolso). Solo el resto sin cubrir queda retenido y se devuelve si cancelas.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "Ce que tout le monde ouvre en ce moment.",
     "winnings": "Gains"
   },
+  "liveStats": {
+    "empty": "Jouez une manche et ceci se remplit. Conservé pour cet onglet uniquement.",
+    "hide": "Masquer",
+    "losses": "Défaites",
+    "profit": "Bénéfice",
+    "reset": "Réinitialiser",
+    "title": "Stats en direct",
+    "wagered": "Misé",
+    "wins": "Victoires"
+  },
   "market": {
     "allRarities": "Toutes les raretés",
     "anythingAlreadyListedAt": "Tout ce qui est déjà en vente à votre prix ou en dessous est acheté immédiatement (dépensé, non remboursable). Seul le reste non servi est conservé en garantie et remboursé si vous annulez.",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "Apa yang sedang dibuka oleh semua orang saat ini.",
     "winnings": "Kemenangan"
   },
+  "liveStats": {
+    "empty": "Mainkan satu ronde dan ini akan terisi. Hanya disimpan di tab ini.",
+    "hide": "Sembunyikan",
+    "losses": "Kalah",
+    "profit": "Untung",
+    "reset": "Atur ulang",
+    "title": "Statistik langsung",
+    "wagered": "Dipertaruhkan",
+    "wins": "Menang"
+  },
   "market": {
     "allRarities": "Semua kelangkaan",
     "anythingAlreadyListedAt": "Apa pun yang sudah terdaftar dengan harga yang sama atau lebih rendah dari penawaran Anda akan langsung dibeli (dibelanjakan, tidak dapat dikembalikan). Hanya sisa yang belum terpenuhi yang akan ditahan sebagai dana jaminan dan dikembalikan jika Anda membatalkan pesanan.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "Cosa stanno aprendo tutti in questo momento.",
     "winnings": "Vincite"
   },
+  "liveStats": {
+    "empty": "Gioca un round e si riempie. Conservato solo in questa scheda.",
+    "hide": "Nascondi",
+    "losses": "Sconfitte",
+    "profit": "Profitto",
+    "reset": "Azzera",
+    "title": "Statistiche live",
+    "wagered": "Puntato",
+    "wins": "Vittorie"
+  },
   "market": {
     "allRarities": "Tutte le rarità",
     "anythingAlreadyListedAt": "Tutto ciò che è già in vendita al tuo prezzo o meno viene comprato subito (speso, non rimborsabile). Solo la parte non coperta resta a garanzia e viene rimborsata se annulli.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "いまみんなが開けているもの。",
     "winnings": "獲得額"
   },
+  "liveStats": {
+    "empty": "1回プレイすると表示されます。このタブでのみ保持されます。",
+    "hide": "隠す",
+    "losses": "負け",
+    "profit": "損益",
+    "reset": "リセット",
+    "title": "ライブ統計",
+    "wagered": "賭け金",
+    "wins": "勝ち"
+  },
   "market": {
     "allRarities": "すべてのレアリティ",
     "anythingAlreadyListedAt": "あなたの提示額以下ですでに出品されている分はその場で購入されます（支払い済みで返金されません）。約定しなかった残りだけが担保として預かられ、キャンセル時に返金されます。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "지금 다들 열고 있는 것.",
     "winnings": "획득액"
   },
+  "liveStats": {
+    "empty": "한 판 플레이하면 채워집니다. 이 탭에서만 유지됩니다.",
+    "hide": "숨기기",
+    "losses": "패",
+    "profit": "수익",
+    "reset": "초기화",
+    "title": "실시간 통계",
+    "wagered": "베팅액",
+    "wins": "승"
+  },
   "market": {
     "allRarities": "모든 등급",
     "anythingAlreadyListedAt": "입찰가 이하로 이미 올라와 있는 물량은 즉시 구매됩니다(지출되며 환불되지 않습니다). 체결되지 않은 나머지만 보증금으로 잡혀 있다가 취소 시 환불됩니다.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "O que todo mundo está abrindo agora.",
     "winnings": "Ganhos"
   },
+  "liveStats": {
+    "empty": "Jogue uma rodada e isto se preenche. Guardado só nesta aba.",
+    "hide": "Esconder",
+    "losses": "Derrotas",
+    "profit": "Lucro",
+    "reset": "Zerar",
+    "title": "Estatísticas ao vivo",
+    "wagered": "Apostado",
+    "wins": "Vitórias"
+  },
   "market": {
     "allRarities": "Todas as raridades",
     "anythingAlreadyListedAt": "Tudo o que já estiver anunciado por até o seu lance é comprado na hora (gasto, sem reembolso). Só o restante não preenchido fica como garantia e é devolvido se você cancelar.",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "Mọi người đang mở gì lúc này.",
     "winnings": "Tiền thắng"
   },
+  "liveStats": {
+    "empty": "Chơi một ván và bảng này sẽ hiện. Chỉ lưu trong tab này.",
+    "hide": "Ẩn",
+    "losses": "Thua",
+    "profit": "Lợi nhuận",
+    "reset": "Đặt lại",
+    "title": "Thống kê trực tiếp",
+    "wagered": "Đã cược",
+    "wins": "Thắng"
+  },
   "market": {
     "allRarities": "Mọi độ hiếm",
     "anythingAlreadyListedAt": "Phần nào đang rao bán bằng hoặc thấp hơn giá bạn đặt sẽ được mua ngay (đã chi, không hoàn lại). Chỉ phần chưa khớp mới được giữ làm ký quỹ và hoàn lại nếu bạn huỷ.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -626,6 +626,16 @@
     "whatEveryoneIsOpening": "看看大家现在都在开什么。",
     "winnings": "奖金"
   },
+  "liveStats": {
+    "empty": "玩一局后就会显示。仅在本标签页中保留。",
+    "hide": "隐藏",
+    "losses": "负",
+    "profit": "盈亏",
+    "reset": "重置",
+    "title": "实时统计",
+    "wagered": "投注额",
+    "wins": "胜"
+  },
   "market": {
     "allRarities": "全部稀有度",
     "anythingAlreadyListedAt": "凡是已挂单且价格不高于你出价的部分会立即成交（已花费，不可退还）。只有未成交的剩余部分会作为保证金冻结，取消时全额退还。",

--- a/src/pages/Blackjack/Blackjack.services.ts
+++ b/src/pages/Blackjack/Blackjack.services.ts
@@ -13,6 +13,7 @@ import {
 } from "../../services/games/GamesServices";
 import { BlackjackHandState, BlackjackHistoryEntry, BlackjackPhase } from "./Blackjack.types";
 import i18n from "../../i18n";
+import { useSessionStats } from "../../stats/SessionStatsContext";
 
 const DEFAULT_BET = 10;
 export const MIN_BET = 1;
@@ -25,6 +26,8 @@ const RESULT_MS = 500;
 
 export const useBlackjackServices = () => {
   const { userData, toogleUserFlow } = useContext(UserContext);
+  const { track } = useSessionStats();
+  const trackedHand = useRef<string | null>(null);
   const navigate = useNavigate();
 
   const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
@@ -48,6 +51,15 @@ export const useBlackjackServices = () => {
   };
 
   const pushHistory = (settled: BlackjackHandState) => {
+    // refresh() replays a settled hand on mount and on the 409 resync, so the hand id is
+    // what decides whether this one has already been counted
+    if (trackedHand.current !== settled.handId) {
+      trackedHand.current = settled.handId;
+      // doubling doubles the hand's own bet and a split makes two of them, so the stake
+      // is the sum of the hands plus whatever insurance cost
+      const staked = settled.hands.reduce((sum, h) => sum + (h.bet || 0), 0) + (settled.insuranceBet || 0);
+      track({ game: "blackjack", wagered: staked, payout: settled.totalPayout || 0 });
+    }
     setHistory((h) =>
       [
         {

--- a/src/pages/Blackjack/Blackjack.view.tsx
+++ b/src/pages/Blackjack/Blackjack.view.tsx
@@ -8,6 +8,8 @@ import PlayingCard from "./PlayingCard";
 import { outcomeLabel, totalLabel } from "./blackjackCards";
 import { BlackjackViewProps } from "./Blackjack.types";
 import i18n from "../../i18n";
+import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
+import GameBar from "../../components/game/GameBar";
 
 const OUTCOME_TEXT: Record<string, string> = {
   blackjack: "text-[#FFCC00]",
@@ -175,6 +177,11 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
 
   return (
     <GameLayout
+      bar={
+        <GameBar>
+          <LiveStatsButton />
+        </GameBar>
+      }
       title={i18n.t("blackjack.blackjack")}
       footer={
         <button

--- a/src/pages/Dice/Dice.services.ts
+++ b/src/pages/Dice/Dice.services.ts
@@ -15,6 +15,7 @@ import {
 } from "./diceControls";
 import { DiceHistoryEntry, DiceRollResult } from "./Dice.types";
 import i18n from "../../i18n";
+import { useSessionStats } from "../../stats/SessionStatsContext";
 
 const DEFAULT_BET = 10;
 const DEFAULT_TARGET = 5050; // over 50.50 -> 2.0000x, the classic starting point
@@ -24,6 +25,7 @@ export const AUTO_COUNTS = [10, 25, 50, 100];
 
 export const useDiceServices = () => {
   const { userData, toogleUserFlow } = useContext(UserContext);
+  const { track } = useSessionStats();
   const navigate = useNavigate();
 
   const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
@@ -101,6 +103,7 @@ export const useDiceServices = () => {
     setRolling(true);
     try {
       const result: DiceRollResult = await rollDice(betValue, target, direction);
+      track({ game: "dice", wagered: betValue, payout: result.payout || 0 });
       rollSeq.current += 1;
       setLast(result);
       setHistory((h) =>

--- a/src/pages/Dice/Dice.view.tsx
+++ b/src/pages/Dice/Dice.view.tsx
@@ -7,6 +7,8 @@ import Monetary from "../../components/Monetary";
 import { AUTO_COUNTS } from "./Dice.services";
 import { DiceViewProps } from "./Dice.types";
 import i18n from "../../i18n";
+import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
+import GameBar from "../../components/game/GameBar";
 
 const TICKS = [0, 25, 50, 75, 100];
 const GREEN = "#22C55E";
@@ -54,6 +56,11 @@ const DiceView: React.FC<DiceViewProps> = ({
 
   return (
     <GameLayout
+      bar={
+        <GameBar>
+          <LiveStatsButton />
+        </GameBar>
+      }
       title={i18n.t("dice.dice")}
       footer={
         <p className="text-ink-muted text-xs max-w-[640px] text-center">

--- a/src/pages/Hilo/Hilo.services.ts
+++ b/src/pages/Hilo/Hilo.services.ts
@@ -12,12 +12,14 @@ import {
 import { MAX_BET, MIN_BET } from "./hiloCards";
 import { HiloGameState } from "./Hilo.types";
 import i18n from "../../i18n";
+import { useSessionStats } from "../../stats/SessionStatsContext";
 
 const DEFAULT_BET = 10;
 const HISTORY_SIZE = 10;
 
 export const useHiloServices = () => {
   const { userData, toogleUserFlow } = useContext(UserContext);
+  const { track } = useSessionStats();
   const navigate = useNavigate();
 
   const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
@@ -45,6 +47,7 @@ export const useHiloServices = () => {
   }, [userData]);
 
   const recordEnd = (g: HiloGameState) => {
+    track({ game: "hilo", wagered: g.betAmount, payout: g.payout || 0 });
     seq.current += 1;
     setHistory((h) =>
       [{ key: `h${seq.current}`, won: g.status === "cashed", multiplier: g.multiplier, payout: g.payout, rollId: g.rollId }, ...h].slice(0, HISTORY_SIZE)

--- a/src/pages/Hilo/Hilo.view.tsx
+++ b/src/pages/Hilo/Hilo.view.tsx
@@ -8,6 +8,8 @@ import { isRedSuit, rankLabel, suitOf } from "../Blackjack/blackjackCards";
 import { pct } from "./hiloCards";
 import { HiloViewProps } from "./Hilo.types";
 import i18n from "../../i18n";
+import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
+import GameBar from "../../components/game/GameBar";
 
 const CardChip = ({ card, label }: { card: number; label?: string }) => (
   <div className="flex flex-col items-center gap-1 shrink-0">
@@ -43,6 +45,11 @@ const HiloView: React.FC<HiloViewProps> = ({
 
   return (
     <GameLayout
+      bar={
+        <GameBar>
+          <LiveStatsButton />
+        </GameBar>
+      }
       title={i18n.t("hilo.hilo")}
       footer={
         <p className="text-ink-muted text-xs max-w-[640px] text-center">

--- a/src/pages/Mines/Mines.services.ts
+++ b/src/pages/Mines/Mines.services.ts
@@ -11,6 +11,7 @@ import {
 import { MAX_BET, MIN_BET, MIN_MINES, TILES, gemsFor, payoutFor } from "./minesGrid";
 import { MinesGameState } from "./Mines.types";
 import i18n from "../../i18n";
+import { useSessionStats } from "../../stats/SessionStatsContext";
 
 const DEFAULT_BET = 10;
 const DEFAULT_MINES = 3;
@@ -22,6 +23,7 @@ const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export const useMinesServices = () => {
   const { userData, toogleUserFlow } = useContext(UserContext);
+  const { track } = useSessionStats();
   const navigate = useNavigate();
 
   const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
@@ -60,6 +62,7 @@ export const useMinesServices = () => {
   }, [userData]);
 
   const recordEnd = (g: MinesGameState) => {
+    track({ game: "mines", wagered: g.betAmount, payout: g.payout || 0 });
     seq.current += 1;
     setHistory((h) =>
       [{ key: `m${seq.current}`, won: g.status === "cashed", multiplier: g.multiplier, payout: g.payout, rollId: g.rollId }, ...h].slice(0, HISTORY_SIZE)

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -8,6 +8,8 @@ import { AUTO_COUNTS } from "./Mines.services";
 import { TILES, mineOptions } from "./minesGrid";
 import { MinesViewProps } from "./Mines.types";
 import i18n from "../../i18n";
+import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
+import GameBar from "../../components/game/GameBar";
 
 const Diamond = () => (
   <svg viewBox="0 0 24 24" className="w-3/5 h-3/5 drop-shadow">
@@ -82,6 +84,11 @@ const MinesView: React.FC<MinesViewProps> = ({
 
   return (
     <GameLayout
+      bar={
+        <GameBar>
+          <LiveStatsButton />
+        </GameBar>
+      }
       title={i18n.t("mines.mines")}
       footer={
         <p className="text-ink-muted text-xs max-w-[640px] text-center">

--- a/src/pages/Plinko/Plinko.services.ts
+++ b/src/pages/Plinko/Plinko.services.ts
@@ -7,6 +7,7 @@ import { DROP_DURATION_S, MAX_BET, PlinkoRisk } from "./plinkoBoard";
 import { DropOutcome, autoStep, outcomeFor } from "./autoRun";
 import { PlinkoBall, PlinkoDropResult } from "./Plinko.types";
 import i18n from "../../i18n";
+import { useSessionStats } from "../../stats/SessionStatsContext";
 
 const DEFAULT_BET = 10;
 const HISTORY_SIZE = 8;
@@ -18,6 +19,7 @@ export const AUTO_COUNTS = [10, 25, 50, 100];
 
 export const usePlinkoServices = () => {
   const { userData, toogleUserFlow } = useContext(UserContext);
+  const { track } = useSessionStats();
   const navigate = useNavigate();
 
   const [betInput, setBetInput] = useState<string>(String(DEFAULT_BET));
@@ -153,11 +155,14 @@ export const usePlinkoServices = () => {
   const settleBall = useCallback((ball: PlinkoBall) => {
     if (settled.current.has(ball.key)) return;
     settled.current.add(ball.key);
+    // the server answered while the ball was still falling; the tally waits for the bin,
+    // otherwise the panel spoils the drop the player is watching
+    track({ game: "plinko", wagered: ball.betAmount, payout: ball.payout || 0 });
     hitSeq.current += 1;
     setBalls((prev) => prev.filter((b) => b.key !== ball.key));
     setLastHit({ bin: ball.bin, seq: hitSeq.current });
     setHistory((h) => [ball, ...h].slice(0, HISTORY_SIZE));
-  }, []);
+  }, [track]);
 
   const canChangeRisk = balls.length === 0 && pendingDrops === 0 && !autoRunning;
   const changeRisk = (next: PlinkoRisk) => {

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -31,6 +31,8 @@ import {
 import { AUTO_COUNTS } from "./Plinko.services";
 import { PlinkoBall, PlinkoViewProps } from "./Plinko.types";
 import i18n from "../../i18n";
+import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
+import GameBar from "../../components/game/GameBar";
 
 const PEG_ROWS = pegRows();
 
@@ -125,6 +127,11 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
   openRoll,
 }) => (
   <GameLayout
+      bar={
+        <GameBar>
+          <LiveStatsButton />
+        </GameBar>
+      }
     title={i18n.t("nav.plinko")}
     panel={
       <>

--- a/src/pages/Slot/Slot.tsx
+++ b/src/pages/Slot/Slot.tsx
@@ -9,6 +9,9 @@ import bigwin from "/bigwin.mp3"
 import ValueViewer from './ValueViewer';
 import UserContext from '../../UserContext';
 import i18n from "../../i18n";
+import { useSessionStats } from "../../stats/SessionStatsContext";
+import GameBar from "../../components/game/GameBar";
+import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
 // import { RotatingLines } from "react-loader-spinner";
 
 const renderPlaceholder = () => {
@@ -28,6 +31,7 @@ const Slots = () => {
     const [loadedImages, setLoadedImages] = useState<number>(0);
     const audioRef = useRef<HTMLAudioElement | null>(null);
     const { userData, toogleUserFlow } = useContext(UserContext);
+    const { track } = useSessionStats();
 
     const startAudio = () => {
         setTimeout(() => {
@@ -101,6 +105,8 @@ const Slots = () => {
 
             setTimeout(() => {
                 setIsSpinning(false);
+                // only once the reels have stopped, or the panel reads out the spin early
+                track({ game: "slots", wagered: betAmount, payout: response.totalPayout || 0 });
             }, 3000);
         } catch (e: any) {
             console.error(e.response?.data.message || "Error spinning slots");
@@ -191,6 +197,9 @@ const Slots = () => {
                     </div>
                 </div>
 
+                <GameBar>
+                    <LiveStatsButton />
+                </GameBar>
             </div >
         </div>
 

--- a/src/stats/SessionStatsContext.test.tsx
+++ b/src/stats/SessionStatsContext.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { SessionStatsProvider, useSessionStats } from "./SessionStatsContext";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SessionStatsProvider>{children}</SessionStatsProvider>
+);
+
+const render = () => renderHook(() => useSessionStats(), { wrapper });
+
+describe("the live stats session", () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it("starts empty and closed", () => {
+    const { result } = render();
+    expect(result.current.stats.rounds).toBe(0);
+    expect(result.current.open).toBe(false);
+  });
+
+  // the promise made to the player: hiding the panel is not a reset
+  it("keeps the tally when the panel is closed", () => {
+    const { result } = render();
+    act(() => result.current.track({ game: "dice", wagered: 100, payout: 250 }));
+    act(() => result.current.setOpen(true));
+    act(() => result.current.setOpen(false));
+    expect(result.current.stats.rounds).toBe(1);
+    expect(result.current.stats.wagered).toBe(100);
+  });
+
+  it("clears only when reset is asked for", () => {
+    const { result } = render();
+    act(() => result.current.track({ game: "dice", wagered: 100, payout: 0 }));
+    expect(result.current.stats.rounds).toBe(1);
+    act(() => result.current.reset());
+    expect(result.current.stats.rounds).toBe(0);
+    expect(result.current.stats.wagered).toBe(0);
+    expect(result.current.stats.points).toEqual([]);
+  });
+
+  // a reload inside the same tab keeps the run; the tab closing is what ends it
+  it("survives a remount, because the tab is the session", () => {
+    const first = render();
+    act(() => first.result.current.track({ game: "mines", wagered: 40, payout: 90 }));
+    first.unmount();
+
+    const second = render();
+    expect(second.result.current.stats.rounds).toBe(1);
+    expect(second.result.current.stats.payout).toBe(90);
+  });
+
+  it("remembers where the panel was dragged to", () => {
+    const first = render();
+    act(() => first.result.current.setPosition({ x: 320, y: 180 }));
+    first.unmount();
+
+    const second = render();
+    expect(second.result.current.position).toEqual({ x: 320, y: 180 });
+  });
+});

--- a/src/stats/SessionStatsContext.tsx
+++ b/src/stats/SessionStatsContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { EMPTY, applyRound, clear, load, loadPosition, save, savePosition } from "./sessionStats";
+import type { Point, Round, SessionStats } from "./sessionStats";
+
+interface Value {
+    stats: SessionStats;
+    track: (round: Round) => void;
+    reset: () => void;
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    position: Point | null;
+    setPosition: (point: Point) => void;
+}
+
+const SessionStatsContext = createContext<Value>({
+    stats: EMPTY,
+    track: () => undefined,
+    reset: () => undefined,
+    open: false,
+    setOpen: () => undefined,
+    position: null,
+    setPosition: () => undefined,
+});
+
+const OPEN_KEY = "kani.liveStatsOpen";
+
+export const SessionStatsProvider = ({ children }: { children: ReactNode }) => {
+    const [stats, setStats] = useState<SessionStats>(() => load());
+    const [open, setOpenState] = useState<boolean>(() => {
+        try {
+            return sessionStorage.getItem(OPEN_KEY) === "1";
+        } catch {
+            return false;
+        }
+    });
+
+    const track = useCallback((round: Round) => {
+        setStats((prev) => {
+            const next = applyRound(prev, round);
+            save(next);
+            return next;
+        });
+    }, []);
+
+    const reset = useCallback(() => {
+        clear();
+        setStats(EMPTY);
+    }, []);
+
+    const [position, setPositionState] = useState<Point | null>(() => loadPosition());
+
+    const setPosition = useCallback((point: Point) => {
+        setPositionState(point);
+        savePosition(point);
+    }, []);
+
+    const setOpen = useCallback((next: boolean) => {
+        setOpenState(next);
+        try {
+            sessionStorage.setItem(OPEN_KEY, next ? "1" : "0");
+        } catch {
+            // the panel just will not remember, which is survivable
+        }
+    }, []);
+
+    const value = useMemo(
+        () => ({ stats, track, reset, open, setOpen, position, setPosition }),
+        [stats, track, reset, open, setOpen, position, setPosition]
+    );
+
+    return <SessionStatsContext.Provider value={value}>{children}</SessionStatsContext.Provider>;
+};
+
+export const useSessionStats = () => useContext(SessionStatsContext);

--- a/src/stats/sessionStats.test.ts
+++ b/src/stats/sessionStats.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { EMPTY, MAX_POINTS, applyRound, profitOf } from "./sessionStats";
+
+const play = (rounds: Array<[number, number]>) =>
+  rounds.reduce((s, [wagered, payout]) => applyRound(s, { game: "dice", wagered, payout }), EMPTY);
+
+describe("the session tally", () => {
+  it("starts empty", () => {
+    expect(EMPTY.rounds).toBe(0);
+    expect(profitOf(EMPTY)).toBe(0);
+  });
+
+  it("nets profit against what was staked, not against the payout alone", () => {
+    const s = play([[100, 0], [100, 250]]);
+    expect(s.wagered).toBe(200);
+    expect(s.payout).toBe(250);
+    expect(profitOf(s)).toBe(50);
+  });
+
+  it("counts a win only when the round returned more than it took", () => {
+    const s = play([[100, 200], [100, 0], [100, 100]]);
+    expect(s.wins).toBe(1);
+    expect(s.losses).toBe(1);
+    // the push is a round, and it is neither a win nor a loss
+    expect(s.rounds).toBe(3);
+  });
+
+  it("plots cumulative profit, so the line is the running total", () => {
+    const s = play([[100, 0], [100, 300], [100, 0]]);
+    expect(s.points).toEqual([-100, 100, 0]);
+  });
+
+  it("keeps the totals exact while the graph is only a window", () => {
+    const many: Array<[number, number]> = Array.from({ length: MAX_POINTS + 250 }, () => [10, 0]);
+    const s = play(many);
+    expect(s.rounds).toBe(MAX_POINTS + 250);
+    expect(s.wagered).toBe((MAX_POINTS + 250) * 10);
+    expect(profitOf(s)).toBe(-(MAX_POINTS + 250) * 10);
+    expect(s.points).toHaveLength(MAX_POINTS);
+    // the window ends on the newest round, not the oldest
+    expect(s.points[s.points.length - 1]).toBe(-(MAX_POINTS + 250) * 10);
+  });
+
+  it("never mutates the tally it was handed", () => {
+    const first = play([[100, 0]]);
+    const second = applyRound(first, { game: "dice", wagered: 50, payout: 90 });
+    expect(first.rounds).toBe(1);
+    expect(first.points).toEqual([-100]);
+    expect(second.rounds).toBe(2);
+  });
+});

--- a/src/stats/sessionStats.ts
+++ b/src/stats/sessionStats.ts
@@ -1,0 +1,99 @@
+// the running tally behind the live stats panel. it lives in the tab and nowhere else:
+// no request, no row, no server state. closing the tab ends the session.
+
+// one point per round, and a long session is thousands of them, so the series is a
+// window. the totals stay exact; only what the graph draws is trimmed.
+export const MAX_POINTS = 500;
+
+export interface Round {
+    game: string;
+    wagered: number;
+    payout: number;
+}
+
+export interface SessionStats {
+    rounds: number;
+    wins: number;
+    losses: number;
+    wagered: number;
+    payout: number;
+    // cumulative profit after each of the last MAX_POINTS rounds
+    points: number[];
+}
+
+export const EMPTY: SessionStats = { rounds: 0, wins: 0, losses: 0, wagered: 0, payout: 0, points: [] };
+
+export const profitOf = (stats: SessionStats) => stats.payout - stats.wagered;
+
+// a push returns the stake and counts as neither, which is why wins and losses do not
+// have to add up to rounds
+export const applyRound = (stats: SessionStats, round: Round): SessionStats => {
+    const wagered = stats.wagered + round.wagered;
+    const payout = stats.payout + round.payout;
+    const points = [...stats.points, payout - wagered];
+    return {
+        rounds: stats.rounds + 1,
+        wins: stats.wins + (round.payout > round.wagered ? 1 : 0),
+        losses: stats.losses + (round.payout < round.wagered ? 1 : 0),
+        wagered,
+        payout,
+        points: points.length > MAX_POINTS ? points.slice(points.length - MAX_POINTS) : points,
+    };
+};
+
+const KEY = "kani.liveStats";
+
+// sessionStorage is per tab and dies with it, which is exactly the lifetime wanted. it
+// throws outright in some privacy modes, so every touch is guarded.
+export const load = (): SessionStats => {
+    try {
+        const raw = sessionStorage.getItem(KEY);
+        if (!raw) return EMPTY;
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed.rounds !== "number" || !Array.isArray(parsed.points)) return EMPTY;
+        return { ...EMPTY, ...parsed };
+    } catch {
+        return EMPTY;
+    }
+};
+
+export const save = (stats: SessionStats) => {
+    try {
+        sessionStorage.setItem(KEY, JSON.stringify(stats));
+    } catch {
+        // a full or blocked store must never break a game
+    }
+};
+
+export const clear = () => {
+    try {
+        sessionStorage.removeItem(KEY);
+    } catch {
+        // nothing to do
+    }
+};
+
+// where the player dragged the panel to. remembered for the tab so it does not jump back
+// to the corner every time they walk to another game.
+const POS_KEY = "kani.liveStatsPos";
+
+export interface Point { x: number; y: number; }
+
+export const loadPosition = (): Point | null => {
+    try {
+        const raw = sessionStorage.getItem(POS_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return typeof parsed?.x === "number" && typeof parsed?.y === "number" ? parsed : null;
+    } catch {
+        return null;
+    }
+};
+
+export const savePosition = (point: Point) => {
+    try {
+        sessionStorage.setItem(POS_KEY, JSON.stringify(point));
+    } catch {
+        // the panel just will not remember where it was
+    }
+};


### PR DESCRIPTION
A live stats panel, opened from the bar under the game canvas. It tracks every round the player plays as one combined total across the six instant-settle games.

**Nothing touches the server.** No endpoint, no row, no query. The tally lives in `sessionStorage`, so it survives a reload and a walk from Dice to Plinko, and ends when the tab closes.

## It counts when the player sees the result, not when the server answers

Three games reply well before anything is on screen, and counting on the response spoiled the outcome the player was still watching:

| Game | Counted at |
|---|---|
| Plinko | the ball reaching its bin (`settleBall`) |
| Slots | the reels stopping, 3s later |
| Blackjack | the dealer reveal finishing (`pushHistory`) |

Measured on plinko: flight time is `DROP_DURATION_S = 3.1`, and the tally now updates at 3196ms. Dice, Mines and Hilo have no reveal delay — checked, not assumed; Mines' only `setTimeout` is auto-play pacing.

Blackjack additionally dedupes on `handId`, because `refresh()` replays a settled hand through the same path on mount and on the 409 resync.

## Details worth a look

- **Blackjack wagered** is the sum of the hands plus insurance. Doubling doubles a hand's own bet and a split makes two of them, so `betAmount` alone understates the stake.
- **A push is a round but neither a win nor a loss**, which is why wins + losses do not equal rounds.
- **The graph keeps a 500-point window** while the totals stay exact, so a long session cannot grow the array or the SVG path without bound. Inline SVG, no charting dependency.
- **Closing the panel never resets.** Clearing is the reset button, or closing the tab. Pinned by a test.
- **The panel is dragged by its header** and remembers where it was left. `useDraggable` ignores a pointerdown that lands on a control, so the close and reset buttons keep their click — without that, `preventDefault` on the drag handle swallowed them and neither button worked.

## Crash and Coin Flip are out, and carry no button

A bet there is settled by a socket event the page may never see, so a refresh mid-round would lose it and the count would be wrong. `GameLayout`'s new `bar` slot is opt-in for the same reason: if either game migrates into that shell later, it cannot silently inherit a control it does not feed.

## Tests

11 new: the reducer (netting, win/loss/push, the cumulative series, the window, immutability) and the context (closing keeps the tally, reset clears it, a remount keeps it, the position is remembered). 181 frontend tests pass; `tsc`, `eslint` and `npm run build` clean.

Behaviour was also driven in a real browser against a local dev server: three rolls counted, drag moved and persisted, close kept the tally, reopen restored the position, reset cleared it.