### PR TITLE
fix(leaderboard): stop holding a screen open when the board has reset

### DIFF
--- a/src/pages/Home/Leaderboard/Leaderboard.view.test.tsx
+++ b/src/pages/Home/Leaderboard/Leaderboard.view.test.tsx
@@ -45,6 +45,9 @@ const props = (over: Partial<LeaderboardViewProps> = {}): LeaderboardViewProps =
   ...over,
 });
 
+// attribute match, so the arbitrary-value class needs no css escaping
+const SPACER = '[class*="h-[330px]"]';
+
 const draw = (over: Partial<LeaderboardViewProps> = {}) =>
   render(
     <MemoryRouter>
@@ -93,5 +96,39 @@ describe("the daily leaderboard", () => {
       (row) => row.querySelector("td")?.textContent
     );
     expect(ranks).toEqual(["#2", "#3", "#4", "#5"]);
+  });
+
+  it("holds no space open when the board has just reset", () => {
+    // it reserved a 330px placeholder whenever it had fewer than three players, so a
+    // freshly reset board was a screenful of nothing above an empty table
+    const { container } = draw({ podium: [], rest: [], podiumRest: [], me: null });
+
+    expect(container.querySelector(SPACER)).toBeNull();
+    expect(screen.getByText(/no bets yet/i)).toBeTruthy();
+  });
+
+  it("still draws the podium with only one or two players on it", () => {
+    // the old condition was >= 3, so a board with two players drew neither of them
+    const two = [standings[0], standings[1]];
+    const { container } = draw({ podium: [two[1], two[0]], rest: [], podiumRest: [two[1]] });
+
+    expect(container.querySelectorAll("img[src=\"images/podium.svg\"]")).toHaveLength(2);
+    expect(screen.getAllByText("first").length).toBeGreaterThan(0);
+  });
+
+  it("does not tell a player who has not bet how far they are off tenth", () => {
+    draw({
+      podium: [], rest: [], podiumRest: [],
+      me: { _id: "u9", points: 0, bets: 0, rank: null, toPaidPlace: 1, prize: 0 },
+      meOnBoard: false,
+    });
+
+    expect(screen.queryByText(/points from/i)).toBeNull();
+    expect(screen.getByText("You")).toBeTruthy();
+  });
+
+  it("keeps the placeholder while it is still loading, so the page does not jump", () => {
+    const { container } = draw({ loading: true, podium: [], rest: [], podiumRest: [] });
+    expect(container.querySelector(SPACER)).toBeTruthy();
   });
 });

--- a/src/pages/Home/Leaderboard/Leaderboard.view.tsx
+++ b/src/pages/Home/Leaderboard/Leaderboard.view.tsx
@@ -62,7 +62,9 @@ const YourRow = ({ me, paidPlaces }: { me: NonNullable<LeaderboardViewProps["me"
         <td className="px-6 py-4 whitespace-nowrap">{me.rank ? `#${me.rank}` : "-"}</td>
         <td className="p-4">
             <span className="font-bold">{i18n.t("leaderboard.you")}</span>
-            {me.toPaidPlace > 0 && (
+            {/* gated on rank: a player who has not bet today is not "1 point from 10th",
+                they are simply not on the board yet */}
+            {me.rank !== null && me.toPaidPlace > 0 && (
                 <span className="block tabular-nums text-xs text-ink-muted">
                     {i18n.t("leaderboard.fromPlace", { points: num(me.toPaidPlace), place: paidPlaces })}
                 </span>
@@ -204,20 +206,25 @@ const LeaderboardView = ({
                     </div>
                 )}
 
-                {!loading && podium.length >= 3 ? (
+                {/* the podium used to hold 330px open whenever it had fewer than three
+                    players, so a board that had just reset was a screen of nothing. it
+                    also drew nobody at one or two players, who then appeared on no
+                    surface at all. */}
+                {loading && <div className="h-[330px]" />}
+                {!loading && podium.length > 0 && (
                     <div className="flex gap-4 md:gap-6 xl:gap-14 my-16">
                         {podium.map((user) => (
                             <TopPlayer key={user._id} user={user} rank={user.rank} />
                         ))}
                     </div>
-                ) : (
-                    <div className="h-[330px]" />
                 )}
             </div>
 
             <div className="w-full min-w-0 overflow-x-auto lg:col-start-2 lg:row-start-2">
                 <table className="min-w-full divide-y divide-gray-500">
-                    <thead className="bg-[#19172d]">
+                    {/* column headings over an empty table say nothing: the message below
+                        is the whole content when the board has just reset */}
+                    <thead className={`bg-[#19172d] ${!loading && !podium.length && !me ? "hidden" : ""}`}>
                         <tr>
                             <th className={TH}>{i18n.t("leaderboard.rank")}</th>
                             <th className={TH}>{i18n.t("leaderboard.player")}</th>


### PR DESCRIPTION
## Problem

The podium reserved a fixed 330px whenever it had fewer than three players, so a board that had just reset showed a screenful of nothing above an empty table. The placeholder is inherited from the old weekly board, where it was a never-filled "put a skeleton here".

The same condition drew no podium at all with one or two players. They sit above the table's fourth-place cut and below the podium's threshold of three, so on a wide screen they appeared nowhere.

A player who had not bet was told they were "1 points from #10", which is what the gap works out to against an empty board.

## Change

The placeholder is held only while loading, so the page still does not jump, and nothing is drawn once an empty board arrives. Column headings hide over a table with no rows. The podium draws whatever it has. The "points from" line is gated on having a rank.

## Tests

Four new component cases. Three fail against the previous version: no reserved space on an empty board, a podium with two players, and no "points from" line for a player who has not bet.

Frontend unit 188, e2e 46, lint and build clean.