### PR TITLE
feat(leaderboard): seat the empty rows, and drop the result banner

### DIFF
--- a/backend/__tests__/integration/leaderboard.test.js
+++ b/backend/__tests__/integration/leaderboard.test.js
@@ -270,3 +270,87 @@ describe("the sweep", () => {
     expect(await Leaderboard.countDocuments({})).toBe(1);
   });
 });
+
+describe("the empty seats", () => {
+  test("fills the board out to the paid places with players who have not bet", async () => {
+    const better = await makeUser(1000, { level: 5 });
+    for (let i = 0; i < 4; i++) await makeUser(1000, { level: 40 - i });
+    const { startsAt, endsAt } = leaderboard.windowFor();
+    await wager(better, TX.CASE_OPEN, 1000, midWindow());
+
+    const rows = await leaderboard.padStandings(
+      await leaderboard.standings(startsAt, endsAt, leaderboard.PAID_PLACES),
+      leaderboard.PAID_PLACES
+    );
+
+    // one real standing, then the rest of the field
+    expect(rows).toHaveLength(5);
+    expect(String(rows[0]._id)).toBe(String(better._id));
+    expect(rows[0].placeholder).toBeUndefined();
+    expect(rows.slice(1).every((row) => row.placeholder === true)).toBe(true);
+    expect(rows.slice(1).every((row) => row.points === 0)).toBe(true);
+    // the biggest accounts take the empty seats, so they read as names
+    expect(rows.slice(1).map((row) => row.user.level)).toEqual([40, 39, 38, 37]);
+  });
+
+  test("never seats the same player twice", async () => {
+    const better = await makeUser(1000, { level: 60 });
+    await makeUser(1000, { level: 50 });
+    const { startsAt, endsAt } = leaderboard.windowFor();
+    await wager(better, TX.CASE_OPEN, 1000, midWindow());
+
+    const rows = await leaderboard.padStandings(
+      await leaderboard.standings(startsAt, endsAt, leaderboard.PAID_PLACES),
+      leaderboard.PAID_PLACES
+    );
+
+    const ids = rows.map((row) => String(row._id));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("leaves a disabled account out of the empty seats too", async () => {
+    await makeUser(1000, { level: 90, disabled: true });
+    await makeUser(1000, { level: 10 });
+
+    const { startsAt, endsAt } = leaderboard.windowFor();
+    const rows = await leaderboard.padStandings(
+      await leaderboard.standings(startsAt, endsAt, leaderboard.PAID_PLACES),
+      leaderboard.PAID_PLACES
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].user.level).toBe(10);
+  });
+
+  test("a full board is left alone", async () => {
+    const { startsAt, endsAt } = leaderboard.windowFor();
+    for (let i = 0; i < leaderboard.PAID_PLACES; i++) {
+      const u = await makeUser(1000);
+      await wager(u, TX.CASE_OPEN, (leaderboard.PAID_PLACES - i) * 100, midWindow());
+    }
+    await makeUser(1000, { level: 99 });
+
+    const rows = await leaderboard.padStandings(
+      await leaderboard.standings(startsAt, endsAt, leaderboard.PAID_PLACES),
+      leaderboard.PAID_PLACES
+    );
+
+    expect(rows).toHaveLength(leaderboard.PAID_PLACES);
+    expect(rows.some((row) => row.placeholder)).toBe(false);
+  });
+
+  test("a seat on nought is never paid at settlement", async () => {
+    // padding is a display concern: the settle path reads standings, which drops zeroes
+    const { startsAt, endsAt } = leaderboard.windowFor(new Date(Date.now() - 86400000));
+    const board = await Leaderboard.create({ startsAt, endsAt, status: "running" });
+    const better = await makeUser(0);
+    await makeUser(0, { level: 99 });
+    await wager(better, TX.CASE_OPEN, 1000, new Date(startsAt.getTime() + 3600000));
+
+    await leaderboard.settleBoard(board);
+
+    const done = await Leaderboard.findById(board._id);
+    expect(done.standings).toHaveLength(1);
+    expect(await Transaction.countDocuments({ type: TX.LEADERBOARD_PRIZE })).toBe(1);
+  });
+});

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -232,6 +232,7 @@ UserSchema.index({ slug: 1 }, { unique: true, sparse: true }); // profile url lo
 UserSchema.index({ referralCode: 1 }, { unique: true, sparse: true });
 UserSchema.index({ referredBy: 1 }, { sparse: true });
 UserSchema.index({ weeklyWinnings: -1 }); // leaderboard, ranking window, weekly cron
+UserSchema.index({ level: -1 }); // the idle seats the daily board fills its empty rows with
 UserSchema.index({ "fixedItem.name": 1 }, { sparse: true }); // fan board recount on pin
 UserSchema.index({ discordId: 1 }, { unique: true, sparse: true }); // bot lookups, one account per discord user
 UserSchema.index({ discordGuilds: 1 }, { sparse: true }); // per-server boards

--- a/backend/routes/leaderboardRoutes.js
+++ b/backend/routes/leaderboardRoutes.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { maybeAuthenticated, isAuthenticated } = require("../middleware/authMiddleware");
+const { maybeAuthenticated } = require("../middleware/authMiddleware");
 
 const Leaderboard = require("../models/Leaderboard");
 const badges = require("../utils/badges");
@@ -16,7 +16,10 @@ let cached = { key: null, at: 0, rows: null };
 async function board(startsAt, endsAt) {
   const key = String(startsAt.getTime());
   if (cached.key === key && Date.now() - cached.at < BOARD_TTL_MS) return cached.rows;
-  const rows = await leaderboard.standings(startsAt, endsAt, leaderboard.PAID_PLACES);
+  const rows = await leaderboard.padStandings(
+    await leaderboard.standings(startsAt, endsAt, leaderboard.PAID_PLACES),
+    leaderboard.PAID_PLACES
+  );
   cached = { key, at: Date.now(), rows };
   return rows;
 }
@@ -26,7 +29,8 @@ const publicRow = (row, index) => ({
   rank: index + 1,
   points: row.points,
   bets: row.bets,
-  prize: leaderboard.prizeFor(index + 1),
+  prize: row.placeholder ? 0 : leaderboard.prizeFor(index + 1),
+  placeholder: !!row.placeholder,
   username: row.user.username,
   slug: row.user.slug,
   profilePicture: row.user.profilePicture,
@@ -41,7 +45,6 @@ router.get("/", maybeAuthenticated, async (req, res) => {
   try {
     const current = await leaderboard.ensureToday();
     const rows = await board(current.startsAt, current.endsAt);
-    const prizeCase = await null;
 
     const payload = {
       boardId: String(current._id),
@@ -57,7 +60,10 @@ router.get("/", maybeAuthenticated, async (req, res) => {
 
     if (req.user) {
       const mine = await leaderboard.standingFor(req.user._id, current.startsAt, current.endsAt);
-      const lastPaid = rows.length >= leaderboard.PAID_PLACES ? rows[rows.length - 1].points : 0;
+      // against the last row somebody actually earned, not a padded seat on nought
+      const earned = rows.filter((row) => !row.placeholder);
+      const lastPaid =
+        earned.length >= leaderboard.PAID_PLACES ? earned[earned.length - 1].points : 0;
       payload.me = {
         // the id lets the board mark the caller's own row rather than repeat it underneath
         _id: String(req.user._id),
@@ -108,38 +114,6 @@ router.get("/history", async (req, res) => {
         })),
       }))
     );
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: "Server error" });
-  }
-});
-
-// the caller's own last result, for the banner that tells a winner they won. separate
-// from the board because it reads the settled board, not the running one.
-router.get("/me/last", isAuthenticated, async (req, res) => {
-  try {
-    const last = await Leaderboard.findOne({
-      status: "settled",
-      settlementDone: true,
-      "standings.userId": req.user._id,
-    })
-      .sort({ startsAt: -1 })
-      .select("startsAt endsAt standings")
-      .lean();
-
-    if (!last) return res.json(null);
-    const mine = last.standings.find((s) => String(s.userId) === String(req.user._id));
-    if (!mine) return res.json(null);
-
-    res.json({
-      startsAt: last.startsAt,
-      endsAt: last.endsAt,
-      rank: mine.rank,
-      points: mine.points,
-      prize: mine.prize,
-      caseId: mine.caseId || null,
-      badge: !!mine.badge,
-    });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "Server error" });

--- a/backend/scripts/benchMissionsAggregate.mjs
+++ b/backend/scripts/benchMissionsAggregate.mjs
@@ -1,0 +1,95 @@
+// benchmarks the missions context aggregate against a synthetic ledger, so the covering
+// index can be judged before anything is created on production.
+//
+//   node scripts/benchMissionsAggregate.mjs [rows]
+//
+// the aggregate today plans as IXSCAN -> FETCH -> GROUP: the index finds the user's rows
+// and then every one of them is fetched to read type, amount and meta.quantity. an index
+// carrying those fields answers it without touching a document.
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MongoClient } from "mongodb";
+
+const ROWS = Number(process.argv[2] || 120000);
+const TYPES = ["dice_bet", "dice_win", "plinko_bet", "plinko_win", "case_open", "bonus", "blackjack_bet"];
+
+const mongod = await MongoMemoryServer.create();
+const client = await MongoClient.connect(mongod.getUri());
+const db = client.db("bench");
+const tx = db.collection("transactions");
+
+const userId = "u1";
+const launch = new Date(Date.now() - 400 * 864e5);
+console.log(`seeding ${ROWS.toLocaleString()} rows...`);
+for (let i = 0; i < ROWS; i += 10000) {
+  const batch = [];
+  for (let k = 0; k < Math.min(10000, ROWS - i); k++) {
+    batch.push({
+      userId,
+      type: TYPES[(i + k) % TYPES.length],
+      direction: (i + k) % 2 ? "credit" : "debit",
+      amount: Math.round(Math.random() * 5000),
+      balanceAfter: 1000,
+      meta: { quantity: ((i + k) % 5) + 1 },
+      createdAt: new Date(launch.getTime() + (i + k) * 1000),
+    });
+  }
+  await tx.insertMany(batch, { ordered: false });
+}
+// a second user, so the index actually has to select
+await tx.insertMany(Array.from({ length: 5000 }, (_, i) => ({
+  userId: "u2", type: "dice_bet", direction: "debit", amount: 1, balanceAfter: 1,
+  meta: { quantity: 1 }, createdAt: new Date(launch.getTime() + i * 1000),
+})), { ordered: false });
+
+const pipeline = [
+  { $match: { userId, createdAt: { $gte: launch } } },
+  {
+    $group: {
+      _id: "$type", count: { $sum: 1 },
+      qty: { $sum: { $ifNull: ["$meta.quantity", 0] } },
+      maxAmount: { $max: "$amount" }, sumAmount: { $sum: "$amount" },
+    },
+  },
+];
+
+const plan = async () => {
+  const e = await db.command({ explain: { aggregate: "transactions", pipeline, cursor: {} }, verbosity: "executionStats" });
+  const s = JSON.stringify(e);
+  const stages = [...new Set((s.match(/"stage"\s*:\s*"([A-Z_]+)"/g) || []).map((x) => x.split('"')[3]))];
+  const docs = (s.match(/"totalDocsExamined"\s*:\s*(\d+)/) || [])[1];
+  return { stages: stages.join(" <- "), docs: Number(docs || 0) };
+};
+
+const timeIt = async (label) => {
+  await tx.aggregate(pipeline).toArray();                       // warm
+  const runs = [];
+  for (let i = 0; i < 5; i++) {
+    const t0 = process.hrtime.bigint();
+    await tx.aggregate(pipeline).toArray();
+    runs.push(Number(process.hrtime.bigint() - t0) / 1e6);
+  }
+  runs.sort((a, b) => a - b);
+  const p = await plan();
+  console.log(`\n${label}`);
+  console.log(`  plan            ${p.stages}`);
+  console.log(`  docs examined   ${p.docs.toLocaleString()}`);
+  console.log(`  median          ${runs[2].toFixed(0)} ms   (best ${runs[0].toFixed(0)}, worst ${runs[4].toFixed(0)})`);
+};
+
+await tx.createIndex({ userId: 1, createdAt: -1 });
+await timeIt("today: { userId, createdAt }");
+
+await tx.createIndex(
+  { userId: 1, createdAt: -1, type: 1, amount: 1, "meta.quantity": 1 },
+  { name: "missionsCovering" }
+);
+await timeIt("with the covering index");
+
+const sizes = await db.command({ collStats: "transactions" });
+console.log("\nindex sizes:");
+for (const [name, bytes] of Object.entries(sizes.indexSizes)) {
+  console.log(`  ${name.padEnd(46)} ${(bytes / 1048576).toFixed(1)} MB`);
+}
+
+await client.close();
+await mongod.stop();

--- a/backend/utils/leaderboard.js
+++ b/backend/utils/leaderboard.js
@@ -73,6 +73,32 @@ async function standings(startsAt, endsAt, limit = PAID_PLACES) {
   ]);
 }
 
