### PR TITLE
fix(games): settle the live rounds on shutdown, and pay coin flip from the ledger

### DIFF
--- a/backend/__tests__/integration/roundRecords.test.js
+++ b/backend/__tests__/integration/roundRecords.test.js
@@ -23,6 +23,7 @@ const { crashPointFromSeed } = require("../../utils/crashMath");
 const { coinResultFromSeed } = require("../../utils/coinMath");
 const crashGame = require("../../games/crash");
 const coinFlip = require("../../games/coinFlip");
+const { recoverStuckRounds } = require("../../utils/rounds");
 
 const seedBy = (hash, pred) => {
   for (let i = 0; i < 200000; i++) {
@@ -71,7 +72,7 @@ const start = (game, io, opts) => {
 };
 
 afterEach(async () => {
-  while (running.length) running.pop()();
+  while (running.length) await running.pop()();
   jest.restoreAllMocks();
   await clearDb();
 });
@@ -255,4 +256,57 @@ test("no stake is taken while the round record cannot be written", async () => {
   expect(reply).toEqual({ error: "Betting is closed for this round" });
   expect((await User.findById(user._id)).walletBalance).toBe(5000);
   expect(await Transaction.countDocuments({ userId: user._id })).toBe(0);
+});
+
+describe("a graceful stop settles in process rather than leaving it to the next boot", () => {
+  test("the live crash round is voided and the stake goes back exactly once", async () => {
+    mockCrashSeed = RUNNING_SEED; // a long round, so it is still live when the stop lands
+    const user = await makeUser(5000);
+    const io = makeIo();
+
+    const stop = start(crashGame, io, FAST_CRASH);
+    const socket = makeSocket(String(user._id));
+    io.connection(socket);
+    const opened = await betOnRound("crash", "crash:bet", socket, [100]);
+    expect((await User.findById(user._id)).walletBalance).toBe(4900);
+
+    await stop();
+    await recoverStuckRounds(io, coinFlip.winPayout, { boot: true });
+
+    const done = await Round.findById(opened._id);
+    expect(done.status).toBe("voided");
+    expect(done.settlementDone).toBe(true);
+    expect((await User.findById(user._id)).walletBalance).toBe(5000);
+    expect(
+      await Transaction.countDocuments({ userId: user._id, type: TX.CRASH_REFUND })
+    ).toBe(1);
+  });
+
+  test("a flip that already landed pays its winner once, whoever gets there first", async () => {
+    // the stop can arrive before or after the reveal's own payout loop; either way the
+    // winner is owed one payout, and the drain is what stops the second one
+    mockCoinSeed = HEADS_SEED;
+    const user = await makeUser(5000);
+    const io = makeIo();
+
+    const stop = start(coinFlip, io, FAST_FLIP);
+    const socket = makeSocket(String(user._id));
+    io.connection(socket);
+    const opened = await betOnRound("coinflip", "coinFlip:bet", socket, [100, 0]);
+    await until(async () => {
+      const r = await Round.findById(opened._id);
+      return r && r.status !== "betting" ? r : null;
+    }, "the flip to land");
+
+    await stop();
+    await recoverStuckRounds(io, coinFlip.winPayout, { boot: true });
+
+    const paid = await Transaction.find({
+      userId: user._id,
+      type: TX.COINFLIP_WIN,
+      "meta.roundId": String(opened._id),
+    });
+    expect(paid).toHaveLength(1);
+    expect((await User.findById(user._id)).walletBalance).toBe(5000 - 100 + 194);
+  });
 });

--- a/backend/__tests__/integration/roundRecovery.test.js
+++ b/backend/__tests__/integration/roundRecovery.test.js
@@ -20,11 +20,12 @@ const makeUser = (walletBalance) => {
 
 const balanceOf = async (user) => (await User.findById(user._id)).walletBalance;
 
-// the ledger row chargeUser writes when a stake is taken
-const stakeRow = (user, round, amount, type) =>
+// the ledger row chargeUser writes when a stake is taken. coin flip carries the pick in
+// meta.side, exactly as games/coinFlip.js writes it, because that is what recovery reads
+const stakeRow = (user, round, amount, type, side) =>
   Transaction.create({
     userId: user._id, type, direction: "debit", amount, balanceAfter: 0,
-    meta: { roundId: String(round._id) },
+    meta: { roundId: String(round._id), ...(side ? { side } : {}) },
   });
 
 const paidRow = (user, round, amount, type) =>
@@ -98,8 +99,8 @@ describe("rounds a restart left in flight", () => {
         { userId: loser._id, amount: 100, side: "tails" },
       ],
     });
-    await stakeRow(winner, round, 100, TX.COINFLIP_BET);
-    await stakeRow(loser, round, 100, TX.COINFLIP_BET);
+    await stakeRow(winner, round, 100, TX.COINFLIP_BET, "heads");
+    await stakeRow(loser, round, 100, TX.COINFLIP_BET, "tails");
 
     expect(await recover()).toEqual({ voided: 0, settled: 1 });
 
@@ -115,11 +116,25 @@ describe("rounds a restart left in flight", () => {
       game: "coinflip", status: "running", outcome: { result: 0, winningSide: "heads" },
       bets: [{ userId: winner._id, amount: 100, side: "heads" }],
     });
-    await stakeRow(winner, round, 100, TX.COINFLIP_BET);
+    await stakeRow(winner, round, 100, TX.COINFLIP_BET, "heads");
     await paidRow(winner, round, winPayout(100), TX.COINFLIP_WIN);
 
     await recover();
 
+    expect(await balanceOf(winner)).toBe(900 + winPayout(100));
+  });
+
+  test("a winning stake the round doc never recorded is still paid", async () => {
+    // the charge lands, then the process dies before the bet reaches the round doc. reading
+    // claimed.bets dropped this player from the payout and silently kept their stake.
+    const winner = await makeUser(900);
+    const round = await Round.create({
+      game: "coinflip", status: "running", outcome: { result: 0, winningSide: "heads" },
+      bets: [],
+    });
+    await stakeRow(winner, round, 100, TX.COINFLIP_BET, "heads");
+
+    expect(await recover()).toEqual({ voided: 0, settled: 1 });
     expect(await balanceOf(winner)).toBe(900 + winPayout(100));
   });
 

