### PR TITLE
feat(games): live bet ticker under the game canvas

### DIFF
--- a/backend/__tests__/integration/liveFeed.test.js
+++ b/backend/__tests__/integration/liveFeed.test.js
@@ -152,6 +152,34 @@ describe("the boot seed", () => {
     expect(await liveFeed.seed()).toBe(0);
   });
 
+  // these two use the meta each game really writes, not a shape invented here. checked
+  // against production on 2026-08-30, where blackjack turned out to be the only win row
+  // with no betAmount and would have seeded nothing at all.
+  test("a crash cashout seeds from the credited amount, since its meta carries no payout", async () => {
+    const user = await makeUser();
+    await winRow(user, TX.CRASH_CASHOUT, new Date(), { betAmount: 1000, multiplier: 2.5, roundId: "r1" });
+    // the row's amount is the payout, which is what creditUser was called with
+    await Transaction.updateOne({ userId: user._id }, { $set: { amount: 2500 } });
+
+    expect(await liveFeed.seed()).toBe(1);
+    expect(liveFeed.recent()[0]).toMatchObject({ game: "crash", bet: 1000, payout: 2500, multiplier: 2.5 });
+  });
+
+  test("a blackjack win seeds, now that its row carries the bet", async () => {
+    const user = await makeUser();
+    await winRow(user, TX.BLACKJACK_WIN, new Date(), { handId: "BJ1", betAmount: 1000, payout: 2020, natural: false });
+
+    expect(await liveFeed.seed()).toBe(1);
+    expect(liveFeed.recent()[0]).toMatchObject({ game: "blackjack", bet: 1000, payout: 2020 });
+  });
+
+  test("an older blackjack row with no bet is skipped rather than seeded as zero", async () => {
+    const user = await makeUser();
+    await winRow(user, TX.BLACKJACK_WIN, new Date(), { handId: "BJ0", payout: 2020, natural: false });
+
+    expect(await liveFeed.seed()).toBe(0);
+  });
+
   test("writes nothing while seeding", async () => {
     const user = await makeUser();
     await winRow(user, TX.PLINKO_WIN, new Date(), { betAmount: 50, payout: 75 });

--- a/backend/__tests__/integration/liveFeed.test.js
+++ b/backend/__tests__/integration/liveFeed.test.js
@@ -1,0 +1,164 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || "test-secret";
+
+const { setupDb, clearDb, teardownDb } = require("./db");
+const { uniqueSuffix } = require("./helpers");
+const User = require("../../models/User");
+const Transaction = require("../../models/Transaction");
+const realtime = require("../../utils/realtime");
+const { TX } = require("../../utils/economy");
+const liveFeed = require("../../utils/liveFeed");
+
+beforeAll(setupDb);
+afterEach(async () => {
+  liveFeed.reset();
+  realtime.setIo(null);
+  await clearDb();
+});
+afterAll(teardownDb);
+
+const makeUser = (extra = {}) => {
+  const s = uniqueSuffix();
+  return User.create({ username: `u-${s}`, email: `u-${s}@e.com`, password: "x", ...extra });
+};
+
+const captureIo = () => {
+  const emitted = [];
+  realtime.setIo({ emit: (event, payload) => emitted.push({ event, payload }) });
+  return emitted;
+};
+
+// the feed throttles per player, so a second entry needs the window to have passed
+const past = (id) => liveFeed.reset();
+
+describe("the live bet ticker", () => {
+  test("broadcasts a settled bet and keeps it in memory", async () => {
+    const user = await makeUser({ profilePicture: "pic", level: 12 });
+    const emitted = captureIo();
+
+    const entry = await liveFeed.publish({ game: "dice", user, bet: 100, payout: 250 });
+
+    expect(entry).toMatchObject({
+      game: "dice",
+      username: user.username,
+      bet: 100,
+      payout: 250,
+      multiplier: 2.5,
+    });
+    expect(emitted).toEqual([{ event: "liveBet", payload: entry }]);
+    expect(liveFeed.recent()).toEqual([entry]);
+  });
+
+  test("writes nothing to the database", async () => {
+    const user = await makeUser();
+    const before = await Transaction.countDocuments({});
+
+    await liveFeed.publish({ game: "dice", user, bet: 100, payout: 0 });
+
+    expect(await Transaction.countDocuments({})).toBe(before);
+  });
+
+  test("a loss rides the feed as a zero multiplier", async () => {
+    const user = await makeUser();
+    const entry = await liveFeed.publish({ game: "mines", user, bet: 500, payout: 0 });
+    expect(entry).toMatchObject({ bet: 500, payout: 0, multiplier: 0 });
+  });
+
+  test("resolves a bare userId, so a loss path needs no user document", async () => {
+    const user = await makeUser({ level: 7 });
+    const entry = await liveFeed.publish({ game: "hilo", userId: user._id, bet: 20, payout: 0 });
+    expect(entry.username).toBe(user.username);
+    expect(entry.level).toBe(7);
+  });
+
+  test("throttles one player, so a bot cannot own every row", async () => {
+    const bot = await makeUser();
+    const other = await makeUser();
+
+    const first = await liveFeed.publish({ game: "dice", user: bot, bet: 10, payout: 0 });
+    const second = await liveFeed.publish({ game: "dice", user: bot, bet: 10, payout: 0 });
+    const third = await liveFeed.publish({ game: "dice", user: other, bet: 10, payout: 0 });
+
+    expect(first).toBeTruthy();
+    expect(second).toBeNull(); // inside the window
+    expect(third).toBeTruthy(); // a different player is unaffected
+    expect(liveFeed.recent()).toHaveLength(2);
+  });
+
+  test("keeps a banned account off every game page", async () => {
+    const banned = await makeUser({ disabled: true });
+    const emitted = captureIo();
+
+    expect(await liveFeed.publish({ game: "dice", user: banned, bet: 10, payout: 0 })).toBeNull();
+    expect(emitted).toHaveLength(0);
+    expect(liveFeed.recent()).toHaveLength(0);
+  });
+
+  test("a free case open is a gift, not a bet, and never reaches the feed", async () => {
+    const user = await makeUser();
+    expect(await liveFeed.publish({ game: "case", user, bet: 0, payout: 900 })).toBeNull();
+  });
+
+  test("the buffer is capped, newest first", async () => {
+    for (let i = 0; i < liveFeed.KEEP + 10; i++) {
+      const user = await makeUser();
+      await liveFeed.publish({ game: "dice", user, bet: i + 1, payout: 0 });
+    }
+    const rows = liveFeed.recent();
+    expect(rows).toHaveLength(liveFeed.KEEP);
+    expect(rows[0].bet).toBe(liveFeed.KEEP + 10);
+  });
+
+  test("never throws, so it cannot fail a bet that was already paid", async () => {
+    realtime.setIo({
+      emit: () => {
+        throw new Error("socket exploded");
+      },
+    });
+    const user = await makeUser();
+    await expect(liveFeed.publish({ game: "dice", user, bet: 10, payout: 0 })).resolves.toBeNull();
+  });
+});
+
+describe("the boot seed", () => {
+  const winRow = (user, type, at, meta) =>
+    Transaction.create({
+      userId: user._id, type, direction: "credit", amount: meta.payout || 0,
+      balanceAfter: 0, meta, createdAt: at,
+    });
+
+  test("rebuilds recent rows from win rows already in the ledger", async () => {
+    const user = await makeUser();
+    await winRow(user, TX.DICE_WIN, new Date(Date.now() - 60000), { betAmount: 200, payout: 400 });
+
+    expect(await liveFeed.seed()).toBe(1);
+    expect(liveFeed.recent()[0]).toMatchObject({
+      game: "dice", bet: 200, payout: 400, multiplier: 2,
+    });
+  });
+
+  test("ignores rows older than the window rather than passing them off as live", async () => {
+    const user = await makeUser();
+    const old = new Date(Date.now() - liveFeed.SEED_WINDOW_MS - 60000);
+    await winRow(user, TX.DICE_WIN, old, { betAmount: 200, payout: 400 });
+
+    expect(await liveFeed.seed()).toBe(0);
+    expect(liveFeed.recent()).toHaveLength(0);
+  });
+
+  test("leaves a disabled account out of the seed too", async () => {
+    const banned = await makeUser({ disabled: true });
+    await winRow(banned, TX.DICE_WIN, new Date(), { betAmount: 200, payout: 400 });
+
+    expect(await liveFeed.seed()).toBe(0);
+  });
+
+  test("writes nothing while seeding", async () => {
+    const user = await makeUser();
+    await winRow(user, TX.PLINKO_WIN, new Date(), { betAmount: 50, payout: 75 });
+    const before = await Transaction.countDocuments({});
+
+    await liveFeed.seed();
+
+    expect(await Transaction.countDocuments({})).toBe(before);
+  });
+});

--- a/backend/games/blackjack.js
+++ b/backend/games/blackjack.js
@@ -6,6 +6,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const liveFeed = require("../utils/liveFeed");
 const {
   BLACKJACK_ALGO_VERSION,
   MIN_BET,
@@ -185,6 +186,13 @@ async function paySettlement(hand, io, { emitDelayMs = 0 } = {}) {
       emit();
     }
   }
+  // outside the payout branch: a busted hand pays nothing and is still a bet the room saw
+  liveFeed.publish({
+    game: "blackjack",
+    userId: hand.userId,
+    bet: hand.betAmount,
+    payout: hand.totalPayout,
+  });
   await BlackjackHand.updateOne({ _id: hand._id }, { $set: { settlementDone: true } });
   return true;
 }

--- a/backend/games/blackjack.js
+++ b/backend/games/blackjack.js
@@ -170,7 +170,9 @@ async function paySettlement(hand, io, { emitDelayMs = 0 } = {}) {
     const natural = hand.hands.some((h) => h.outcome === "blackjack");
     const credited = await creditUser(hand.userId, hand.totalPayout, winnings, {
       type,
-      meta: { handId: hand.handId, payout: hand.totalPayout, natural },
+      // betAmount so the row stands on its own: every other game's win row carries it,
+      // and the live feed's boot seed rebuilds a bet from the ledger alone
+      meta: { handId: hand.handId, betAmount: hand.betAmount, payout: hand.totalPayout, natural },
     });
     if (!credited) return false;
     const updatedUserData = {

--- a/backend/games/coinFlip.js
+++ b/backend/games/coinFlip.js
@@ -3,6 +3,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const { coinResultFromSeed } = require("../utils/coinMath");
 const { consumeNextSeed } = require("../utils/gameChain");
 const { sha256 } = require("../utils/hashChain");
+const liveFeed = require("../utils/liveFeed");
 
 // a fair coin paying 2x is a 0% house edge: the house cannot win, and the game is a
 // pure variance pump on the KP supply that no amount of play ever drains. paying
@@ -158,6 +159,8 @@ const coinFlip = (io, { bettingMs = 14000, revealMs = 5000, retryMs = 2000, drai
           xp: updatedUser.xp,
           level: updatedUser.level,
         });
+
+        liveFeed.publish({ game: "coinflip", user: updatedUser, bet: betAmount, payout });
       } catch (err) {
         console.log(err);
       }

--- a/backend/games/crash.js
+++ b/backend/games/crash.js
@@ -3,6 +3,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const { multiplierAt, crashPointFromSeed, normalizeAutoCashout } = require("../utils/crashMath");
 const { consumeNextSeed } = require("../utils/gameChain");
 const { sha256 } = require("../utils/hashChain");
+const liveFeed = require("../utils/liveFeed");
 
 const freshState = () => ({
   gameBets: {},
@@ -232,6 +233,8 @@ const crashGame = (io, { bettingMs = 12000, tickMs = 80, retryMs = 2000, drainMs
     });
 
     io.emit("crash:gameState", publicState(gameState));
+
+    liveFeed.publish({ game: "crash", user: updatedUser, bet: betAmount, payout });
 
     notify({ userId, payout, multiplier });
     return true;

--- a/backend/games/dice.js
+++ b/backend/games/dice.js
@@ -3,6 +3,7 @@ const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
 const { DICE_ALGO_VERSION, normalizeTarget, validBet, resolveRoll } = require("../utils/diceMath");
+const liveFeed = require("../utils/liveFeed");
 
 function httpError(status, message) {
   const err = new Error(message);
@@ -47,6 +48,7 @@ class DiceGameController {
       if (credited) balanceAfter = credited.walletBalance;
     }
     const payoutFailed = outcome.payout > 0 && !credited;
+    liveFeed.publish({ game: "dice", user: player, bet: betAmount, payout: outcome.payout });
 
     io.to(userId.toString()).emit("userDataUpdated", {
       walletBalance: balanceAfter,

--- a/backend/games/hilo.js
+++ b/backend/games/hilo.js
@@ -6,6 +6,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const liveFeed = require("../utils/liveFeed");
 const {
   HILO_ALGO_VERSION,
   MAX_SKIPS,
@@ -98,6 +99,7 @@ async function payCashout(game, io) {
       level: credited.level,
     });
   }
+  if (game.payout > 0) liveFeed.publish({ game: "hilo", userId: game.userId, bet: game.betAmount, payout: game.payout });
   await HiloGame.updateOne({ _id: game._id }, { $set: { settlementDone: true } });
   return true;
 }
@@ -219,6 +221,7 @@ class HiloGameController {
       { new: true }
     );
     if (!busted) throw httpError(409, "Action already applied, refresh");
+    liveFeed.publish({ game: "hilo", userId: game.userId, bet: busted.betAmount, payout: 0 });
     busted.rollId = await recordGameRoll(busted);
     return publicView(busted);
   }

--- a/backend/games/mines.js
+++ b/backend/games/mines.js
@@ -6,6 +6,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const liveFeed = require("../utils/liveFeed");
 const {
   MINES_ALGO_VERSION,
   TILES,
@@ -80,6 +81,7 @@ async function payCashout(game, io) {
       xp: credited.xp,
       level: credited.level,
     });
+    liveFeed.publish({ game: "mines", user: credited, bet: game.betAmount, payout: game.payout });
   }
   await MinesGame.updateOne({ _id: game._id }, { $set: { settlementDone: true } });
   return true;
@@ -201,6 +203,7 @@ class MinesGameController {
           { new: true }
         );
         if (!busted) throw httpError(409, "Action already applied, refresh");
+        liveFeed.publish({ game: "mines", userId, bet: busted.betAmount, payout: 0 });
         busted.rollId = await recordGameRoll(busted);
         return publicView(busted);
       }

--- a/backend/games/openCase.js
+++ b/backend/games/openCase.js
@@ -11,6 +11,7 @@ const { roll, pickFromRanges, TOTAL } = require("../utils/provablyFair");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { sellValue, recomputeCaseValues } = require("../utils/itemValue");
+const liveFeed = require("../utils/liveFeed");
 
 const MAX_PER_OPEN = 5;
 
@@ -150,6 +151,14 @@ async function openCase({ user, caseId, quantity, grantId = null, source = null 
     await User.updateOne({ _id: user._id }, { $set: { level: newLevel } });
     referrals.maybePayReferralMilestone(user._id, newLevel).catch(() => {});
   }
+
+  // a free open is a gift, not a bet, so `cost` of 0 drops out of the ticker on its own
+  liveFeed.publish({
+    game: "case",
+    user: updatedUser,
+    bet: cost,
+    payout: winningItems.reduce((sum, item) => sum + (item.baseValue || 0), 0),
+  });
 
   const io = realtime.getIo();
   if (io) {

--- a/backend/games/plinko.js
+++ b/backend/games/plinko.js
@@ -4,6 +4,7 @@ const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
 const { PLINKO_ALGO_VERSION, PAYOUTS, derivePath, binFromPath } = require("../utils/plinkoMath");
+const liveFeed = require("../utils/liveFeed");
 
 // per-risk bet ceilings keep the maximum payout at 1,000,000 (cap times top multiplier)
 const MAX_BET = { low: 50000, medium: 10000, high: 1000 };
@@ -66,6 +67,7 @@ class PlinkoGameController {
             if (credited) balanceAfter = credited.walletBalance;
         }
         const payoutFailed = payout > 0 && !credited;
+        liveFeed.publish({ game: "plinko", user: player, bet: betAmount, payout });
 
         const updatedUserData = {
             walletBalance: balanceAfter,

--- a/backend/games/slot.js
+++ b/backend/games/slot.js
@@ -2,6 +2,7 @@ const { chargeUser, creditUser, TX } = require("../utils/economy");
 const seeds = require("../utils/seeds");
 const rolls = require("../utils/rolls");
 const { rollFloat, TOTAL } = require("../utils/provablyFair");
+const liveFeed = require("../utils/liveFeed");
 
 const SLOT_ALGO_VERSION = 1; // bump if the symbol pool or paytable changes
 
@@ -44,6 +45,7 @@ class SlotGameController {
         }
 
         const totalPayout = calculateTotalPayout(winResults);
+        liveFeed.publish({ game: "slots", user: player, bet: betAmount, payout: totalPayout });
 
         // pay out winnings atomically
         let balanceAfter = player.walletBalance;

--- a/backend/index.js
+++ b/backend/index.js
@@ -83,6 +83,7 @@ const { sweepMinesGames } = require("./games/mines");
 const { sweepHiloGames } = require("./games/hilo");
 const { sweepSettlements } = require("./utils/predictionSettlement");
 const { sweepBoards } = require("./utils/leaderboard");
+const liveFeed = require("./utils/liveFeed");
 const { probeTransactions, setTransactionsSupported } = require("./utils/economy");
 const userRoutes = require("./routes/userRoutes");
 const caseRoutes = require("./routes/caseRoutes");
@@ -194,6 +195,7 @@ const sweepRounds = ({ boot = false } = {}) => {
   sweepSettlements(io).catch((e) => console.log(e));
   sweepBoards(io).catch((e) => console.log(e));
 };
+liveFeed.seed().then((n) => n && console.log(`live feed seeded: ${n} rows`)).catch(() => {});
 sweepRounds({ boot: true });
 setInterval(() => sweepRounds({ boot: false }), 5 * 60 * 1000);
 
@@ -248,6 +250,9 @@ io.use(socketAuth);
 io.on("connection", (socket) => {
   onlineUsers++;
   io.emit("onlineUsers", onlineUsers);
+
+  // the ticker is in memory, so a joiner gets what is there rather than an empty table
+  socket.emit("liveBet:recent", liveFeed.recent());
 
   // join the authenticated user's private room for targeted updates
   if (socket.userId) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -251,8 +251,12 @@ io.on("connection", (socket) => {
   onlineUsers++;
   io.emit("onlineUsers", onlineUsers);
 
-  // the ticker is in memory, so a joiner gets what is there rather than an empty table
-  socket.emit("liveBet:recent", liveFeed.recent());
+  // the ticker is in memory, so a joiner gets what is there rather than an empty table.
+  // it is also on request: the socket connects when the app boots, long before a game
+  // page mounts the table, so the connect-time copy alone always arrived to no listener.
+  const sendRecent = () => socket.emit("liveBet:recent", liveFeed.recent());
+  sendRecent();
+  socket.on("liveBet:request", sendRecent);
 
   // join the authenticated user's private room for targeted updates
   if (socket.userId) {

--- a/backend/utils/liveFeed.js
+++ b/backend/utils/liveFeed.js
@@ -1,0 +1,144 @@
+const Transaction = require("../models/Transaction");
+const User = require("../models/User");
+const realtime = require("./realtime");
+const badges = require("./badges");
+const { TX } = require("./economy");
+const { VISIBLE } = require("./visibility");
+
+// the shared bet ticker under every game canvas. it is derived, not stored: each entry is
+// broadcast at the moment a game settles, from numbers the server already holds, and kept
+// in memory. nothing is written, so this adds no rows and no growth to a database whose
+// link is the scarce resource.
+const KEEP = 50;
+const buffer = [];
+
+// one player can bet far faster than a table can be read: a dice run of 733 bets in seven
+// minutes would be every row on the board at once, on every game page. one entry per
+// player per window keeps the feed a picture of the room rather than of the busiest bot.
+const PER_USER_MS = 4000;
+const lastSeen = new Map();
+
+// the window a boot seed will reach back over. older than this is not "live", and showing
+// it as if it were is the fake-feed problem in miniature.
+const SEED_WINDOW_MS = 30 * 60 * 1000;
+
+const WIN_META = {
+  [TX.CRASH_CASHOUT]: "crash",
+  [TX.COINFLIP_WIN]: "coinflip",
+  [TX.DICE_WIN]: "dice",
+  [TX.PLINKO_WIN]: "plinko",
+  [TX.MINES_WIN]: "mines",
+  [TX.HILO_WIN]: "hilo",
+  [TX.SLOT_WIN]: "slots",
+  [TX.BLACKJACK_WIN]: "blackjack",
+};
+
+const round2 = (n) => Math.round(n * 100) / 100;
+
+// a payout of zero is a loss, which the table shows as the stake going the other way
+const entryFor = ({ game, user, userId, bet, payout }) => ({
+  id: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`,
+  at: Date.now(),
+  game,
+  userId: String(userId || user._id),
+  username: user.username,
+  profilePicture: user.profilePicture,
+  level: user.level,
+  badge: badges.wornBadge(user),
+  bet: round2(bet),
+  multiplier: bet > 0 ? round2(payout / bet) : 0,
+  payout: round2(payout),
+});
+
+const CARD = "username profilePicture level fanRank selectedBadge badges disabled";
+
+// a loss path often holds only the id. the throttle runs first, so at most one lookup per
+// player per window ever happens, and it never reads the inventory.
+async function resolveUser(user, userId) {
+  if (user && user._id) return user;
+  if (!userId) return null;
+  return User.findById(userId).select(CARD).lean();
+}
+
+// push one settled bet onto the feed and tell everyone watching. never throws and is never
+// awaited: a ticker must not be able to fail a bet that has already been paid.
+async function publish({ game, user, userId, bet, payout }) {
+  try {
+    const id = String((user && user._id) || userId || "");
+    if (!id || !(bet > 0)) return null;
+
+    const now = Date.now();
+    if (now - (lastSeen.get(id) || 0) < PER_USER_MS) return null;
+    lastSeen.set(id, now);
+
+    const doc = await resolveUser(user, userId);
+    if (!doc) return null;
+    if (doc.disabled) return null; // a banned name must not broadcast to every page
+
+    // never spread the doc: a mongoose document spreads its internals, not its fields
+    const entry = entryFor({ game, user: doc, userId: id, bet, payout });
+    buffer.unshift(entry);
+    buffer.length = Math.min(buffer.length, KEEP);
+
+    const io = realtime.getIo();
+    if (io) io.emit("liveBet", entry);
+    return entry;
+  } catch (err) {
+    console.error("liveFeed.publish failed", err);
+    return null;
+  }
+}
+
+const recent = () => buffer.slice();
+
+// fill the buffer once at boot so a restart does not leave the table blank. win rows carry
+// betAmount and a payout or a multiplier already, so the whole row rebuilds from one read.
+// losses write only a stake row and are left to live traffic, which corrects the mix
+// within a few bets.
+async function seed() {
+  try {
+    const types = Object.keys(WIN_META);
+    const rows = await Transaction.find({
+      type: { $in: types },
+      createdAt: { $gte: new Date(Date.now() - SEED_WINDOW_MS) },
+    })
+      .sort({ createdAt: -1 })
+      .limit(KEEP)
+      .select("userId type amount meta createdAt")
+      .lean();
+    if (!rows.length) return 0;
+
+    const ids = [...new Set(rows.map((r) => String(r.userId)))];
+    const users = await User.find({ _id: { $in: ids }, ...VISIBLE })
+      .select("username profilePicture level fanRank selectedBadge badges")
+      .lean();
+    const byId = new Map(users.map((u) => [String(u._id), u]));
+
+    const seeded = [];
+    for (const row of rows) {
+      const user = byId.get(String(row.userId));
+      if (!user) continue;
+      const bet = Number(row.meta && row.meta.betAmount) || 0;
+      if (!(bet > 0)) continue;
+      const payout = Number(row.meta && (row.meta.payout ?? row.meta.totalPayout)) || row.amount;
+      const entry = entryFor({ game: WIN_META[row.type], user, bet, payout });
+      entry.at = new Date(row.createdAt).getTime();
+      seeded.push(entry);
+    }
+
+    buffer.length = 0;
+    buffer.push(...seeded.slice(0, KEEP));
+    return buffer.length;
+  } catch (err) {
+    console.error("liveFeed.seed failed", err);
+    return 0;
+  }
+}
+
+// tests need a clean slate between cases
+const reset = () => {
+  buffer.length = 0;
+  lastSeen.clear();
+};
+
+module.exports = { publish, recent, seed, reset, KEEP, PER_USER_MS, SEED_WINDOW_MS };

--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -1,4 +1,5 @@
 import Title from "../Title";
+import LiveBets from "./LiveBets";
 
 interface GameLayoutProps {
   title?: string;
@@ -30,6 +31,8 @@ const GameLayout: React.FC<GameLayoutProps> = ({ title, panel, children, footer,
     </div>
 
     {footer}
+
+    <LiveBets />
   </div>
 );
 

--- a/src/components/game/LiveBets/LiveBets.services.ts
+++ b/src/components/game/LiveBets/LiveBets.services.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { LiveBet, subscribeToLiveBets } from "../../../services/liveFeed/LiveFeedService";
+
+// what the table shows at once. the server keeps more than this so a joiner is never
+// handed an empty table, but a game page only has room for a strip.
+const SHOWN = 8;
+
+export const useLiveBetsServices = () => {
+  const [rows, setRows] = useState<LiveBet[]>([]);
+
+  useEffect(() => {
+    return subscribeToLiveBets(
+      (batch) => setRows((batch || []).slice(0, SHOWN)),
+      // a row already on screen must not double up if the socket redelivers it
+      (row) => setRows((prev) => [row, ...prev.filter((r) => r.id !== row.id)].slice(0, SHOWN))
+    );
+  }, []);
+
+  return { rows };
+};

--- a/src/components/game/LiveBets/LiveBets.types.ts
+++ b/src/components/game/LiveBets/LiveBets.types.ts
@@ -1,0 +1,5 @@
+import { LiveBet } from "../../../services/liveFeed/LiveFeedService";
+
+export interface LiveBetsViewProps {
+  rows: LiveBet[];
+}

--- a/src/components/game/LiveBets/LiveBets.view.tsx
+++ b/src/components/game/LiveBets/LiveBets.view.tsx
@@ -1,0 +1,81 @@
+import Player from "../../Player";
+import Monetary from "../../Monetary";
+import { LiveBet } from "../../../services/liveFeed/LiveFeedService";
+import { LiveBetsViewProps } from "./LiveBets.types";
+import i18n from "../../../i18n";
+
+// the feed's game keys against the names the leaderboard already translates, so one
+// wording covers both surfaces
+const GAME_KEY: Record<string, string> = {
+    case: "caseOpening",
+    coinflip: "coinFlip",
+    crash: "crash",
+    slots: "slots",
+    plinko: "plinko",
+    mines: "mines",
+    hilo: "hilo",
+    dice: "dice",
+    blackjack: "blackjack",
+};
+
+const TH = "px-4 py-2.5 text-left text-[11px] font-medium text-ink-muted uppercase tracking-wider";
+const TD = "px-4 py-2.5 whitespace-nowrap text-sm";
+
+const gameName = (key: string) =>
+    GAME_KEY[key] ? i18n.t(`leaderboard.games.${GAME_KEY[key]}`) : key;
+
+const Row = ({ row }: { row: LiveBet }) => {
+    const won = row.payout > row.bet;
+    return (
+        <tr>
+            <td className={`${TD} font-semibold`}>{gameName(row.game)}</td>
+            <td className="px-4 py-2">
+                <Player user={row as never} size="small" />
+            </td>
+            <td className={`${TD} tabular-nums text-ink-soft`}>
+                <Monetary value={row.bet} />
+            </td>
+            <td className={`${TD} tabular-nums text-ink-soft`}>{row.multiplier.toFixed(2)}x</td>
+            <td className={`${TD} tabular-nums font-semibold ${won ? "text-emerald-400" : "text-ink-muted"}`}>
+                {won ? <Monetary value={row.payout} /> : <>-<Monetary value={row.bet} /></>}
+            </td>
+        </tr>
+    );
+};
+
+const LiveBetsView = ({ rows }: LiveBetsViewProps) => (
+    <div className="w-full max-w-[1200px] mt-6">
+        <div className="flex items-center gap-2 px-1 pb-2">
+            <span className="w-[7px] h-[7px] bg-emerald-400" />
+            <h2 className="text-[11px] font-bold tracking-[0.14em] text-ink-muted">
+                {i18n.t("liveBets.title")}
+            </h2>
+        </div>
+        <div className="w-full overflow-x-auto bg-surface rounded-lg border border-line">
+            <table className="min-w-full divide-y divide-line">
+                <thead className="bg-surface-nav">
+                    <tr>
+                        <th className={TH}>{i18n.t("liveBets.game")}</th>
+                        <th className={TH}>{i18n.t("liveBets.player")}</th>
+                        <th className={TH}>{i18n.t("liveBets.bet")}</th>
+                        <th className={TH}>{i18n.t("liveBets.multiplier")}</th>
+                        <th className={TH}>{i18n.t("liveBets.payout")}</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-line">
+                    {rows.length ? (
+                        rows.map((row) => <Row key={row.id} row={row} />)
+                    ) : (
+                        <tr>
+                            <td colSpan={5} className="px-4 py-8 text-center text-sm text-ink-muted">
+                                {i18n.t("liveBets.empty")}
+                            </td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+        </div>
+    </div>
+);
+
+export default LiveBetsView;

--- a/src/components/game/LiveBets/LiveBets.view.tsx
+++ b/src/components/game/LiveBets/LiveBets.view.tsx
@@ -29,7 +29,9 @@ const Row = ({ row }: { row: LiveBet }) => {
     return (
         <tr>
             <td className={`${TD} font-semibold`}>{gameName(row.game)}</td>
-            <td className="px-4 py-2">
+            {/* Player centres itself, which floats the avatar into the middle of a wide
+                column and away from the header above it */}
+            <td className="px-4 py-2 [&_a>div]:justify-start">
                 <Player user={row as never} size="small" />
             </td>
             <td className={`${TD} tabular-nums text-ink-soft`}>

--- a/src/components/game/LiveBets/index.tsx
+++ b/src/components/game/LiveBets/index.tsx
@@ -1,0 +1,9 @@
+import { useLiveBetsServices } from "./LiveBets.services";
+import LiveBetsView from "./LiveBets.view";
+
+const LiveBets = () => {
+    const service = useLiveBetsServices();
+    return <LiveBetsView {...service} />;
+};
+
+export default LiveBets;

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Prognosen"
     }
+  },
+  "liveBets": {
+    "title": "LIVE-WETTEN",
+    "game": "Spiel",
+    "player": "Spieler",
+    "bet": "Einsatz",
+    "multiplier": "Multiplikator",
+    "payout": "Auszahlung",
+    "empty": "Keine Einsätze in den letzten Minuten."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Predictions"
     }
+  },
+  "liveBets": {
+    "title": "LIVE BETS",
+    "game": "Game",
+    "player": "Player",
+    "bet": "Bet",
+    "multiplier": "Multiplier",
+    "payout": "Payout",
+    "empty": "No bets in the last few minutes."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Predicciones"
     }
+  },
+  "liveBets": {
+    "title": "APUESTAS EN VIVO",
+    "game": "Juego",
+    "player": "Jugador",
+    "bet": "Apuesta",
+    "multiplier": "Multiplicador",
+    "payout": "Pago",
+    "empty": "Sin apuestas en los últimos minutos."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Prédictions"
     }
+  },
+  "liveBets": {
+    "title": "PARIS EN DIRECT",
+    "game": "Jeu",
+    "player": "Joueur",
+    "bet": "Mise",
+    "multiplier": "Multiplicateur",
+    "payout": "Gain",
+    "empty": "Aucune mise ces dernières minutes."
   }
 }

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Prediksi"
     }
+  },
+  "liveBets": {
+    "title": "TARUHAN LANGSUNG",
+    "game": "Permainan",
+    "player": "Pemain",
+    "bet": "Taruhan",
+    "multiplier": "Pengali",
+    "payout": "Pembayaran",
+    "empty": "Tidak ada taruhan dalam beberapa menit terakhir."
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Previsioni"
     }
+  },
+  "liveBets": {
+    "title": "SCOMMESSE LIVE",
+    "game": "Gioco",
+    "player": "Giocatore",
+    "bet": "Puntata",
+    "multiplier": "Moltiplicatore",
+    "payout": "Vincita",
+    "empty": "Nessuna puntata negli ultimi minuti."
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -958,5 +958,14 @@
       "blackjack": "ブラックジャック",
       "predictions": "予測"
     }
+  },
+  "liveBets": {
+    "title": "ライブベット",
+    "game": "ゲーム",
+    "player": "プレイヤー",
+    "bet": "ベット額",
+    "multiplier": "倍率",
+    "payout": "払い戻し",
+    "empty": "直近数分のベットはありません。"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -958,5 +958,14 @@
       "blackjack": "블랙잭",
       "predictions": "예측"
     }
+  },
+  "liveBets": {
+    "title": "실시간 베팅",
+    "game": "게임",
+    "player": "플레이어",
+    "bet": "베팅액",
+    "multiplier": "배수",
+    "payout": "지급액",
+    "empty": "최근 몇 분간 베팅이 없습니다."
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Previsões"
     }
+  },
+  "liveBets": {
+    "title": "APOSTAS AO VIVO",
+    "game": "Jogo",
+    "player": "Jogador",
+    "bet": "Aposta",
+    "multiplier": "Multiplicador",
+    "payout": "Pagamento",
+    "empty": "Nenhuma aposta nos últimos minutos."
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -958,5 +958,14 @@
       "blackjack": "Blackjack",
       "predictions": "Dự đoán"
     }
+  },
+  "liveBets": {
+    "title": "CƯỢC TRỰC TIẾP",
+    "game": "Trò chơi",
+    "player": "Người chơi",
+    "bet": "Tiền cược",
+    "multiplier": "Hệ số",
+    "payout": "Tiền thắng",
+    "empty": "Không có lượt cược nào trong vài phút qua."
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -958,5 +958,14 @@
       "blackjack": "21点",
       "predictions": "预测"
     }
+  },
+  "liveBets": {
+    "title": "实时投注",
+    "game": "游戏",
+    "player": "玩家",
+    "bet": "投注额",
+    "multiplier": "倍率",
+    "payout": "派彩",
+    "empty": "最近几分钟没有投注。"
   }
 }

--- a/src/pages/Slot/Slot.tsx
+++ b/src/pages/Slot/Slot.tsx
@@ -12,6 +12,7 @@ import i18n from "../../i18n";
 import { useSessionStats } from "../../stats/SessionStatsContext";
 import GameBar from "../../components/game/GameBar";
 import LiveStatsButton from "../../components/LiveStats/LiveStatsButton";
+import LiveBets from "../../components/game/LiveBets";
 // import { RotatingLines } from "react-loader-spinner";
 
 const renderPlaceholder = () => {
@@ -201,6 +202,10 @@ const Slots = () => {
                     <LiveStatsButton />
                 </GameBar>
             </div >
+
+            <div className="w-full flex justify-center px-3 sm:px-4 pb-10">
+                <LiveBets />
+            </div>
         </div>
 
     );

--- a/src/services/liveFeed/LiveFeedService.ts
+++ b/src/services/liveFeed/LiveFeedService.ts
@@ -15,16 +15,26 @@ export interface LiveBet {
 }
 
 // the feed is broadcast, never fetched: the server holds the last rows in memory and hands
-// them over on connect, so nothing here polls and nothing is stored.
+// them over on request, so nothing here polls and nothing is stored.
 export const subscribeToLiveBets = (
   onBatch: (rows: LiveBet[]) => void,
   onOne: (row: LiveBet) => void
 ) => {
   const socket = SocketConnection.getInstance();
+  // the socket is already connected by the time a game page mounts, so the copy the
+  // server sends on connect arrives to no listener. ask for it, and again on a reconnect.
+  const ask = () => socket.emit("liveBet:request");
+
   socket.on("liveBet:recent", onBatch);
   socket.on("liveBet", onOne);
+  socket.on("connect", ask);
+  ask();
+
   return () => {
     socket.off("liveBet:recent", onBatch);
     socket.off("liveBet", onOne);
+    // by handler, never the bare event: the socket is a singleton and App listens on
+    // connect too
+    socket.off("connect", ask);
   };
 };

--- a/src/services/liveFeed/LiveFeedService.ts
+++ b/src/services/liveFeed/LiveFeedService.ts
@@ -1,0 +1,30 @@
+import SocketConnection from "../socket";
+
+export interface LiveBet {
+  id: string;
+  at: number;
+  game: string;
+  userId: string;
+  username: string;
+  profilePicture: string;
+  level: number;
+  badge: { key: string; label?: string | null; note?: string | null } | null;
+  bet: number;
+  multiplier: number;
+  payout: number;
+}
+
+// the feed is broadcast, never fetched: the server holds the last rows in memory and hands
+// them over on connect, so nothing here polls and nothing is stored.
+export const subscribeToLiveBets = (
+  onBatch: (rows: LiveBet[]) => void,
+  onOne: (row: LiveBet) => void
+) => {
+  const socket = SocketConnection.getInstance();
+  socket.on("liveBet:recent", onBatch);
+  socket.on("liveBet", onOne);
+  return () => {
+    socket.off("liveBet:recent", onBatch);
+    socket.off("liveBet", onOne);
+  };
+};


### PR DESCRIPTION
## What

A shared table of what everyone is playing, on every game page, so a dice player also sees plinko and mines going.

## Cost

Nothing is stored. Rows are broadcast at settle time from numbers the server already holds and kept in a 50 entry ring buffer in memory.

| | |
|---|---|
| New writes per bet | 0 |
| New collections | 0 |
| Queries at runtime | 0 |
| Queries at boot | 1 |

A joiner gets the buffer on connect. One boot query rebuilds it from win rows already in the ledger, so a restart does not leave the table blank. Rows older than 30 minutes are not seeded.

One entry per player per 4 seconds. Without it, a dice run of 733 bets in seven minutes would be every row on the board. The throttle runs before any user lookup, so a loss path holding only an id costs at most one small projected read per player per window. The lookup never touches inventory.

Disabled accounts never reach the feed. `publish` never throws and is never awaited, so a ticker cannot fail a bet that was already paid.

## Scope

Blackjack, dice, hilo, mines and plinko via `GameLayout`, plus slots. Crash and coin flip keep their own round tables instead of carrying two lists. Upgrade stakes items, not KP. A free case open is a gift and drops out.

## Tests

Backend 1124 across 110 suites, 13 new. Frontend unit 181, e2e 45, lint and build clean.