### PR TITLE
fix(games): fit the board on a short screen, and stop the ticker spoiling bets

### DIFF
--- a/backend/__tests__/integration/liveFeed.test.js
+++ b/backend/__tests__/integration/liveFeed.test.js
@@ -48,6 +48,44 @@ describe("the live bet ticker", () => {
     expect(liveFeed.recent()).toEqual([entry]);
   });
 
+test("a row waits for the animation that reveals it, or the table spoils the bet", async () => {
+    // the plinko ball is still falling when the server settles: listing the payout now
+    // tells the player the result before their own screen does
+    const user = await makeUser();
+    const emitted = captureIo();
+
+    const entry = await liveFeed.publish({ game: "plinko", user, bet: 100, payout: 800 });
+
+    expect(entry).toBeTruthy();
+    expect(emitted).toHaveLength(0);
+    expect(liveFeed.recent()).toHaveLength(0);
+  });
+
+  test("and lands once the reveal is over", async () => {
+    const user = await makeUser();
+    const emitted = captureIo();
+
+    await liveFeed.publish({ game: "plinko", user, bet: 100, payout: 800, revealMs: 40 });
+    expect(liveFeed.recent()).toHaveLength(0);
+
+    await new Promise((r) => setTimeout(r, 90));
+    expect(liveFeed.recent()).toHaveLength(1);
+    expect(emitted).toHaveLength(1);
+  });
+
+  test("an instant game is not held back", async () => {
+    const user = await makeUser();
+    await liveFeed.publish({ game: "dice", user, bet: 100, payout: 0 });
+    expect(liveFeed.recent()).toHaveLength(1);
+  });
+
+  test("every animated game is covered, and nothing else is delayed", async () => {
+    expect(liveFeed.REVEAL_MS).toEqual({ case: 7500, plinko: 3200, slots: 3000, blackjack: 1200 });
+    for (const instant of ["dice", "mines", "hilo", "crash", "coinflip"]) {
+      expect(liveFeed.REVEAL_MS[instant]).toBeUndefined();
+    }
+  });
+
   test("writes nothing to the database", async () => {
     const user = await makeUser();
     const before = await Transaction.countDocuments({});

--- a/backend/utils/liveFeed.js
+++ b/backend/utils/liveFeed.js
@@ -33,6 +33,17 @@ const WIN_META = {
   [TX.BLACKJACK_WIN]: "blackjack",
 };
 
+// a row must not reach the table before the animation that reveals it has finished, or
+// the ticker spoils the player's own bet: their plinko ball is still falling while the
+// payout is already listed. these match each game's own reveal, which the client and the
+// balance emit already wait out.
+const REVEAL_MS = {
+  case: 7500, // the opening roulette, the same wait App.tsx gives the drop ticker
+  plinko: 3200, // the ball drop, the same wait games/plinko.js gives the balance
+  slots: 3000, // the reels
+  blackjack: 1200, // the dealer reveal, SETTLE_EMIT_DELAY_MS
+};
+
 const round2 = (n) => Math.round(n * 100) / 100;
 
 // a payout of zero is a loss, which the table shows as the stake going the other way
@@ -60,9 +71,19 @@ async function resolveUser(user, userId) {
   return User.findById(userId).select(CARD).lean();
 }
 
+const commit = (entry) => {
+  buffer.unshift(entry);
+  buffer.length = Math.min(buffer.length, KEEP);
+  const io = realtime.getIo();
+  if (io) io.emit("liveBet", entry);
+};
+
 // push one settled bet onto the feed and tell everyone watching. never throws and is never
 // awaited: a ticker must not be able to fail a bet that has already been paid.
-async function publish({ game, user, userId, bet, payout }) {
+//
+// `revealMs` overrides the wait, so a test runs in milliseconds rather than sitting out a
+// ball drop, the same reason the crash and coin flip loops take their timings as arguments.
+async function publish({ game, user, userId, bet, payout, revealMs }) {
   try {
     const id = String((user && user._id) || userId || "");
     if (!id || !(bet > 0)) return null;
@@ -77,11 +98,14 @@ async function publish({ game, user, userId, bet, payout }) {
 
     // never spread the doc: a mongoose document spreads its internals, not its fields
     const entry = entryFor({ game, user: doc, userId: id, bet, payout });
-    buffer.unshift(entry);
-    buffer.length = Math.min(buffer.length, KEEP);
 
-    const io = realtime.getIo();
-    if (io) io.emit("liveBet", entry);
+    const wait = revealMs === undefined ? REVEAL_MS[game] || 0 : revealMs;
+    if (!wait) {
+      commit(entry);
+      return entry;
+    }
+    const timer = setTimeout(() => commit(entry), wait);
+    if (timer.unref) timer.unref(); // never hold the event loop open
     return entry;
   } catch (err) {
     console.error("liveFeed.publish failed", err);
@@ -141,4 +165,4 @@ const reset = () => {
   lastSeen.clear();
 };
 
-module.exports = { publish, recent, seed, reset, KEEP, PER_USER_MS, SEED_WINDOW_MS };
+module.exports = { publish, recent, seed, reset, KEEP, PER_USER_MS, SEED_WINDOW_MS, REVEAL_MS };

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -273,3 +273,22 @@ test("the games menu closes on escape", async ({ page }) => {
   await page.keyboard.press("Escape");
   await expect(page.getByRole("link", { name: "Mines", exact: true })).toHaveCount(0);
 });
+
+// a 1366x768 laptop is the resolution the mines board used to run off the bottom of:
+// every board is sized from its width, and nothing asked how much height was left
+test("a game board fits a short screen without scrolling", async ({ page }) => {
+  // 768 minus the browser's own chrome is roughly what the page actually gets
+  await page.setViewportSize({ width: 1366, height: 678 });
+
+  for (const game of ["mines", "plinko", "blackjack"]) {
+    await page.goto(`/${game}`);
+    const shell = page.locator("div.rounded-lg.border.border-line").first();
+    await expect(shell).toBeVisible();
+
+    const box = await shell.boundingBox();
+    const viewport = page.viewportSize();
+    expect(
+      { game, overflow: Math.max(0, Math.round(box!.y + box!.height - viewport!.height)) }
+    ).toEqual({ game, overflow: 0 });
+  }
+});

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -6,7 +6,7 @@ interface TitleProps {
 
 const Title: React.FC<TitleProps> = ({ title, compact = false }) => {
   return (
-    <div className={`w-fit ${compact ? "pb-4" : "py-10"}`}>
+    <div className={`w-fit ${compact ? "pb-4 short:pb-1" : "py-10 short:py-4"}`}>
       <div className="text-white w-auto text-3xl font-semibold">
         {title.toUpperCase()}
       </div>

--- a/src/components/game/GameLayout.tsx
+++ b/src/components/game/GameLayout.tsx
@@ -15,15 +15,21 @@ interface GameLayoutProps {
 // the board comes first on phones, so the game is on screen without scrolling past a tall
 // stack of controls to reach it.
 const GameLayout: React.FC<GameLayoutProps> = ({ title, panel, children, footer, bar }) => (
-  <div className="w-full flex flex-col items-center gap-6 px-3 sm:px-4 pt-4 pb-10">
-    {title && <Title title={title} compact />}
+  <div className="w-full flex flex-col items-center gap-6 short:gap-3 px-3 sm:px-4 pt-4 short:pt-2 pb-10">
+    {/* the board is what a short screen has no room for, and the page title is the
+        cheapest 56px to give back: the tab and the panel already say which game it is */}
+    {title && (
+      <div className="short:hidden">
+        <Title title={title} compact />
+      </div>
+    )}
 
     <div className="w-full max-w-[1200px] flex flex-col bg-surface rounded-lg overflow-hidden border border-line">
       <div className="flex flex-col-reverse lg:flex-row">
-        <div className="w-full lg:w-[320px] shrink-0 flex flex-col gap-3 p-4 sm:p-5 border-t lg:border-t-0 lg:border-r border-line">
+        <div className="w-full lg:w-[320px] shrink-0 flex flex-col gap-3 short:gap-2 p-4 sm:p-5 short:p-3 border-t lg:border-t-0 lg:border-r border-line">
           {panel}
         </div>
-        <div className="flex-1 min-w-0 flex items-center justify-center p-3 sm:p-6">
+        <div className="flex-1 min-w-0 flex items-center justify-center p-3 sm:p-6 short:p-2">
           {children}
         </div>
       </div>

--- a/src/pages/Blackjack/Blackjack.view.tsx
+++ b/src/pages/Blackjack/Blackjack.view.tsx
@@ -296,9 +296,9 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
         </>
       }
     >
-      <div className="w-full rounded-lg p-4 sm:p-8 flex flex-col items-center justify-between min-h-[460px] sm:min-h-[540px] [background:radial-gradient(ellipse_at_50%_-20%,#2a2650_0%,#1a1830_55%,#151225_100%)]">
+      <div className="w-full rounded-lg p-4 sm:p-8 short:p-3 flex flex-col items-center justify-between min-h-[460px] sm:min-h-[540px] short:min-h-0 short:max-h-[calc(100svh_-_340px)] [background:radial-gradient(ellipse_at_50%_-20%,#2a2650_0%,#1a1830_55%,#151225_100%)]">
           {/* dealer */}
-          <div className="flex flex-col items-center min-h-[170px] justify-start">
+          <div className="flex flex-col items-center min-h-[170px] short:min-h-[120px] justify-start">
             {hand ? (
               <CardFan
                 key={hand.handId}
@@ -317,7 +317,7 @@ const BlackjackView: React.FC<BlackjackViewProps> = ({
           <Ribbon />
 
           {/* player: one fan per hand, the active split hand highlighted */}
-          <div className="flex flex-col items-center min-h-[190px] justify-start">
+          <div className="flex flex-col items-center min-h-[190px] short:min-h-[130px] justify-start">
             {hand ? (
               <div className="flex gap-8 sm:gap-12 items-start">
                 {hand.hands.map((h, i) => {

--- a/src/pages/Mines/Mines.view.tsx
+++ b/src/pages/Mines/Mines.view.tsx
@@ -195,7 +195,7 @@ const MinesView: React.FC<MinesViewProps> = ({
             ))}
           </div>
 
-          <div className="grid grid-cols-5 gap-2 sm:gap-3 max-w-[560px] mx-auto w-full">
+          <div className="grid grid-cols-5 gap-2 sm:gap-3 short:gap-1.5 max-w-[560px] short:max-w-[min(560px,calc(100svh_-_340px))] mx-auto w-full">
             {Array.from({ length: TILES }).map((_, tile) => {
               const face = tileFace(tile);
               const clickable = active && !busy && face.kind === "covered" && mode === "manual";

--- a/src/pages/Plinko/Plinko.view.tsx
+++ b/src/pages/Plinko/Plinko.view.tsx
@@ -206,7 +206,7 @@ const PlinkoView: React.FC<PlinkoViewProps> = ({
         ))}
       </div>
 
-      <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[680px]">
+      <svg viewBox={`0 0 ${BOARD_W} ${BOARD_H}`} className="w-full max-w-[680px] short:w-auto short:max-h-[calc(100svh_-_340px)]">
         <PegField />
 
         {Array.from({ length: BINS }, (_, k) => {

--- a/src/pages/Slot/Slot.tsx
+++ b/src/pages/Slot/Slot.tsx
@@ -152,7 +152,7 @@ const Slots = () => {
     }
 
     return (
-        <div className='w-full flex justify-center -mt-10'>
+        <div className='w-full flex flex-col items-center -mt-10'>
             {
                 openBigWin && <BigWinAlert value={response?.totalPayout || 0} />
             }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,13 @@ module.exports = {
 
   theme: {
     extend: {
+      // every other responsive class here is about width, but a game board running off
+      // the bottom of a 1366x768 laptop is a height problem: the board is sized from its
+      // width and never asked how much room it had. `short` is the missing axis.
+      screens: {
+        short: { raw: "(max-height: 800px)" },
+      },
+
       // one ordering for everything that can cover something else. the site has had three
       // separate incidents from picking a number inline: the category bar over the login
       // form, the leaderboard over the category bar, each fix breaking the next thing.


### PR DESCRIPTION
## Problem

Two things on the game pages.

**The board runs off a 1366x768 laptop.** Measured against 678px of page after browser chrome: mines overflows 259px, plinko 267, blackjack 195. Every board is sized from its width only. Mines is `grid-cols-5 max-w-[560px]` with square tiles, plinko is an svg with a viewBox. Neither asks how much height is left.

**The live ticker spoiled the bet.** It listed a row the moment the server settled, which is before the player's own screen shows the result: their plinko ball is still falling while the payout is already on the board under it.

## Change

A `short` screen in tailwind, `(max-height: 800px)`. Every other responsive class in the repo is width based, which is the axis this problem is not on. On a short viewport the shell gives back its padding, the page title hides, and each board is bounded by height as well as width. The panel drove the row height on mines rather than the board, so it tightens too. A tall screen is untouched: measured at 990px of page, the boards are the same size as before.

Each animated game now holds its ticker row until the reveal is over, matching the delay the client already uses: cases 7500ms, plinko 3200, slots 3000, blackjack 1200. Dice, mines, hi-lo, crash and coin flip reveal as they settle.

Also fixes the ticker on slots, which rendered beside the machine instead of under it because the wrapper it went into is a flex row.

## Tests

Backend 1131 across 110 suites, 4 new. New e2e case asserts the shell fits at 1366x678 for mines, plinko and blackjack; against the previous layout it reports 323px of overflow. Frontend unit 181, e2e 46, lint and build clean.