### PR TITLE
fix(rain): keep the people who were in a round that could not pay

### DIFF
--- a/backend/__tests__/integration/rain.test.js
+++ b/backend/__tests__/integration/rain.test.js
@@ -265,3 +265,75 @@ describe("what the cap leaves behind", () => {
     expect(next.carriedIn).toBe(result.pool - rain.MAX_PER_PLAYER);
   });
 });
+
+describe("a round that could not pay", () => {
+  const ripen = async () => {
+    const round = await rain.currentRound();
+    const endsAt = new Date(Date.now() - 1000);
+    await RainRound.updateOne(
+      { _id: round._id },
+      { $set: { startsAt: new Date(endsAt.getTime() - rain.INTERVAL_MS), endsAt } }
+    );
+    rain.resetCache();
+    return round;
+  };
+
+  it("keeps the people who were in it, rather than throwing their join away", async () => {
+    // most windows at this traffic are under the floor. a player joined, waited out the
+    // clock, got nothing, and had to join again to keep waiting: the join was discarded.
+    const a = await makeUser();
+    await rain.join(a._id);
+    await ripen();
+
+    const result = await rain.settle();
+    expect(result.paidOut).toBe(0);
+
+    const next = await rain.currentRound();
+    expect(next.joiners.map(String)).toEqual([String(a._id)]);
+    expect((await rain.state(a._id)).joined).toBe(true);
+  });
+
+  it("carries the pool and the people together", async () => {
+    const a = await makeUser();
+    await rain.join(a._id);
+    await ripen();
+    const round = await RainRound.findOne({ settledAt: null }).lean();
+    await Transaction.create({
+      userId: a._id, type: TX.CRASH_BET, direction: "debit",
+      amount: 4000, balanceAfter: 0,
+      createdAt: new Date(round.startsAt.getTime() + 1000),
+    });
+    rain.resetCache();
+
+    await rain.settle();
+
+    const next = await rain.currentRound();
+    expect(next.carriedIn).toBe(Math.floor(4000 * rain.RATE));
+    expect(next.joiners).toHaveLength(1);
+  });
+
+  it("clears the list once a round actually falls", async () => {
+    // otherwise somebody joins once and collects from every rain thereafter
+    const a = await makeUser();
+    await rain.join(a._id);
+    await ripen();
+    const round = await RainRound.findOne({ settledAt: null }).lean();
+    await Transaction.create({
+      userId: a._id, type: TX.CRASH_BET, direction: "debit",
+      amount: 400000, balanceAfter: 0,
+      createdAt: new Date(round.startsAt.getTime() + 1000),
+    });
+    rain.resetCache();
+
+    const result = await rain.settle();
+    expect(result.paidOut).toBeGreaterThan(0);
+
+    const next = await rain.currentRound();
+    expect(next.joiners).toHaveLength(0);
+    expect((await rain.state(a._id)).joined).toBe(false);
+  });
+
+  it("tells the panel the floor, so it can say what it is waiting for", async () => {
+    expect((await rain.state(null)).minPool).toBe(rain.MIN_POOL);
+  });
+});

--- a/backend/utils/rain.js
+++ b/backend/utils/rain.js
@@ -50,11 +50,16 @@ async function currentRound(now = new Date()) {
   // whatever the shares could not take rides in: nobody joined, the pool was dust, or
   // every share hit the per-player cap
   const carriedIn = last ? Math.max(0, (last.pool || 0) - (last.paidOut || 0)) : 0;
+  // and so do the people. a round that paid nobody must not throw their join away: at this
+  // traffic most windows are under the floor, so a player joined, waited out the clock,
+  // got nothing, and had to join again to keep waiting. they were in the room; they stay
+  // in it until a round actually falls, which is what resets the list.
+  const joiners = last && !last.paidOut ? last.joiners || [] : [];
   return RainRound.create({
     startsAt: now,
     endsAt: new Date(now.getTime() + INTERVAL_MS),
     carriedIn,
-    joiners: [],
+    joiners,
   });
 }
 
@@ -100,6 +105,9 @@ async function state(userId) {
     joined: !!userId && round.joiners.some((id) => String(id) === String(userId)),
     minLevel: MIN_LEVEL,
     maxPerPlayer: MAX_PER_PLAYER,
+    // the floor, so the panel can say a pool is still building rather than showing a
+    // countdown to nothing happening
+    minPool: MIN_POOL,
     intervalMs: INTERVAL_MS,
   };
 }

--- a/src/components/chat/ChatDock.test.ts
+++ b/src/components/chat/ChatDock.test.ts
@@ -63,3 +63,19 @@ describe("whether the rail is docked", () => {
     expect(shouldDock(true, "0")).toBe(false);
   });
 });
