### PR TITLE
fix(upgrade): keep the target selected after a won upgrade

### DIFF
--- a/src/pages/Upgrade/TopContent.tsx
+++ b/src/pages/Upgrade/TopContent.tsx
@@ -11,7 +11,6 @@ import i18n from "../../i18n";
 interface Props {
     selectedItems: any[];
     setSelectedItems: React.Dispatch<React.SetStateAction<any[]>>;
-    setSelectedCase: React.Dispatch<React.SetStateAction<string | null>>;
     selectedTarget: any;
     setSelectedTarget: React.Dispatch<React.SetStateAction<any>>;
     successRate: number;
@@ -23,7 +22,7 @@ interface Props {
     setSpinning: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const TopContent: React.FC<Props> = ({ selectedItems, setSelectedItems, selectedTarget, setSelectedTarget, successRate, finished, setFinished, setToggleReload, toggleReload, setSelectedCase, spinning, setSpinning }) => {
+const TopContent: React.FC<Props> = ({ selectedItems, setSelectedItems, selectedTarget, setSelectedTarget, successRate, finished, setFinished, setToggleReload, toggleReload, spinning, setSpinning }) => {
     const [loadingUpgrade, setLoadingUpgrade] = useState<boolean>(false);
     const [stopAngle, setStopAngle] = useState(0);
     const [success, setSuccess] = useState(false);
@@ -63,11 +62,9 @@ const TopContent: React.FC<Props> = ({ selectedItems, setSelectedItems, selected
                 setSuccess(response.success)
                 setFinished(true);
                 setStopAngle(0);
-
-                if (response.success) {
-                    setSelectedCase(null);
-                    setSelectedTarget(null);
-                }
+                // the staked copies are gone, so they clear; the target does not. a player
+                // chasing a second copy of the same character would otherwise have to pick
+                // the case and the item again after every single attempt.
             }, 8000);
 
         } catch (err: any) {

--- a/src/pages/Upgrade/Upgrade.tsx
+++ b/src/pages/Upgrade/Upgrade.tsx
@@ -43,7 +43,7 @@ const Upgrade: React.FC = () => {
 
                 <TopContent selectedItems={selectedItems} setSelectedItems={setSelectedItems} selectedTarget={selectedTarget}
                     setSelectedTarget={setSelectedTarget} successRate={successRate} finished={finished} setFinished={setFinished}
-                    toggleReload={toggleReload} setToggleReload={setToggleReload} setSelectedCase={setSelectedCase}
+                    toggleReload={toggleReload} setToggleReload={setToggleReload}
                     spinning={spinning} setSpinning={setSpinning} />
                 <div className="flex justify-center">
                     <Title title={i18n.t("help.upgradeItems")} />


### PR DESCRIPTION
Player request:

> seria legal se no upgrade não tirasse a personagem selecionada quando você obtivesse ela, seria mais conveniente pra pegar múltiplas cópias

Winning an upgrade cleared both the target and the case, so a player chasing a second copy of the same character had to reselect the case and then the item after every attempt. **Losing already kept both**, which made the good outcome the annoying one.

The staked copies still clear, because the server consumed them. Only the target and its case survive. The rarity filter from #271 then keeps the inventory narrowed to exactly what can be fed at that item, so the repeat attempt is one click.

`setSelectedCase` was only used by the block that has been removed, so the prop is gone from `TopContent` and from its call site.

**On verification.** I drove this on a local dev server: after an upgrade the target stays selected, the case stays selected, and the staked items clear. That run happened to be a *loss*, which already behaved this way before the change — so it does not prove the fix on its own. What does is that no success-specific branch remains: the only surviving `if (response.success)` picks the wheel's stop angle, and every remaining reset of the target sits behind a button the player pressed (the Clear link, the X on the target, the Clear case link). Success and failure now run identical cleanup.

`tsc`, `eslint` and the upgrade unit tests pass.