### PR TITLE
feat(bot): sign every message with the site, and make /open ask for the series first

### DIFF
--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -266,6 +266,7 @@ const commands = [
             [
               `**KaniCasino** is a fake-coin casino where you open cases, collect characters and fight for their fan boards.`,
               "",
+              "`/open` open a case. Leave the box empty and it asks for a series first, then a case",
               "`/link` attach your account, once",
               "`/showcase` your pinned character and standing",
               "`/topfan` who in this server collects a character hardest",

--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -167,39 +167,13 @@ const commands = [
     },
   },
   {
-    data: new SlashCommandBuilder()
-      .setName("open")
-      .setDescription("Open a case")
-      .addStringOption((option) =>
-        option
-          .setName("case")
-          .setDescription("Which case. Leave it empty to pick from a menu.")
-          .setRequired(false)
-          .setAutocomplete(true)
-      ),
-    // 64 cases is well past discord's 25 choice cap, so the list is filtered server side.
-    // an empty box leads with whatever this player opened last.
-    async autocomplete(interaction) {
-      const typed = interaction.options.getFocused();
-      const { cases } = await api.cases(typed, interaction.user.id);
-      await interaction.respond(
-        cases.map((one) => ({
-          // the series is on the label because the titles do not carry it, so a row reads
-          // as "Lunatic Case · Touhou" rather than leaving the player to know which is which
-          name: [one.title, one.category, `K₽ ${one.price.toLocaleString("en-US")}`]
-            .filter(Boolean)
-            .join("  ·  ")
-            .slice(0, 100),
-          value: String(one.id),
-        }))
-      );
-    },
+    // no option, deliberately. an optional autocomplete argument is not optional in
+    // practice: discord opens its dropdown the moment the field takes focus, so the flat
+    // list of every case was the first thing a player saw and the series menu below was
+    // only reachable by submitting a box you had been invited to fill.
+    data: new SlashCommandBuilder().setName("open").setDescription("Open a case"),
     async run(interaction) {
-      const caseId = interaction.options.getString("case");
-      // no case named is not an error: it is the menu, which is the whole point of not
-      // making a player know a case id before they can open one
-      if (!caseId) return interaction.reply(await seriesMenu());
-      await runOpen(interaction, caseId);
+      await interaction.reply(await seriesMenu());
     },
   },
   {
@@ -266,7 +240,7 @@ const commands = [
             [
               `**KaniCasino** is a fake-coin casino where you open cases, collect characters and fight for their fan boards.`,
               "",
-              "`/open` open a case. Leave the box empty and it asks for a series first, then a case",
+              "`/open` open a case: pick a series, then a case",
               "`/link` attach your account, once",
               "`/showcase` your pinned character and standing",
               "`/topfan` who in this server collects a character hardest",

--- a/bot/src/embeds.js
+++ b/bot/src/embeds.js
@@ -1,6 +1,10 @@
 const { EmbedBuilder } = require("discord.js");
 
 const SITE = (process.env.SITE_URL || "https://kanicasino.com").replace(/\/$/, "");
+// the domain, derived rather than typed, so a staging SITE_URL never signs itself as
+// production. every message the bot sends carries it: a link button with no visible
+// destination is what makes a bot look like a scam.
+const HOST = SITE.replace(/^https?:\/\//, "");
 
 // the same five the site paints items with, so a card in discord reads as the same object
 const RARITY = {
@@ -25,7 +29,7 @@ function showcaseEmbed(card) {
     .setColor(colorOf(card.pinned && card.pinned.rarity))
     .setTitle(card.username)
     .setURL(profileUrl(card))
-    .setFooter({ text: "kanicasino.com" });
+    .setFooter({ text: HOST });
 
   if (card.profilePicture) embed.setThumbnail(card.profilePicture);
 
@@ -67,7 +71,7 @@ function topFanEmbed(board, guildName) {
     .setColor(colorOf(board.rarity))
     .setTitle(`Top ${board.name} fan in ${guildName}`)
     .setURL(boardUrl(board.name))
-    .setFooter({ text: "kanicasino.com" });
+    .setFooter({ text: HOST });
 
   if (board.image) embed.setThumbnail(board.image);
 
@@ -98,7 +102,7 @@ function leaderboardEmbed(payload, guildName) {
     .setColor(NEUTRAL)
     .setTitle(byCollection ? `Biggest collections in ${guildName}` : `Highest levels in ${guildName}`)
     .setURL(SITE)
-    .setFooter({ text: "kanicasino.com" });
+    .setFooter({ text: HOST });
 
   if (!payload.players.length) {
     embed.setDescription("Nobody here has linked an account yet. Run `/link` to be the first.");
@@ -132,9 +136,10 @@ function linkEmbed(link) {
         "No account yet? Sign up on that page first, then the same link finishes the job.",
       ].join("\n")
     )
-    .setFooter({ text: "kanicasino.com" });
+    .setFooter({ text: HOST });
 }
 
-const noticeEmbed = (text) => new EmbedBuilder().setColor(NEUTRAL).setDescription(text);
+const noticeEmbed = (text) =>
+  new EmbedBuilder().setColor(NEUTRAL).setDescription(text).setFooter({ text: HOST });
 
-module.exports = { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE };
+module.exports = { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE, HOST };

--- a/bot/src/menu.js
+++ b/bot/src/menu.js
@@ -9,7 +9,7 @@ const {
   StringSelectMenuOptionBuilder,
   TextDisplayBuilder,
 } = require("discord.js");
-const { SITE, colorOf } = require("./spin");
+const { SITE, HOST, colorOf, sign } = require("./spin");
 
 // discord's own ceiling on a select, and the same number the backend pages by
 const PER_PAGE = 25;
@@ -51,8 +51,10 @@ function categoryFrame(categories) {
     .addSeparatorComponents(new SeparatorBuilder());
 
   if (!categories.length) {
-    return container.addTextDisplayComponents(
-      new TextDisplayBuilder().setContent("No cases are open in Discord right now.")
+    return sign(
+      container.addTextDisplayComponents(
+        new TextDisplayBuilder().setContent("No cases are open in Discord right now.")
+      )
     );
   }
 
@@ -68,7 +70,7 @@ function categoryFrame(categories) {
       )
     );
 
-  return container.addActionRowComponents(row(select));
+  return sign(container.addActionRowComponents(row(select)));
 }
 
 function caseFrame({ category, cases, total, offset }) {
@@ -124,17 +126,21 @@ function caseFrame({ category, cases, total, offset }) {
         .setStyle(ButtonStyle.Secondary)
     );
   }
-  controls.push(new ButtonBuilder().setLabel("See them on the site").setStyle(ButtonStyle.Link).setURL(SITE));
+  controls.push(
+    new ButtonBuilder().setLabel(`See them on ${HOST}`).setStyle(ButtonStyle.Link).setURL(SITE)
+  );
 
-  return container.addActionRowComponents(new ActionRowBuilder().addComponents(...controls));
+  return sign(container.addActionRowComponents(new ActionRowBuilder().addComponents(...controls)));
 }
 
 // what the menu turns into once a case has been picked: the spin is its own message, so
 // leaving the select live would let a stray second pick charge for a case nobody chose
 function chosenFrame(title) {
-  return new ContainerBuilder()
-    .setAccentColor(colorOf(null))
-    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${title}** below.`));
+  return sign(
+    new ContainerBuilder()
+      .setAccentColor(colorOf(null))
+      .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${title}** below.`))
+  );
 }
 
 module.exports = {

--- a/bot/src/messages.test.js
+++ b/bot/src/messages.test.js
@@ -52,3 +52,70 @@ test("the showcase answers name the person who has to act", () => {
   assert.match(aboutYou, /^You have not/, "the caller is the one who has to act");
   assert.match(aboutYou, /\/link/);
 });
+
+// A player called the demo spin's bare "Create an account" button suspicious: nothing on
+// the message said where the account would be, or who was asking. Every message the bot
+// sends signs itself with the domain now, and the link buttons name it too.
+test("every message the bot sends carries the site it came from", () => {
+  process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+  const embeds = require("./embeds");
+  const spin = require("./spin");
+  const menu = require("./menu");
+  const host = embeds.HOST;
+
+  const item = { name: "Sakuya", rarity: "5", value: 900, image: "https://x/y.png" };
+  const card = { username: "someone", level: 3, userId: "u1" };
+
+  const built = {
+    "embeds.noticeEmbed": embeds.noticeEmbed("anything at all"),
+    "embeds.showcaseEmbed": embeds.showcaseEmbed(card),
+    "embeds.topFanEmbed": embeds.topFanEmbed({ name: "Sakuya", ranks: [] }, "a server"),
+    "embeds.leaderboardEmbed": embeds.leaderboardEmbed({ players: [] }, "a server"),
+    "embeds.linkEmbed": embeds.linkEmbed({ url: "https://x/link" }),
+    "spin.spinningFrame": spin.spinningFrame("Nuclear", [{ name: "a", rarity: "1" }], 0, false, null),
+    "spin.revealFrame": spin.revealFrame({ item, caseTitle: "Nuclear", caseId: "c1", ownerId: "u1" }),
+    "spin.demoFrame": spin.demoFrame({ item, caseTitle: "Nuclear" }),
+    "menu.categoryFrame": menu.categoryFrame([{ name: "Touhou", count: 2, from: 60 }]),
+    "menu.categoryFrame (empty)": menu.categoryFrame([]),
+    "menu.caseFrame": menu.caseFrame({
+      category: "Touhou",
+      cases: [{ id: "c1", title: "Nuclear", price: 60 }],
+      total: 1,
+      offset: 0,
+    }),
+    "menu.chosenFrame": menu.chosenFrame("Nuclear"),
+  };
+
+  const unsigned = Object.entries(built)
+    .filter(([, message]) => !JSON.stringify(message.toJSON()).includes(host))
+    .map(([name]) => name);
+
+  assert.deepStrictEqual(unsigned, [], "these go out with nothing saying where they came from");
+});
+
+test("the demo spin says where the account would be, on the button as well", () => {
+  process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+  const { demoFrame, HOST } = require("./spin");
+  const json = JSON.stringify(
+    demoFrame({ item: { name: "Sakuya", rarity: "5", value: 900 }, caseTitle: "Nuclear" }).toJSON()
+  );
+
+  assert.ok(json.includes(`Create a free account on **${HOST}**`), "the copy names the site");
+  // the label itself, because a link button showing only "Create an account" is the part
+  // that reads as a scam
+  assert.ok(json.includes(`"label":"Create an account on ${HOST}"`), "so does the button");
+});
+
+test("help lists the command the bot exists for", () => {
+  process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+  const { commands } = require("./commands");
+  const names = commands.map((command) => command.data.name);
+
+  // /open was missing from help, which is how a player came to ask for a series-then-case
+  // picker that /open has had all along
+  const source = fs.readFileSync(path.join(__dirname, "commands.js"), "utf8");
+  const help = source.slice(source.indexOf('setName("help")'));
+  for (const name of names.filter((n) => n !== "help")) {
+    assert.ok(help.includes(`\`/${name}\``), `/${name} is not in the help list`);
+  }
+});

--- a/bot/src/messages.test.js
+++ b/bot/src/messages.test.js
@@ -111,11 +111,22 @@ test("help lists the command the bot exists for", () => {
   const { commands } = require("./commands");
   const names = commands.map((command) => command.data.name);
 
-  // /open was missing from help, which is how a player came to ask for a series-then-case
-  // picker that /open has had all along
+  // /open was missing from help entirely, which is the command the bot exists for
   const source = fs.readFileSync(path.join(__dirname, "commands.js"), "utf8");
   const help = source.slice(source.indexOf('setName("help")'));
   for (const name of names.filter((n) => n !== "help")) {
     assert.ok(help.includes(`\`/${name}\``), `/${name} is not in the help list`);
   }
+});
+
+test("/open asks for a series first, with nothing to pre-empt it", () => {
+  process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+  const { commands } = require("./commands");
+  const open = commands.find((command) => command.data.name === "open");
+
+  // an optional autocomplete argument is not optional in practice: discord opens its
+  // dropdown as soon as the field takes focus, so a flat list of every case was the first
+  // thing a player saw and the series menu was only reachable by submitting an empty box
+  assert.deepStrictEqual(open.data.toJSON().options || [], [], "/open takes no options");
+  assert.strictEqual(open.autocomplete, undefined, "and answers no autocomplete");
 });

--- a/bot/src/spin.js
+++ b/bot/src/spin.js
@@ -106,13 +106,20 @@ function reelRow(strip, offset) {
 }
 
 function spinningFrame(caseTitle, strip, offset, landed, rarity) {
-  return new ContainerBuilder()
+  const container = new ContainerBuilder()
     .setAccentColor(landed ? colorOf(rarity) : SPINNING)
     .addTextDisplayComponents(new TextDisplayBuilder().setContent(`Opening **${caseTitle}**`))
     .addTextDisplayComponents(new TextDisplayBuilder().setContent(reelRow(strip, offset)));
+  return sign(container);
 }
 
 const buttons = (...rows) => new ActionRowBuilder().addComponents(...rows.filter(Boolean));
+
+// a container has no footer of its own, so the signature is a small trailing line. `-# `
+// is discord's subtext, which renders it the way an embed footer reads.
+const HOST = SITE.replace(/^https?:\/\//, "");
+const sign = (container) =>
+  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`-# ${HOST}`));
 
 // a section is only valid with an accessory, so an item carrying no art gets a plain
 // heading. building it the other way throws, and discord does not say so until a player
@@ -152,10 +159,13 @@ function revealFrame({ item, caseTitle, caseId, ownerId, fanRank }) {
   container.addActionRowComponents(
     buttons(
       new ButtonBuilder().setCustomId(`open:${caseId}:${ownerId}`).setLabel("Open another").setStyle(ButtonStyle.Primary),
-      new ButtonBuilder().setLabel("Open it on the site").setStyle(ButtonStyle.Link).setURL(`${SITE}/case/${caseId}`)
+      new ButtonBuilder()
+        .setLabel(`Open it on ${HOST}`)
+        .setStyle(ButtonStyle.Link)
+        .setURL(`${SITE}/case/${caseId}`)
     )
   );
-  return container;
+  return sign(container);
 }
 
 // the same reveal for somebody with no account, saying plainly that it was not kept
@@ -165,12 +175,19 @@ function demoFrame({ item, caseTitle }) {
   addHeading(container, item, caseTitle);
   container.addSeparatorComponents(new SeparatorBuilder());
   container.addTextDisplayComponents(
-    new TextDisplayBuilder().setContent("This was a demo spin. Create an account to keep the next rolls.")
+    new TextDisplayBuilder().setContent(
+      `This was a demo spin. Create a free account on **${HOST}** to keep the next rolls.`
+    )
   );
   container.addActionRowComponents(
-    buttons(new ButtonBuilder().setLabel("Create an account").setStyle(ButtonStyle.Link).setURL(SITE))
+    buttons(
+      new ButtonBuilder()
+        .setLabel(`Create an account on ${HOST}`)
+        .setStyle(ButtonStyle.Link)
+        .setURL(SITE)
+    )
   );
-  return container;
+  return sign(container);
 }
 
 module.exports = {
@@ -186,5 +203,7 @@ module.exports = {
   MIDDLE,
   colorOf,
   nameOf,
+  sign,
   SITE,
+  HOST,
 };

--- a/bot/src/spin.test.js
+++ b/bot/src/spin.test.js
@@ -191,7 +191,10 @@ test("the open again button carries the case and its owner", () => {
 
 test("the demo says plainly that nothing was kept, and offers the way to change that", () => {
   const json = demoFrame({ item: ITEM, caseTitle: "Touhou Case" }).toJSON();
-  assert.match(text(json), /This was a demo spin\. Create an account to keep the next rolls\./);
+  // the domain is in the copy now: a link with no visible destination is what made a
+  // player call this button suspicious
+  assert.match(text(json), /This was a demo spin\. Create a free account on/);
+  assert.match(text(json), /kanicasino\.com/);
   const link = row(json).components[0];
   assert.strictEqual(link.style, 5, "a link button, not one that charges anybody");
   assert.match(link.url, /^https:\/\//);


### PR DESCRIPTION
## Problem

A player called the demo spin's "Create an account" button suspicious. The copy never named the site and the button label sat next to a bare link, so nothing said where it went or who was asking. `noticeEmbed` was the only embed with no footer, and it is behind almost every plain reply. The spin and menu frames are containers, which have no footer at all.

Separately, `/open` never showed the series menu. It carried an optional `case` argument with autocomplete, and an optional autocomplete argument is not optional in practice: Discord opens its dropdown the moment the field takes focus, so a flat list of every case was the first thing on screen. The menu was only reachable by submitting a box you had just been invited to fill.

## Change

Every message carries the domain. Embeds get a footer, containers get a subtext line. Link buttons name the destination: "Create an account on kanicasino.com", "Open it on kanicasino.com", "See them on kanicasino.com". The domain is derived from `SITE_URL`, so a staging bot never signs itself as production.

The `case` argument is gone, so `/open` replies with the series picker and nothing pre-empts it. Paging and the back button already carried the rest of the flow. `/open` was also missing from `/help` entirely; it is listed now.

## Deploy

Discord caches command definitions. This needs `npm run register` from `bot/` after deploy, or the old argument stays on screen.

## Tests

Bot suite 44 passing, 4 new. All fail against the previous version: every message shape carries the host, the demo copy and button label name the site, every registered command appears in help, and `/open` takes no options so the shortcut cannot come back and hide the menu.