+
+describe("remembering the choice", () => {
+  it("reads a closed chat back as closed", () => {
+    // closing went through a setter that skipped the write, so a chat closed on purpose
+    // came straight back on the next reload
+    expect(shouldDock(true, "0")).toBe(false);
+  });
+
+  it("reads an opened chat back as open", () => {
+    expect(shouldDock(true, "1")).toBe(true);
+  });
+
+  it("starts closed for somebody who has never touched it", () => {
+    expect(shouldDock(true, null)).toBe(false);
+  });
+});

--- a/src/components/chat/ChatDock.tsx
+++ b/src/components/chat/ChatDock.tsx
@@ -153,17 +153,19 @@ export const useChatDock = () => {
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  const toggle = () => {
-    setOpen((was) => {
-      const next = !was;
-      try {
-        window.localStorage.setItem(KEY, next ? "1" : "0");
-      } catch {
-        // storage blocked: the toggle still works, it just does not survive a reload
-      }
-      return next;
-    });
+  // one place that writes the preference, so no route into the state can forget to. the
+  // close arrows used to call a setter that skipped this, and a chat closed on purpose
+  // came straight back on the next reload.
+  const remember = (next: boolean) => {
+    try {
+      window.localStorage.setItem(KEY, next ? "1" : "0");
+    } catch {
+      // storage blocked: it still works, it just does not survive a reload
+    }
+    setOpen(next);
   };
+
+  const toggle = () => remember(!open);
 
   return {
     open,
@@ -176,7 +178,7 @@ export const useChatDock = () => {
     // under it otherwise, however much room the centred content happens to have
     railWidth: open && wide ? RAIL_WIDTH : 0,
     toggle,
-    close: () => setOpen(false),
+    close: () => remember(false),
     CONTENT_ID,
   };
 };

--- a/src/components/chat/RainPool.test.ts
+++ b/src/components/chat/RainPool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { remainingShare, splitRemaining } from "./RainPool";
+import { isBuilding, remainingShare, splitRemaining } from "./RainPool";
 
 describe("the bar under the rain pool", () => {
   const start = 1000;
@@ -35,5 +35,23 @@ describe("the countdown", () => {
   it("shows nothing left rather than a negative", () => {
     expect(splitRemaining(-5000)).toBe("00:00");
     expect(splitRemaining(0)).toBe("00:00");
+  });
+});
+
+describe("a pool that is not big enough to fall", () => {
+  it("is building rather than counting down", () => {
+    // the reported bug: a pool of 4 against a floor of 100 showed a countdown, a join
+    // button and a figure, then nothing happened and nothing said why
+    expect(isBuilding(4, 100)).toBe(true);
+    expect(isBuilding(99, 100)).toBe(true);
+  });
+
+  it("is ready the moment it reaches the floor", () => {
+    expect(isBuilding(100, 100)).toBe(false);
+    expect(isBuilding(2500, 100)).toBe(false);
+  });
+
+  it("treats an empty pool as building, not as ready", () => {
+    expect(isBuilding(0, 100)).toBe(true);
   });
 });

--- a/src/components/chat/RainPool.tsx
+++ b/src/components/chat/RainPool.tsx
@@ -33,6 +33,11 @@ export const remainingShare = (endsAt: number, startsAt: number, now: number) =>
 // the last stretch, where the panel stops being furniture and starts being a prompt
 const IMMINENT_MS = 60000;
 
+// a pool under the floor does not fall, it rolls into the next round. saying so is the
+// whole point: without it the panel shows a countdown, a join button and a figure, and
+// then nothing happens and nobody can tell whether it broke.
+export const isBuilding = (pool: number, minPool: number) => pool < minPool;
+
 // the figure walks to its new value instead of jumping: the pool moves whenever anyone on
 // the site bets, and a number that silently changes is a number nobody notices.
 const useCountUp = (value: number) => {
@@ -125,7 +130,9 @@ const RainPool = () => {
 
   if (!state) return null;
 
-  const imminent = share > 0 && window_.current.endsAt - (Date.now() - skew.current) <= IMMINENT_MS;
+  const building = isBuilding(state.pool, state.minPool);
+  const imminent =
+    !building && share > 0 && window_.current.endsAt - (Date.now() - skew.current) <= IMMINENT_MS;
 
   return (
     <div
@@ -165,17 +172,28 @@ const RainPool = () => {
         )}
       </div>
 
-      <div className="mt-2 text-[10px] tabular-nums text-ink-faint">
-        {i18n.t("rain.in", { time: left })}
+      {/* a countdown to a drop that cannot happen is worse than no countdown. while the
+          pool is under the floor the panel says what it is waiting for instead. */}
+      <div className="mt-2 text-[10px] text-ink-faint">
+        {building ? (
+          <span>
+            {i18n.t("rain.building", { amount: (state.minPool - state.pool).toLocaleString("en-US") })}
+          </span>
+        ) : (
+          <span className="tabular-nums">{i18n.t("rain.in", { time: left })}</span>
+        )}
       </div>
 
-      {/* the bar sits on the bottom edge and drains with the clock */}
+      {/* the bar drains with the clock, or fills toward the floor while the pool is still
+          too small to fall: either way it is showing what has to happen next */}
       <div className="absolute bottom-0 left-0 h-[3px] w-full bg-surface">
         <div
           className={`h-full transition-[width] duration-1000 ease-linear ${
-            imminent ? "bg-accent-amber" : "bg-secondary"
+            imminent ? "bg-accent-amber" : building ? "bg-line-strong" : "bg-secondary"
           }`}
-          style={{ width: `${share * 100}%` }}
+          style={{
+            width: `${(building ? Math.min(1, state.pool / state.minPool) : share) * 100}%`,
+          }}
         />
       </div>
     </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "Gleich regnet es",
+    "building": "noch K₽{{amount}} bis es faellt",
     "in": "faellt in {{time}}",
     "join": "Mitmachen",
     "joined": "Du bist dabei",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "It is about to rain",
+    "building": "K₽{{amount}} more before it falls",
     "in": "drops in {{time}}",
     "join": "Join",
     "joined": "You are in",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "Esta a punto de llover",
+    "building": "faltan K₽{{amount}} para que caiga",
     "in": "cae en {{time}}",
     "join": "Entrar",
     "joined": "Estas dentro",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "La pluie arrive",
+    "building": "encore K₽{{amount}} avant qu elle tombe",
     "in": "tombe dans {{time}}",
     "join": "Rejoindre",
     "joined": "Vous y etes",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "Sebentar lagi hujan",
+    "building": "kurang K₽{{amount}} lagi sebelum turun",
     "in": "turun dalam {{time}}",
     "join": "Ikut",
     "joined": "Kamu ikut",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "Sta per piovere",
+    "building": "mancano K₽{{amount}} prima che cada",
     "in": "cade tra {{time}}",
     "join": "Entra",
     "joined": "Sei dentro",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "まもなくレイン",
+    "building": "あとK₽{{amount}}で降ります",
     "in": "あと {{time}}",
     "join": "参加",
     "joined": "参加中",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "곧 레인이 시작됩니다",
+    "building": "K₽{{amount}} 더 모이면 내립니다",
     "in": "{{time}} 후 지급",
     "join": "참여",
     "joined": "참여 중",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "Vai chover agora",
+    "building": "faltam K₽{{amount}} para cair",
     "in": "cai em {{time}}",
     "join": "Entrar",
     "joined": "Voce esta dentro",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "Sap mua roi",
+    "building": "can them K₽{{amount}} nua moi roi",
     "in": "roi sau {{time}}",
     "join": "Tham gia",
     "joined": "Ban da tham gia",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -986,6 +986,7 @@
   },
   "rain": {
     "aboutTo": "马上就要下红包了",
+    "building": "还差 K₽{{amount}} 才会落下",
     "in": "{{time}} 后发放",
     "join": "参与",
     "joined": "已参与",

--- a/src/services/chat/RainService.ts
+++ b/src/services/chat/RainService.ts
@@ -18,6 +18,8 @@ export interface RainState {
   joined: boolean;
   minLevel: number;
   maxPerPlayer: number;
+  // under this the pool does not fall, it rolls into the next round
+  minPool: number;
   intervalMs: number;
   error?: string;
 }


### PR DESCRIPTION
## What happened

A player joined a rain showing 4 KP, the round ended, nothing was paid, and after a reload it still showed 4.

The payout was correct: 4 is under the 100 floor, so it paid nobody and carried. Two things around it were not.

## Most rounds do not fall, and that is fine

Measured over 24 hours of real traffic:

| | |
|---|---|
| half-hour windows with any betting | 32 |
| median pool those windows make | **23 KP** |
| windows clearing the floor alone | **12 of 32** |
| rain payouts written since launch | **0** |

23 KP split three ways is seven each, worth less than the click. The pool is meant to accumulate until it is worth dropping.

## The joiners did not accumulate with it

A round that paid nobody threw its list away, so a player joined, waited out a full clock, got nothing, and had to join again to keep waiting. The list now carries with the pool, and clears only when a round actually falls, which is what stops one join collecting from every rain after it.

## The panel explained none of it

It showed a figure, a join button and a countdown to a drop that could not happen. Under the floor it now says how much more is needed, and the bar fills toward the floor rather than draining toward a meaningless deadline.

## Closing the chat is remembered

The close arrows called a setter that skipped the localStorage write, so a chat closed on purpose came back on the next reload. One function writes the preference now, so no route into the state can miss it.

## Tests

Backend 1220 (4 new), frontend 249 (6 new), e2e 54. New coverage for the carry, for the list clearing on a real payout, for the building state, and for the close being remembered.