### PR TITLE
fix(games): link a ticker row to the right profile

### DIFF
--- a/backend/utils/liveFeed.js
+++ b/backend/utils/liveFeed.js
@@ -51,7 +51,9 @@ const entryFor = ({ game, user, userId, bet, payout }) => ({
   id: `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`,
   at: Date.now(),
   game,
-  userId: String(userId || user._id),
+  // _id, not userId: this row is handed straight to the Player component, which links
+  // and renders the avatar off _id
+  _id: String(userId || user._id),
   username: user.username,
   profilePicture: user.profilePicture,
   level: user.level,

--- a/src/components/game/LiveBets/LiveBets.view.test.tsx
+++ b/src/components/game/LiveBets/LiveBets.view.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import LiveBetsView from "./LiveBets.view";
+import { LiveBet } from "../../../services/liveFeed/LiveFeedService";
+
+const row = (over: Partial<LiveBet> = {}): LiveBet => ({
+  id: "r1",
+  at: Date.now(),
+  game: "dice",
+  _id: "u123",
+  username: "player-one",
+  profilePicture: "",
+  level: 10,
+  badge: null,
+  bet: 100,
+  payout: 250,
+  multiplier: 2.5,
+  ...over,
+});
+
+const draw = (rows: LiveBet[]) =>
+  render(
+    <MemoryRouter>
+      <LiveBetsView rows={rows} />
+    </MemoryRouter>
+  );
+
+describe("the live bet ticker", () => {
+  it("links a row to the player's profile", () => {
+    // the row is handed to Player, which links on _id. it carried userId, so every row
+    // in the table pointed at /profile/undefined.
+    draw([row()]);
+
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe("/profile/u123");
+    expect(link.getAttribute("href")).not.toContain("undefined");
+  });
+
+  it("shows a win as its payout and a loss as the stake going the other way", () => {
+    const { container } = draw([
+      row({ id: "w", payout: 250 }),
+      row({ id: "l", payout: 0, multiplier: 0 }),
+    ]);
+
+    const payouts = [...container.querySelectorAll("tbody tr")].map(
+      (tr) => tr.lastElementChild?.textContent?.replace(/\s/g, "") ?? ""
+    );
+    expect(payouts[0]).toMatch(/^K₽250$/);
+    expect(payouts[1]).toMatch(/^-K₽100$/);
+  });
+
+  it("says so when nothing has been bet lately", () => {
+    draw([]);
+    expect(screen.getByText(/no bets|nenhuma aposta/i)).toBeTruthy();
+  });
+});

--- a/src/services/liveFeed/LiveFeedService.ts
+++ b/src/services/liveFeed/LiveFeedService.ts
@@ -4,7 +4,8 @@ export interface LiveBet {
   id: string;
   at: number;
   game: string;
-  userId: string;
+  // named _id because the row is passed to Player, which links on _id
+  _id: string;
   username: string;
   profilePicture: string;
   level: number;


### PR DESCRIPTION
## Problem

Every row in the live bets table linked to `/profile/undefined`.

The row is handed straight to `Player`, which links and draws the avatar off `_id`. The row carried the id as `userId`.

The view passes the row as `never`, so typescript could not see the field was missing.

## Change

Renamed the field to `_id`, which is what every other payload handed to `Player` already uses.

## Tests

A component test asserts the href, since the cast is what let this through. The leaderboard passes a standing the same way and works only because a standing already happens to carry `_id`.

Backend 1131 across 110 suites, frontend unit 184, e2e 46, lint and build clean.