### PR TITLE
fix(header): let the live drop fill its row or leave it

### DIFF
--- a/src/components/header/liveDrop.test.ts
+++ b/src/components/header/liveDrop.test.ts
@@ -47,6 +47,18 @@ describe("how long a drop stays on the live strip", () => {
 
   it("empties completely once the room goes quiet", () => {
     expect(freshDrops([at(60000), at(90000)])).toHaveLength(0);
-    expect(freshDrops([at(1000), at(90000)])).toHaveLength(1);
+    expect(freshDrops([])).toHaveLength(0);
+  });
+
+  it("keeps the whole row while the feed is still live", () => {
+    // dropping the old ones one at a time left the strip half filled: a few cards on the
+    // left and a stretch of bare background to the right of them. the row is full width,
+    // so it either fills or it is not there at all.
+    const drops = [at(1000), at(20000), at(90000), at(600000)];
+    expect(freshDrops(drops)).toHaveLength(4);
+  });
+
+  it("goes on the newest, not on each one", () => {
+    expect(freshDrops([at(90000), at(1000)])).toHaveLength(0);
   });
 });

--- a/src/components/header/liveDrop.ts
+++ b/src/components/header/liveDrop.ts
@@ -17,5 +17,9 @@ export const DROP_TTL_MS = 45000;
 export const isFreshDrop = (drop: { at?: number }, now = Date.now()) =>
   now - (drop.at || 0) < DROP_TTL_MS;
 
+// the strip is live while its newest drop is, and then it goes entirely. expiring the rows
+// one at a time emptied it from the tail while new ones still arrived at the head, so the
+// feed sat half filled with a stretch of bare background to the right of it. the row it
+// draws is full width, so it either fills or it is not there.
 export const freshDrops = <T extends { at?: number }>(drops: T[], now = Date.now()) =>
-  drops.filter((drop) => isFreshDrop(drop, now));
+  drops.length && isFreshDrop(drops[0], now) ? drops : [];


### PR DESCRIPTION
## Problem

The live drop strip stopped part way across, leaving bare background to the right of the cards.

Not a layout regression. The row has always been full width, and it used to hold the last twenty openings so it filled. #294 gave each drop a 45 second life to stop the strip holding its 112px open on every page for the rest of the session, and that expiry empties it from the tail while new drops still arrive at the head.

## Change

The strip is live while its **newest** drop is, and goes entirely when that one ages out, rather than each row expiring on its own. It fills or it is not there.

The space still comes back on a quiet page, which is the whole reason the expiry exists.

## Tests

Frontend 251, three new on the strip: the whole row survives while the feed is live, it empties completely once the room goes quiet, and staleness is judged on the newest drop rather than each one. E2E 54.