### PR TITLE
fix(bot): put the series and the case back in the command box

### DIFF
--- a/bot/src/commands.js
+++ b/bot/src/commands.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder, MessageFlags, ContainerBuilder, TextDisplayBuilder 
 const api = require("./api");
 const { showcaseEmbed, topFanEmbed, leaderboardEmbed, linkEmbed, noticeEmbed, SITE } = require("./embeds");
 const { buildStrip, spinningFrame, revealFrame, demoFrame, FRAMES, FRAME_MS } = require("./spin");
-const { categoryFrame, caseFrame, tokenOf } = require("./menu");
+const { categoryFrame, caseFrame, tokenOf, label } = require("./menu");
 
 // rejected in the bot's own memory, before any http call. spamming a command costs a map
 // lookup here rather than a query on a link that carries about 100 KB/s.
@@ -167,13 +167,73 @@ const commands = [
     },
   },
   {
-    // no option, deliberately. an optional autocomplete argument is not optional in
-    // practice: discord opens its dropdown the moment the field takes focus, so the flat
-    // list of every case was the first thing a player saw and the series menu below was
-    // only reachable by submitting a box you had been invited to fill.
-    data: new SlashCommandBuilder().setName("open").setDescription("Open a case"),
+    // two boxes, in this order, because discord focuses the first one: the dropdown that
+    // opens on its own is the series, and the case list below it is narrowed to whatever
+    // series is already in the command. one flat list of every case was the thing that
+    // made picking a case a guess.
+    data: new SlashCommandBuilder()
+      .setName("open")
+      .setDescription("Open a case")
+      .addStringOption((option) =>
+        option
+          .setName("series")
+          .setDescription("Which series")
+          .setRequired(false)
+          .setAutocomplete(true)
+      )
+      .addStringOption((option) =>
+        option
+          .setName("case")
+          .setDescription("Which case, from that series")
+          .setRequired(false)
+          .setAutocomplete(true)
+      ),
+    async autocomplete(interaction) {
+      const focused = interaction.options.getFocused(true);
+
+      if (focused.name === "series") {
+        const { categories } = await api.categories();
+        const typed = String(focused.value || "").toLowerCase();
+        await interaction.respond(
+          (categories || [])
+            .filter((one) => label(one.name).toLowerCase().includes(typed))
+            .slice(0, 25)
+            .map((one) => ({
+              name: `${label(one.name)}  ·  ${one.count} cases  ·  from K₽ ${one.from.toLocaleString("en-US")}`.slice(0, 100),
+              value: String(one.name).slice(0, 100),
+            }))
+        );
+        return;
+      }
+
+      // the series already chosen narrows this list. without one it is every case, which
+      // is the old behaviour and still the right answer for somebody who knows the name.
+      const series = interaction.options.getString("series");
+      const { cases } = await api.cases(
+        focused.value,
+        interaction.user.id,
+        series ? { category: series } : undefined
+      );
+      await interaction.respond(
+        (cases || []).slice(0, 25).map((one) => ({
+          // the series stays on the label when the box is unfiltered, since the titles do
+          // not carry it and two shelves can hold a similar name
+          name: [one.title, series ? null : one.category, `K₽ ${one.price.toLocaleString("en-US")}`]
+            .filter(Boolean)
+            .join("  ·  ")
+            .slice(0, 100),
+          value: String(one.id).slice(0, 100),
+        }))
+      );
+    },
     async run(interaction) {
-      await interaction.reply(await seriesMenu());
+      const caseId = interaction.options.getString("case");
+      if (caseId) return runOpen(interaction, caseId);
+      // a series and no case lands on that shelf; neither lands on the series menu, so
+      // the command works with nothing typed at all
+      const series = interaction.options.getString("series");
+      if (series) return interaction.reply(await casesMenu(series, 0));
+      return interaction.reply(await seriesMenu());
     },
   },
   {
@@ -240,7 +300,7 @@ const commands = [
             [
               `**KaniCasino** is a fake-coin casino where you open cases, collect characters and fight for their fan boards.`,
               "",
-              "`/open` open a case: pick a series, then a case",
+              "`/open` open a case: pick a series, then a case from it",
               "`/link` attach your account, once",
               "`/showcase` your pinned character and standing",
               "`/topfan` who in this server collects a character hardest",

--- a/bot/src/messages.test.js
+++ b/bot/src/messages.test.js
@@ -119,14 +119,63 @@ test("help lists the command the bot exists for", () => {
   }
 });
 
-test("/open asks for a series first, with nothing to pre-empt it", () => {
+// discord focuses the first option and opens its dropdown there, so the order of these
+// two boxes is the whole feature: series first, then the cases on that shelf.
+test("/open offers the series box before the case box", () => {
   process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
   const { commands } = require("./commands");
   const open = commands.find((command) => command.data.name === "open");
+  const options = open.data.toJSON().options || [];
 
-  // an optional autocomplete argument is not optional in practice: discord opens its
-  // dropdown as soon as the field takes focus, so a flat list of every case was the first
-  // thing a player saw and the series menu was only reachable by submitting an empty box
-  assert.deepStrictEqual(open.data.toJSON().options || [], [], "/open takes no options");
-  assert.strictEqual(open.autocomplete, undefined, "and answers no autocomplete");
+  assert.deepStrictEqual(
+    options.map((option) => option.name),
+    ["series", "case"],
+    "series has to come first, or discord opens the flat case list again"
+  );
+  assert.ok(options.every((option) => option.autocomplete), "both boxes suggest");
+  assert.ok(options.every((option) => !option.required), "and neither is mandatory");
+});
+
+test("the case box only offers cases from the series already chosen", async () => {
+  process.env.SITE_URL = process.env.SITE_URL || "https://kanicasino.com";
+  const api = require("./api");
+  const { commands } = require("./commands");
+  const open = commands.find((command) => command.data.name === "open");
+
+  const realCases = api.cases;
+  const realCategories = api.categories;
+  let askedFor = null;
+  api.cases = async (query, discordId, page) => {
+    askedFor = { query, page };
+    return { cases: [{ id: "c1", title: "Nuclear Case", price: 60, category: "Touhou" }] };
+  };
+  api.categories = async () => ({ categories: [{ name: "Touhou", count: 3, from: 60 }] });
+
+  const asked = (focusedName, focusedValue, series) => {
+    const sent = [];
+    return {
+      sent,
+      user: { id: "u1" },
+      options: {
+        getFocused: () => ({ name: focusedName, value: focusedValue }),
+        getString: (name) => (name === "series" ? series : null),
+      },
+      respond: async (choices) => sent.push(choices),
+    };
+  };
+
+  try {
+    const onCase = asked("case", "nuc", "Touhou");
+    await open.autocomplete(onCase);
+    assert.strictEqual(askedFor.page.category, "Touhou", "the shelf narrows the list");
+    assert.strictEqual(askedFor.query, "nuc", "and what was typed still filters it");
+    assert.strictEqual(onCase.sent[0][0].value, "c1");
+
+    const onSeries = asked("series", "tou", null);
+    await open.autocomplete(onSeries);
+    assert.strictEqual(onSeries.sent[0][0].value, "Touhou", "the series box lists shelves");
+  } finally {
+    api.cases = realCases;
+    api.categories = realCategories;
+  }
 });


### PR DESCRIPTION
## Problem

Removing the `case` argument fixed the flat list of every case, but took the inline picker with it. Typing `/open` suggested nothing, and the only way through was to submit an empty command and click a menu. That is slower than what it replaced.

## Change

`/open` takes two boxes: `series`, then `case`. Discord focuses the first option and opens its dropdown there, so the list that appears on its own is the series, and the case box below is narrowed to whatever series is already in the command.

Neither is required, so a bare `/open` still answers with the message menu, and a series with no case lands on that shelf's page. With the series box empty the case box lists everything, which is what the old argument was good for.

The backend already accepted `q` and `category` together, so no API change.

## Deploy

Discord caches command definitions. Needs `npm run register` from `bot/` after deploy.

## Tests

Bot suite 45 passing. Two new, both failing against the previous version: the options are `series` then `case` and neither is required, and the case autocomplete passes the chosen series through as a category filter while still applying what was typed.