### PR TITLE
fix(leaderboard): stop repeating the caller, and rank 2 and 3 on mobile

### DIFF
--- a/backend/routes/leaderboardRoutes.js
+++ b/backend/routes/leaderboardRoutes.js
@@ -59,6 +59,8 @@ router.get("/", maybeAuthenticated, async (req, res) => {
       const mine = await leaderboard.standingFor(req.user._id, current.startsAt, current.endsAt);
       const lastPaid = rows.length >= leaderboard.PAID_PLACES ? rows[rows.length - 1].points : 0;
       payload.me = {
+        // the id lets the board mark the caller's own row rather than repeat it underneath
+        _id: String(req.user._id),
         ...mine,
         // what it would take to reach the last paid place, which is the only number a
         // player outside the top ten actually wants

--- a/src/pages/Home/Leaderboard/Leaderboard.services.ts
+++ b/src/pages/Home/Leaderboard/Leaderboard.services.ts
@@ -108,6 +108,9 @@ export const useLeaderboardServices = () => {
     board,
     podium: podiumOrder(standings),
     rest: standings.slice(3),
+    // the podium only stands first place on mobile, so second and third join the table
+    // there rather than disappearing off the board entirely
+    podiumRest: standings.slice(1, 3),
     countdown,
     pool: board ? board.pool : 0,
     me,

--- a/src/pages/Home/Leaderboard/Leaderboard.types.ts
+++ b/src/pages/Home/Leaderboard/Leaderboard.types.ts
@@ -12,6 +12,7 @@ export interface LeaderboardViewProps {
   // the three podium places, already ordered 2nd / 1st / 3rd the way they are drawn
   podium: BoardStanding[];
   rest: BoardStanding[];
+  podiumRest: BoardStanding[];
   countdown: Countdown;
   pool: number;
   paidPlaces: number;

--- a/src/pages/Home/Leaderboard/Leaderboard.view.test.tsx
+++ b/src/pages/Home/Leaderboard/Leaderboard.view.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import LeaderboardView from "./Leaderboard.view";
+import { LeaderboardViewProps } from "./Leaderboard.types";
+import { BoardStanding } from "../../../services/leaderboard/LeaderboardService";
+
+const player = (rank: number, username: string): BoardStanding => ({
+  _id: `u${rank}`,
+  rank,
+  points: 10000 - rank * 500,
+  bets: rank,
+  prize: 1000 - rank * 50,
+  username,
+  profilePicture: "",
+  level: 10,
+  badge: null,
+});
+
+const standings = [
+  player(1, "first"),
+  player(2, "second"),
+  player(3, "third"),
+  player(4, "fourth"),
+  player(5, "fifth"),
+];
+
+const props = (over: Partial<LeaderboardViewProps> = {}): LeaderboardViewProps => ({
+  loading: false,
+  board: null,
+  podium: [standings[1], standings[0], standings[2]],
+  rest: standings.slice(3),
+  podiumRest: standings.slice(1, 3),
+  countdown: { hours: "04", minutes: "12", seconds: "38" },
+  pool: 21700,
+  paidPlaces: 10,
+  me: null,
+  meOnBoard: false,
+  lastResult: null,
+  dismissResult: () => undefined,
+  points: [],
+  showPoints: false,
+  openPoints: () => undefined,
+  closePoints: () => undefined,
+  ...over,
+});
+
+const draw = (over: Partial<LeaderboardViewProps> = {}) =>
+  render(
+    <MemoryRouter>
+      <LeaderboardView {...props(over)} />
+    </MemoryRouter>
+  );
+
+const me = { _id: "u4", points: 8000, bets: 4, rank: 4, toPaidPlace: 0, prize: 800 };
+
+describe("the daily leaderboard", () => {
+  it("does not repeat a player who is already ranked in the table", () => {
+    // the pinned row used to render unconditionally, so a player inside the paid places
+    // appeared twice: once under their own name and again as "You"
+    draw({ me, meOnBoard: true });
+
+    expect(screen.queryByText("You")).toBeNull();
+    expect(screen.getAllByText("fourth")).toHaveLength(1);
+  });
+
+  it("pins the player when they are outside the paid places", () => {
+    draw({ me: { ...me, _id: "u99", rank: 23, toPaidPlace: 2410, prize: 0 }, meOnBoard: false });
+
+    expect(screen.getByText("You")).toBeTruthy();
+  });
+
+  it("puts second and third in the table, because the podium hides them on mobile", () => {
+    const { container } = draw();
+
+    const mobileRows = container.querySelectorAll("tr.md\\:hidden");
+    expect([...mobileRows].map((r) => r.textContent)).toEqual([
+      expect.stringContaining("second"),
+      expect.stringContaining("third"),
+    ]);
+    // both copies are in the dom and the breakpoint picks one: the podium card is
+    // hidden below md, the table row is hidden from md up, so they never show together
+    const copies = screen.getAllByText("second");
+    expect(copies).toHaveLength(2);
+    expect(copies.some((n) => n.closest(".hidden.md\\:block"))).toBe(true);
+    expect(copies.some((n) => n.closest("tr.md\\:hidden"))).toBe(true);
+  });
+
+  it("ranks the table rows in order under the podium", () => {
+    const { container } = draw();
+
+    const ranks = [...container.querySelectorAll("tbody tr")].map(
+      (row) => row.querySelector("td")?.textContent
+    );
+    expect(ranks).toEqual(["#2", "#3", "#4", "#5"]);
+  });
+});

--- a/src/pages/Home/Leaderboard/Leaderboard.view.tsx
+++ b/src/pages/Home/Leaderboard/Leaderboard.view.tsx
@@ -44,8 +44,8 @@ const Clock = ({ countdown, pool, paidPlaces }: { countdown: Countdown; pool: nu
     </div>
 );
 
-const Row = ({ user }: { user: BoardStanding }) => (
-    <tr>
+const Row = ({ user, mine, mobileOnly }: { user: BoardStanding; mine?: boolean; mobileOnly?: boolean }) => (
+    <tr className={`${mine ? "bg-surface-nav" : ""} ${mobileOnly ? "md:hidden" : ""}`}>
         <td className="px-6 py-4 whitespace-nowrap">#{user.rank}</td>
         <td className="flex p-4 items-center gap-2">
             <Player user={user as never} size="small" />
@@ -160,10 +160,12 @@ const LeaderboardView = ({
     loading,
     podium,
     rest,
+    podiumRest,
     countdown,
     pool,
     paidPlaces,
     me,
+    meOnBoard,
     lastResult,
     dismissResult,
     points,
@@ -232,8 +234,15 @@ const LeaderboardView = ({
                             </tr>
                         )}
 
-                        {!loading && rest.map((user) => <Row key={user._id} user={user} />)}
-                        {!loading && me && <YourRow me={me} paidPlaces={paidPlaces} />}
+                        {!loading && podiumRest.map((user) => (
+                            <Row key={user._id} user={user} mine={me?._id === user._id} mobileOnly />
+                        ))}
+                        {!loading && rest.map((user) => (
+                            <Row key={user._id} user={user} mine={me?._id === user._id} />
+                        ))}
+                        {/* only when they are not already a row above, or the board shows
+                            the same player twice */}
+                        {!loading && me && !meOnBoard && <YourRow me={me} paidPlaces={paidPlaces} />}
                         {!loading && !podium.length && (
                             <tr>
                                 <td colSpan={4} className="px-6 py-12 text-center text-sm text-ink-soft">

--- a/src/services/leaderboard/LeaderboardService.ts
+++ b/src/services/leaderboard/LeaderboardService.ts
@@ -21,6 +21,7 @@ export interface BoardStanding {
 }
 
 export interface BoardMe {
+  _id: string;
   points: number;
   bets: number;
   rank: number | null;


### PR DESCRIPTION
## Problem

A player inside the paid places was listed twice: once under their own name, once as "You" on the same rank. The pinned row rendered whenever the caller had a standing.

Ranks 2 and 3 were invisible on mobile. `TopPlayer` hides them below the md breakpoint and the table starts at rank 4, so on a phone they were on no surface at all.

## Change

The pinned row only renders when the caller is not already listed. When they are, their own row is highlighted, so `payload.me` now carries `_id`.

Ranks 2 and 3 render as `md:hidden` table rows above rank 4. Both copies are in the DOM and the breakpoint picks one, so they never show together.

## Tests

4 new component tests, covering both defects. Frontend unit 181, e2e 45, backend leaderboard suites 26. Checked in a browser at 390px and 1400px.