--- a/backend/games/coinFlip.js
+++ b/backend/games/coinFlip.js
@@ -36,7 +36,7 @@ const publicCoinState = (state) => ({
 
 // the timings are arguments so a test can run a whole round in milliseconds against a
 // real database. faking the clock instead breaks the mongo driver's own timers.
-const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {}) => {
+const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000, drainMs = 3000 } = {}) => {
   let gameState = freshState();
   // the persisted record of the round being played. bets refuse to open without one:
   // taking a stake we cannot account for later is the thing this exists to stop.
@@ -50,6 +50,8 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
   let stopped = false;
   let nextRound = null;
   let reveal = null;
+  // the reveal's payout run, so a shutdown can wait for it rather than settle alongside it
+  let settling = null;
 
   io.on("connection", (socket) => {
     socket.on("coinFlip:bet", async (bet, choice, callback) => {
@@ -214,8 +216,7 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
       ).catch((e) => console.log(e));
     }
 
-    reveal = setTimeout(async () => {
-      if (stopped) return;
+    const settleFlip = async () => {
       io.emit("coinFlip:result", result);
       // the seed is revealed only now, so nobody could have known the flip early
       io.emit("coinFlip:reveal", {
@@ -235,18 +236,29 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000 } = {
       }
 
       openBetting();
+    };
+
+    reveal = setTimeout(() => {
+      if (stopped) return;
+      settling = settleFlip().catch((e) => console.log(e));
     }, revealMs);
   };
 
   openBetting();
 
-  // stops the loop cleanly. the process exiting mid-round is exactly what the round
-  // record exists to survive, but there is no reason to thrash on the way out.
-  return () => {
+  // stops the loop cleanly, then waits for the money already moving. the caller settles the
+  // round afterwards by reading the ledger, so a charge or a payout still in flight has to
+  // have written its row first: otherwise the settle pays a winner the loop just paid.
+  return async () => {
     stopped = true;
     bettingOpen = false;
     if (nextRound) clearTimeout(nextRound);
     if (reveal) clearTimeout(reveal);
+    if (settling) await settling.catch(() => {});
+    const until = Date.now() + drainMs;
+    while (pendingBets.size && Date.now() < until) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
   };
 };
 

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -26,7 +26,7 @@ const publicState = (state) => ({
 
 // the timings are arguments so a test can run a whole round in milliseconds against a
 // real database. faking the clock instead breaks the mongo driver's own timers.
-const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) => {
+const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000, drainMs = 3000 } = {}) => {
   let gameState = freshState();
   // the persisted record of the round being played. bets refuse to open without one:
   // taking a stake we cannot account for later is the thing this exists to stop.
@@ -42,6 +42,8 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
   let stopped = false;
   let nextRound = null;
   let ticker = null;
+  // the tick that is paying auto-cashouts right now, so a shutdown can wait for it
+  let settling = null;
 
   io.on("connection", (socket) => {
     // sync a joiner to the round in progress: without this a missed crash:start leaves
@@ -125,7 +127,7 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
           { _id: activeRound._id },
           {
             $push: {
-              bets: { userId, username: updatedUser.username, amount, payout: 0 },
+              bets: { userId, username: updatedUser.username, amount, payout: 0, autoCashoutAt },
             },
           }
         );
@@ -300,8 +302,9 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
       if (stopped) return clearInterval(multiplierInterval);
       if (ticking) return;
       ticking = true;
+      settling = tick();
       try {
-        await tick();
+        await settling;
       } finally {
         ticking = false;
       }
@@ -356,13 +359,19 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000 } = {}) 
 
   openBetting();
 
-  // stops the loop cleanly. the process exiting mid-round is exactly what the round
-  // record exists to survive, but there is no reason to thrash on the way out.
-  return () => {
+  // stops the loop cleanly, then waits for the money already moving. the caller voids the
+  // round afterwards by reading the ledger, so a charge or a cashout still in flight has
+  // to have written its row first: otherwise the void refunds a stake that just got paid.
+  return async () => {
     stopped = true;
     bettingOpen = false;
     if (nextRound) clearTimeout(nextRound);
     if (ticker) clearInterval(ticker);
+    if (settling) await settling.catch(() => {});
+    const until = Date.now() + drainMs;
+    while ((pendingBets.size || pendingCashouts.size) && Date.now() < until) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
   };
 };
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -194,13 +194,40 @@ sweepRounds({ boot: true });
 setInterval(() => sweepRounds({ boot: false }), 5 * 60 * 1000);
 
 // Start the games
-coinFlip(io);
-crash(io);
+const stopCoinFlip = coinFlip(io);
+const stopCrash = crash(io);
 caseBattle(io);
 
 // Start the cron jobs
 cronJobs.startCronJobs(io);
 adminRoutes.attachPredictionSettlement(io);
+
+// every deploy used to kill a live round and leave the stakes to the next boot's sweep.
+// settling here instead is the same code on a round that is one, not a backlog, and the
+// players are still connected, so the refund actually reaches them. pm2 sends SIGINT and
+// waits kill_timeout before SIGKILL, so this is best-effort by design: whatever it does
+// not finish is still marked unfinished, and the boot sweep picks it up as before.
+let shuttingDown = false;
+const shutdown = async (signal) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`${signal}: closing betting and settling the live rounds`);
+  try {
+    await Promise.all([stopCrash(), stopCoinFlip()]);
+    await recoverStuckRounds(io, coinFlip.winPayout, { boot: true });
+  } catch (e) {
+    console.log("shutdown settle did not finish, the boot sweep will:", e);
+  }
+  server.close();
+  try {
+    await mongoose.connection.close();
+  } catch (e) {
+    // nothing left to do about it, we are on the way out
+  }
+  process.exit(0);
+};
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
 
 const port = process.env.PORT || 5000;
 

--- a/backend/models/Round.js
+++ b/backend/models/Round.js
@@ -9,6 +9,7 @@ const roundBetSchema = new mongoose.Schema(
     amount: { type: Number, required: true },
     side: String, // coin flip: "heads" / "tails"
     multiplier: Number, // crash: what they cashed out at
+    autoCashoutAt: Number, // crash: the target they set, the one action a restart could have resolved
     payout: { type: Number, default: 0 },
     settledAt: Date,
   },

--- a/backend/utils/rounds.js
+++ b/backend/utils/rounds.js
@@ -44,6 +44,16 @@ async function settledUserIds(roundId, types) {
   return new Set(rows.map((t) => String(t.userId)));
 }
 
+// every stake this round took, from the ledger for the same reason: the charge lands
+// before the bet reaches the round doc, so a restart in between leaves a stake that is
+// real and paid for but invisible in round.bets. meta.side carries the coin flip pick.
+async function stakesIn(roundId, types) {
+  return Transaction.find({
+    type: types.bet,
+    "meta.roundId": String(roundId),
+  }).select("userId amount meta.side");
+}
+
 // give back every stake this round took and never settled. a player who cashed out of
 // crash already has their money and is left alone; a player who never got the chance is
 // made whole, because a round that did not finish cannot be said to have lost.
@@ -62,10 +72,7 @@ async function voidRound(round, io = noopIo) {
   if (!claimed) return null; // already given back, or another runner holds the lease
 
   const settled = await settledUserIds(claimed._id, types);
-  const staked = await Transaction.find({
-    type: types.bet,
-    "meta.roundId": String(claimed._id),
-  }).select("userId amount");
+  const staked = await stakesIn(claimed._id, types);
 
   for (const stake of staked) {
     const userId = String(stake.userId);
@@ -98,16 +105,20 @@ async function settleInterruptedCoinFlip(round, io = noopIo, payoutFor) {
 
   const winningSide = claimed.outcome && claimed.outcome.winningSide;
   const settled = await settledUserIds(claimed._id, types);
+  // the ledger, not claimed.bets: a stake charged in the moment before the round doc was
+  // written belongs to a player who backed a side and paid for it, and reading the doc
+  // dropped them from the payout without a trace
+  const staked = await stakesIn(claimed._id, types);
 
-  for (const bet of claimed.bets) {
-    if (bet.side !== winningSide) continue;
-    const userId = String(bet.userId);
+  for (const stake of staked) {
+    if (!stake.meta || stake.meta.side !== winningSide) continue;
+    const userId = String(stake.userId);
     if (settled.has(userId)) continue;
     settled.add(userId);
-    const payout = payoutFor(bet.amount);
-    const user = await creditUser(bet.userId, payout, payout - bet.amount, {
+    const payout = payoutFor(stake.amount);
+    const user = await creditUser(stake.userId, payout, payout - stake.amount, {
       type: types.paid,
-      meta: { roundId: String(claimed._id), betAmount: bet.amount, payout, side: winningSide },
+      meta: { roundId: String(claimed._id), betAmount: stake.amount, payout, side: winningSide },
     });
     emitUserData(io, userId, user);
   }


### PR DESCRIPTION
## Problem

A restart killed whatever crash or coin flip round was live and left the stakes to the next boot's sweep, so every deploy refunded the lobbies. The refund emit went to a room nobody was connected to yet.

`settleInterruptedCoinFlip` iterated `round.bets` while `voidRound` refunded from the ledger. The stake is charged before the bet reaches the round document, so a restart in that window left a winner charged and never paid.

The crash auto-cashout target existed only in memory, so nothing recorded the one action a restart could have resolved.

## Change

`SIGINT` and `SIGTERM` stop both game loops and run the same `recoverStuckRounds` the boot path runs, in process. pm2 waits `kill_timeout` before `SIGKILL`, so anything unfinished stays marked unfinished and the boot sweep settles it.

Because the process stays alive, a `creditUser` still in flight has not written its ledger row and is invisible to recovery, which would then refund a stake that was just paid. Each stop function is now async: it awaits the settlement already running, then drains `pendingBets` and `pendingCashouts`, capped at 3s.

Both recovery arms read stakes from the ledger through one `stakesIn` helper, taking the coin flip pick from `meta.side`.

`autoCashoutAt` is persisted on the bet entry. Recovery does not act on it; the push happens anyway.

## Tests

`cd backend && npx jest`, 1085 passing across 107 suites. Three new cases: a winning stake the round document never recorded is still paid, a graceful stop voids the live crash round and refunds once, a landed flip pays its winner once whichever path gets there first.

The coin flip fixtures in `roundRecovery.test.js` wrote a shape production only reaches after both writes land, which is what hid the bug. They now write `meta.side`.

## Ops

`kill_timeout` defaults to 1600ms and wants raising. Steps in `operations.md`. Tuning only.