+const CARD = "username slug profilePicture level fixedItem fanRank selectedBadge badges";
+
+// fill the board out to the paid places with players who have not bet today. a board that
+// has just reset is otherwise a header over nothing, and these seats are real: any of them
+// is one bet from being taken.
+//
+// they carry no prize on purpose. settlement only pays a standing with points above zero,
+// so printing K₽1,200 beside somebody on nought would be telling them they had won it.
+async function padStandings(rows, limit) {
+  const missing = limit - rows.length;
+  if (missing <= 0) return rows;
+
+  const taken = rows.map((row) => row._id);
+  // the biggest accounts first, so the empty seats read as names rather than as filler.
+  // one indexed read of at most nine documents, behind the board's own cache.
+  const idle = await User.find({ _id: { $nin: taken }, ...VISIBLE })
+    .sort({ level: -1, _id: 1 })
+    .limit(missing)
+    .select(CARD)
+    .lean();
+
+  return rows.concat(
+    idle.map((user) => ({ _id: user._id, points: 0, bets: 0, user, placeholder: true }))
+  );
+}
+
 // what one player has scored today, and how far they are off the last paid place. read
 // separately from the board because they are usually not on it.
 async function standingFor(userId, startsAt, endsAt) {
@@ -248,6 +274,7 @@ module.exports = {
   prizeFor,
   windowFor,
   standings,
+  padStandings,
   standingFor,
   ensureToday,
   settleBoard,

--- a/src/pages/Home/Leaderboard/Leaderboard.services.ts
+++ b/src/pages/Home/Leaderboard/Leaderboard.services.ts
@@ -1,12 +1,9 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
-import UserContext from "../../../UserContext";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   getBoard,
   getPoints,
-  getMyLastBoard,
   Board,
   PointsGame,
-  BoardResult,
 } from "../../../services/leaderboard/LeaderboardService";
 import { Countdown } from "./Leaderboard.types";
 
@@ -38,13 +35,12 @@ export const podiumOrder = <T,>(rows: T[]): T[] => {
 };
 
 export const useLeaderboardServices = () => {
-  const { isLogged } = useContext(UserContext);
   const [board, setBoard] = useState<Board | null>(null);
   const [loading, setLoading] = useState(true);
   const [countdown, setCountdown] = useState<Countdown>(ZERO);
   const [points, setPoints] = useState<PointsGame[]>([]);
   const [showPoints, setShowPoints] = useState(false);
-  const [lastResult, setLastResult] = useState<BoardResult | null>(null);
+
   // the device clock can be wrong by minutes; the countdown runs off the server's instead
   const skew = useRef(0);
   const endsAt = useRef(0);
@@ -86,13 +82,6 @@ export const useLeaderboardServices = () => {
     return () => window.clearInterval(timer);
   }, [board, load]);
 
-  useEffect(() => {
-    if (!isLogged) {
-      setLastResult(null);
-      return;
-    }
-    getMyLastBoard().then(setLastResult).catch(() => setLastResult(null));
-  }, [isLogged]);
 
   const openPoints = useCallback(() => {
     setShowPoints(true);
@@ -101,23 +90,24 @@ export const useLeaderboardServices = () => {
   }, [points.length]);
 
   const standings = board ? board.standings : [];
+  // the podium is for players who actually scored. the padded seats fill the table below
+  // it, so a board with one real player shows one plinth rather than three strangers.
+  const earned = standings.filter((row) => !row.placeholder);
   const me = board ? board.me : null;
 
   return {
     loading,
     board,
-    podium: podiumOrder(standings),
-    rest: standings.slice(3),
+    podium: podiumOrder(earned.slice(0, 3)),
+    rest: standings.slice(Math.min(earned.length, 3)),
     // the podium only stands first place on mobile, so second and third join the table
     // there rather than disappearing off the board entirely
-    podiumRest: standings.slice(1, 3),
+    podiumRest: earned.slice(1, 3),
     countdown,
     pool: board ? board.pool : 0,
     me,
     paidPlaces: board ? board.paidPlaces : 0,
     meOnBoard: !!me && !!me.rank && me.rank <= (board ? board.paidPlaces : 0),
-    lastResult,
-    dismissResult: () => setLastResult(null),
     points,
     showPoints,
     openPoints,

--- a/src/pages/Home/Leaderboard/Leaderboard.types.ts
+++ b/src/pages/Home/Leaderboard/Leaderboard.types.ts
@@ -1,4 +1,4 @@
-import { Board, BoardMe, BoardResult, BoardStanding, PointsGame } from "../../../services/leaderboard/LeaderboardService";
+import { Board, BoardMe, BoardStanding, PointsGame } from "../../../services/leaderboard/LeaderboardService";
 
 export interface Countdown {
   hours: string;
@@ -18,8 +18,7 @@ export interface LeaderboardViewProps {
   paidPlaces: number;
   me: BoardMe | null;
   meOnBoard: boolean;
-  lastResult: BoardResult | null;
-  dismissResult: () => void;
+
   points: PointsGame[];
   showPoints: boolean;
   openPoints: () => void;

--- a/src/pages/Home/Leaderboard/Leaderboard.view.test.tsx
+++ b/src/pages/Home/Leaderboard/Leaderboard.view.test.tsx
@@ -36,8 +36,6 @@ const props = (over: Partial<LeaderboardViewProps> = {}): LeaderboardViewProps =
   paidPlaces: 10,
   me: null,
   meOnBoard: false,
-  lastResult: null,
-  dismissResult: () => undefined,
   points: [],
   showPoints: false,
   openPoints: () => undefined,
@@ -130,5 +128,40 @@ describe("the daily leaderboard", () => {
   it("keeps the placeholder while it is still loading, so the page does not jump", () => {
     const { container } = draw({ loading: true, podium: [], rest: [], podiumRest: [] });
     expect(container.querySelector(SPACER)).toBeTruthy();
+  });
+
+  it("fills the empty rows with players who have not bet, and pays them nothing", () => {
+    // a board that has just reset was a header over nothing. the seats are real players,
+    // but a settlement only pays a standing above zero, so none of them shows a prize.
+    const seat = (rank: number, username: string) => ({
+      ...player(rank, username),
+      points: 0,
+      prize: 0,
+      placeholder: true,
+    });
+    const rows = [standings[0], seat(2, "idle-a"), seat(3, "idle-b"), seat(4, "idle-c")];
+
+    const { container } = draw({
+      podium: [standings[0]],
+      rest: rows.slice(1),
+      podiumRest: [],
+      me: null,
+    });
+
+    const cells = [...container.querySelectorAll("tbody tr")].map((row) =>
+      [...row.querySelectorAll("td")].map((cell) => cell.textContent?.trim())
+    );
+    expect(cells.map((c) => c[0])).toEqual(["#2", "#3", "#4"]);
+    // no prize against a seat nobody has taken
+    expect(cells.every((c) => c[3] === "-")).toBe(true);
+    expect(screen.queryByText(/no bets yet/i)).toBeNull();
+  });
+
+  it("keeps a player who has not bet off the podium", () => {
+    // a seat on nought standing on the first plinth would be claiming K₽10,000
+    const seat = { ...player(2, "idle"), points: 0, prize: 0, placeholder: true };
+    const { container } = draw({ podium: [standings[0]], rest: [seat], podiumRest: [] });
+
+    expect(container.querySelectorAll("img[src=\"images/podium.svg\"]")).toHaveLength(1);
   });
 });

--- a/src/pages/Home/Leaderboard/Leaderboard.view.tsx
+++ b/src/pages/Home/Leaderboard/Leaderboard.view.tsx
@@ -45,14 +45,20 @@ const Clock = ({ countdown, pool, paidPlaces }: { countdown: Countdown; pool: nu
 );
 
 const Row = ({ user, mine, mobileOnly }: { user: BoardStanding; mine?: boolean; mobileOnly?: boolean }) => (
-    <tr className={`${mine ? "bg-surface-nav" : ""} ${mobileOnly ? "md:hidden" : ""}`}>
+    <tr className={`${mine ? "bg-surface-nav" : ""} ${mobileOnly ? "md:hidden" : ""} ${user.placeholder ? "opacity-60" : ""}`}>
         <td className="px-6 py-4 whitespace-nowrap">#{user.rank}</td>
         <td className="flex p-4 items-center gap-2">
             <Player user={user as never} size="small" />
         </td>
         <td className="px-6 py-4 whitespace-nowrap tabular-nums">{num(user.points)}</td>
-        <td className="px-6 py-4 whitespace-nowrap font-bold text-accent-gold">
-            <Monetary value={user.prize} />
+        <td className="px-6 py-4 whitespace-nowrap">
+            {user.placeholder ? (
+                <span className="text-ink-muted">-</span>
+            ) : (
+                <span className="font-bold text-accent-gold">
+                    <Monetary value={user.prize} />
+                </span>
+            )}
         </td>
     </tr>
 );
@@ -81,42 +87,6 @@ const YourRow = ({ me, paidPlaces }: { me: NonNullable<LeaderboardViewProps["me"
             )}
         </td>
     </tr>
-);
-
-const ResultBanner = ({
-    result,
-    onDismiss,
-}: {
-    result: NonNullable<LeaderboardViewProps["lastResult"]>;
-    onDismiss: () => void;
-}) => (
-    <div className="w-full max-w-[1620px] px-4 mb-6 flex items-stretch">
-        <div className="w-1 bg-accent-gold" />
-        <div className="flex-grow bg-surface px-6 py-5 flex flex-col md:flex-row md:items-center justify-between gap-4">
-            <div className="flex flex-col gap-1.5">
-                <span className="text-[11px] font-bold tracking-[0.12em] text-accent-gold">
-                    {i18n.t("leaderboard.resultTitle", { rank: result.rank })}
-                </span>
-                <span className="tabular-nums text-xl font-bold">
-                    {i18n.t("leaderboard.resultPoints", { points: num(result.points) })}
-                </span>
-                <span className="text-sm text-ink-soft">{i18n.t("leaderboard.resultPaid")}</span>
-            </div>
-            <div className="flex items-center gap-4">
-                <span className="text-3xl font-extrabold text-accent-gold">
-                    <Monetary value={result.prize} />
-                </span>
-                <button
-                    type="button"
-                    onClick={onDismiss}
-                    aria-label={i18n.t("leaderboard.close")}
-                    className="w-8 h-8 bg-surface-raised hover:bg-surface-hover text-ink-muted flex items-center justify-center"
-                >
-                    x
-                </button>
-            </div>
-        </div>
-    </div>
 );
 
 const PointsPanel = ({ points, onClose }: { points: LeaderboardViewProps["points"]; onClose: () => void }) => (
@@ -168,8 +138,6 @@ const LeaderboardView = ({
     paidPlaces,
     me,
     meOnBoard,
-    lastResult,
-    dismissResult,
     points,
     showPoints,
     openPoints,
@@ -177,7 +145,6 @@ const LeaderboardView = ({
     aside,
 }: LeaderboardViewProps) => (
     <div className="flex flex-col items-center justify-center max-w-[360px] md:max-w-none">
-        {lastResult && <ResultBanner result={lastResult} onDismiss={dismissResult} />}
 
         <div className="w-full max-w-[1620px] px-4 flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
             <div className="w-fit">

--- a/src/services/leaderboard/LeaderboardService.ts
+++ b/src/services/leaderboard/LeaderboardService.ts
@@ -12,6 +12,8 @@ export interface BoardStanding {
   points: number;
   bets: number;
   prize: number;
+  // a seat nobody has taken yet: on the board, on nought, winning nothing
+  placeholder?: boolean;
   username: string;
   slug?: string;
   profilePicture: string;
@@ -50,14 +52,6 @@ export interface PointsGame {
   multiplier: number;
 }
 
-export interface BoardResult {
-  startsAt: string;
-  endsAt: string;
-  rank: number;
-  points: number;
-  prize: number;
-}
-
 export const getBoard = async (): Promise<Board> => {
   const { data } = await api.get("/leaderboard");
   return data;
@@ -65,10 +59,5 @@ export const getBoard = async (): Promise<Board> => {
 
 export const getPoints = async (): Promise<{ games: PointsGame[] }> => {
   const { data } = await api.get("/leaderboard/points");
-  return data;
-};
-
-export const getMyLastBoard = async (): Promise<BoardResult | null> => {
-  const { data } = await api.get("/leaderboard/me/last");
   return data;
 };


### PR DESCRIPTION
## Problem

A board that has just reset is a header, a podium and nothing else. The table only ever held players who had scored, so for the first stretch of every day it held none.

The "you finished #9 yesterday" banner duplicated the notification that already goes out at settlement.

## Change

The board fills out to the paid places with players who have not bet yet, biggest accounts first so the seats read as names rather than filler. One indexed read of at most nine documents, behind the board's existing 15s cache, plus a `level` index so it is an index scan rather than a sort of the whole collection.

A seat carries no prize and is drawn back. Settlement only pays a standing with points above zero, so a prize beside somebody on nought would be telling them they had won it. Seats stay off the podium for the same reason.

Padding also broke the gap shown on the pinned row, since the last of ten rows is now a seat on nought. It measures against the last row somebody actually earned.

The banner is gone along with `GET /leaderboard/me/last`, the service call and the props.

## Tests

Backend 1136 across 110 suites, 5 new: the fill, no duplicate seats, disabled accounts excluded, a full board left alone, and a seat on nought never paid at settlement.

Frontend unit 190, 2 new: the seats render with no prize and no empty-state message, and a seat never reaches the podium. E2E 46, lint and build clean.