### PR TITLE
fix(ci): let the release job stand aside when the release is already there

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ name: Release
 #
 #   npm version minor -m "release: %s"   # bumps package.json and makes the v tag
 #   git push --follow-tags
+#
+# notes can also be written by hand: publish the release first, then push the tag, and
+# this step stands aside rather than failing on a release that already exists.
 on:
   push:
     tags:
@@ -26,6 +29,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # hand-written notes beat --generate-notes, so a release that is already there
+          # is left alone: the tag push must not fail just because it got there first
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "release $GITHUB_REF_NAME already exists, leaving it alone"
+            exit 0
+          fi
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \


### PR DESCRIPTION
The Release workflow fires on a `v*` tag and creates the release with `--generate-notes`. That is the right default, but it means a release published by hand before the tag is pushed makes the job fail:

```
HTTP 422: Validation Failed
Release.tag_name already exists
```

That is what happened for v1.1.0. The release itself is correct and carries hand-written notes; only the workflow run went red.

It now checks whether the release exists and exits cleanly if so, so both orders work: tag-only gets generated notes, and a hand-written release is left alone.