### PR TITLE
perf(api): cache the preflight, and stop polling missions during a run

### DIFF
--- a/backend/__tests__/unit/cors.test.js
+++ b/backend/__tests__/unit/cors.test.js
@@ -1,4 +1,4 @@
-const { parseOrigins, originAllowed } = require("../../utils/cors");
+const { parseOrigins, originAllowed, PREFLIGHT_MAX_AGE } = require("../../utils/cors");
 
 describe("allowed origins", () => {
   it("splits, trims and drops blanks", () => {
@@ -31,5 +31,20 @@ describe("who gets through the cors gate", () => {
 
   it("lets everything through in development", () => {
     expect(originAllowed("https://evil.example", { isDevelopment: true, allowedOrigins: [] })).toBe(true);
+  });
+});
+
+// a preflight the browser cannot cache is a second round trip on every authenticated
+// request, and nothing else in the suite would notice it going missing
+describe("preflight caching", () => {
+  it("keeps a max-age the browser will actually honour", () => {
+    expect(PREFLIGHT_MAX_AGE).toBeGreaterThan(0);
+    // chrome caps it here and silently clamps anything larger
+    expect(PREFLIGHT_MAX_AGE).toBeLessThanOrEqual(7200);
+  });
+
+  it("is wired into the server's cors options", () => {
+    const source = require("node:fs").readFileSync(require("node:path").join(__dirname, "../../index.js"), "utf8");
+    expect(source).toMatch(/maxAge:\s*PREFLIGHT_MAX_AGE/);
   });
 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -30,7 +30,7 @@ const isDevelopment = process.env.NODE_ENV === "development";
 
 // allowed origins are configurable via ALLOWED_ORIGINS (comma-separated); falls
 // back to the production domain so behaviour is unchanged when it isn't set
-const { parseOrigins, originAllowed } = require("./utils/cors");
+const { parseOrigins, originAllowed, PREFLIGHT_MAX_AGE } = require("./utils/cors");
 const allowedOrigins = parseOrigins(process.env.ALLOWED_ORIGINS);
 
 const isOriginAllowed = (origin) => originAllowed(origin, { isDevelopment, allowedOrigins });
@@ -47,6 +47,7 @@ const corsOptions = {
   origin: corsOrigin,
   methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
   credentials: true,
+  maxAge: PREFLIGHT_MAX_AGE,
 };
 
 app.use((req, res, next) => {

--- a/backend/utils/cors.js
+++ b/backend/utils/cors.js
@@ -14,4 +14,11 @@ function originAllowed(origin, { isDevelopment = false, allowedOrigins = [] } = 
   return isDevelopment || !origin || allowedOrigins.includes(origin);
 }
 
-module.exports = { parseOrigins, originAllowed };
+// every authenticated call carries Authorization and x-api-key, which makes it a
+// preflighted request. without a max-age the browser re-asks before each one, and chrome
+// only caches for five seconds by default: an auto run paid a whole extra round trip per
+// action, which for a player far from the box was most of the wait. 7200 is chrome's
+// ceiling; firefox keeps it for a day.
+const PREFLIGHT_MAX_AGE = 7200;
+
+module.exports = { parseOrigins, originAllowed, PREFLIGHT_MAX_AGE };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,33 +44,59 @@ function App() {
   const [notification, setNotification] = useState<any>();
 
   const socket = SocketConnection.getInstance();
-  const missionCheck = useRef<{ inFlight: boolean; last: number }>({ inFlight: false, last: 0 });
+  const missionCheck = useRef<{ inFlight: boolean; timer: number | null; queuedAt: number }>({
+    inFlight: false,
+    timer: null,
+    queuedAt: 0,
+  });
   const userIdRef = useRef<string | null>(null);
 
   if(environment == "production"){
     disableReactDevTools();
   }
 
-  // ask the server for missions that just became claimable and toast them once.
-  // best-effort: throttled on the frequent light path, never blocks anything.
-  const checkMissions = (light: boolean) => {
-    if (!localStorage.getItem("accessToken")) return;
+  // the light check rides on the balance socket, and an auto run changes the balance every
+  // round: at the old 1.5s throttle that became a poll, one request per round-and-a-half,
+  // each of which groups the player's entire ledger. it now waits for the activity to
+  // stop, so a whole auto run costs one check instead of hundreds.
+  const MISSION_QUIET_MS = 4000;
+  const MISSION_MAX_WAIT_MS = 30000;
+
+  const runMissionCheck = (light: boolean) => {
     const c = missionCheck.current;
     if (c.inFlight) return;
-    if (light && Date.now() - c.last < 1500) return;
     c.inFlight = true;
+    c.queuedAt = 0;
     const missionsPath = userIdRef.current ? `/profile/${userIdRef.current}?tab=missions` : undefined;
     getPendingMissions(light)
-      .then((pending) => {
-        pending.forEach((m) => toastMissionComplete(m, missionsPath));
-        c.last = Date.now();
-      })
+      .then((pending) => pending.forEach((m) => toastMissionComplete(m, missionsPath)))
       .catch(() => {
         // best-effort: never let a mission check surface an error
       })
       .finally(() => {
         c.inFlight = false;
       });
+  };
+
+  // ask the server for missions that just became claimable and toast them once.
+  const checkMissions = (light: boolean) => {
+    if (!localStorage.getItem("accessToken")) return;
+    if (!light) return runMissionCheck(false);
+
+    const c = missionCheck.current;
+    const now = Date.now();
+    if (!c.queuedAt) c.queuedAt = now;
+    // a run that never goes quiet still gets checked, just not on every round
+    if (now - c.queuedAt >= MISSION_MAX_WAIT_MS) {
+      if (c.timer) window.clearTimeout(c.timer);
+      c.timer = null;
+      return runMissionCheck(true);
+    }
+    if (c.timer) window.clearTimeout(c.timer);
+    c.timer = window.setTimeout(() => {
+      c.timer = null;
+      runMissionCheck(true);
+    }, MISSION_QUIET_MS);
   };
 
   const userDataSocket = () => {
@@ -87,6 +113,9 @@ function App() {
 
     return () => {
       socket.off("userDataUpdated");
+      const c = missionCheck.current;
+      if (c.timer) window.clearTimeout(c.timer);
+      c.timer = null;
     };
   }
 


### PR DESCRIPTION
A player reported auto mode being slow on Plinko and Mines. His waterfall shows two separate costs.

## The mission check had become a poll

`checkMissions(true)` rode on the `userDataUpdated` socket with a 1.5s throttle. An auto run changes the balance every round, so it fired continuously — visible in his capture as the repeated `pending?light=1` calls at **2.47s, 2.95s and 4.14s**, the slowest things on the page, competing with the game requests for the same connection.

Profiled on the box, that endpoint groups the player's entire ledger: **305ms for an account with 116k rows**, and it grows with the ledger.

It now waits 4s for activity to stop, with a 30s ceiling so a run that never goes quiet is still checked. One check per run instead of one per round.

**I believe this is the larger of the two fixes**, on the evidence below.

## Preflight caching

Every authenticated call carries `Authorization` and `x-api-key`, so every one is preflighted, and nothing set `Access-Control-Max-Age`. Now `maxAge: 7200` (Chrome's ceiling), with the value in `utils/cors.js` so a unit test can pin it.

**Measured, in a real browser at 535ms emulated latency**, three Mines rounds with 6s between them:

| | Preflights | Round trips | Wall clock |
|---|---|---|---|
| without | 9 | 27 | 21.83s |
| with | 3 | 21 | 21.87s |

The count drops. **The wall clock does not move**, because Chrome's DevTools latency emulation does not apply to preflights — they were served from localhost at ~1ms regardless. So this A/B can measure how many preflights happen, not what they cost.

Two things this corrected:

- Chrome already caches a preflight for 5s by default, so it was 9 for 18 calls, not 18. An earlier estimate here assumed one per request and was wrong.
- The saving is inferred, not observed: a preflight to production from Natal measures **~535ms** (curl, 6 samples), and the run makes 6 fewer of them. That multiplication is arithmetic, not a measurement.

The change is still correct — fewer round trips costs nothing — but it is not the headline it was first written as. The honest test is to compare his waterfall before and after this deploys.

## Verification

Backend 1082 passing (2 new pinning the max-age), frontend 181, `tsc`, `eslint`, `build` clean.