### PR TITLE
feat(backoffice): tabs, and a url that remembers where you were

### DIFF
--- a/src/pages/Backoffice/Backoffice.services.ts
+++ b/src/pages/Backoffice/Backoffice.services.ts
@@ -1,4 +1,5 @@
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   getAdminOverview,
   getAdminGameStats,
@@ -16,28 +17,40 @@ import {
   TimeseriesPoint,
 } from "../../services/admin/AdminServices";
 import UserContext from "../../UserContext";
+import { AdminUrlState, Tab, parseAdminUrl, writeAdminUrl } from "./Backoffice.tabs";
 
 export type Window = 7 | 30 | null;
 
 export const useBackofficeServices = () => {
   const { userData } = useContext(UserContext);
-  const [days, setDays] = useState<Window>(null);
+  const [params, setParams] = useSearchParams();
+
+  // the url is the state. nothing is mirrored into react state, so there is one place a
+  // value can come from and the back button cannot disagree with what is rendered.
+  const url = useMemo(() => parseAdminUrl(params), [params]);
+  const { tab, days, page, search, playerId } = url;
+
   const [overview, setOverview] = useState<AdminOverview | null>(null);
   const [games, setGames] = useState<AdminGameStats | null>(null);
   const [cases, setCases] = useState<AdminCaseRow[] | null>(null);
   const [series, setSeries] = useState<TimeseriesPoint[] | null>(null);
   const [wins, setWins] = useState<AdminBigWin[] | null>(null);
   const [usersPage, setUsersPage] = useState<AdminUsersPage | null>(null);
-  const [page, setPage] = useState<number>(1);
-  const [search, setSearch] = useState<string>("");
   const [loading, setLoading] = useState<boolean>(true);
+  const [usersLoading, setUsersLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
-  const [playerId, setPlayerId] = useState<string | null>(null);
   const [player, setPlayer] = useState<AdminPlayerDetail | null>(null);
   const [playerLoading, setPlayerLoading] = useState<boolean>(false);
 
   const isAdmin = !!userData?.isAdmin;
 
+  const go = useCallback(
+    (next: Partial<AdminUrlState>) => setParams(writeAdminUrl({ ...url, ...next })),
+    [setParams, url]
+  );
+
+  // the headline numbers and the charts. every tab shows the window toggle, so this is the
+  // one fetch that is not deferred.
   useEffect(() => {
     if (!isAdmin) {
       setLoading(false);
@@ -45,51 +58,55 @@ export const useBackofficeServices = () => {
     }
     let active = true;
     setLoading(true);
-    Promise.all([
-      getAdminOverview(days),
-      getAdminGameStats(days),
-      getAdminCaseStats(days),
-      getAdminTimeseries(days),
-      getAdminBigWins(days),
-    ])
-      .then(([o, g, c, s, w]) => {
+    Promise.all([getAdminOverview(days), getAdminTimeseries(days)])
+      .then(([o, s]) => {
         if (!active) return;
         setOverview(o);
-        setGames(g);
-        setCases(c);
         setSeries(s);
-        setWins(w);
         setError(false);
       })
-      .catch(() => {
-        if (active) setError(true);
-      })
-      .finally(() => {
-        if (active) setLoading(false);
-      });
+      .catch(() => active && setError(true))
+      .finally(() => active && setLoading(false));
     return () => {
       active = false;
     };
   }, [isAdmin, days]);
 
-  // the user table follows its own paging and search, debounced against typing
+  // the rest is fetched when its tab is opened, rather than five requests on every load
+  // for four sections nobody is looking at
   useEffect(() => {
     if (!isAdmin) return;
     let active = true;
+    if (tab === "games" || tab === "overview") {
+      getAdminGameStats(days).then((g) => active && setGames(g)).catch(() => undefined);
+    }
+    if (tab === "games") {
+      getAdminBigWins(days).then((w) => active && setWins(w)).catch(() => undefined);
+    }
+    if (tab === "cases") {
+      getAdminCaseStats(days).then((c) => active && setCases(c)).catch(() => undefined);
+    }
+    return () => {
+      active = false;
+    };
+  }, [isAdmin, tab, days]);
+
+  // the user table follows its own paging and search, debounced against typing
+  useEffect(() => {
+    if (!isAdmin || tab !== "players" || playerId) return;
+    let active = true;
+    setUsersLoading(true);
     const t = setTimeout(() => {
       getAdminUserStats(days, page, search)
-        .then((res) => {
-          if (active) setUsersPage(res);
-        })
-        .catch(() => {
-          if (active) setUsersPage(null);
-        });
+        .then((res) => active && setUsersPage(res))
+        .catch(() => active && setUsersPage(null))
+        .finally(() => active && setUsersLoading(false));
     }, search ? 300 : 0);
     return () => {
       active = false;
       clearTimeout(t);
     };
-  }, [isAdmin, days, page, search]);
+  }, [isAdmin, tab, days, page, search, playerId]);
 
   // the drill-down loads on open and follows the window toggle while open
   useEffect(() => {
@@ -97,30 +114,21 @@ export const useBackofficeServices = () => {
     let active = true;
     setPlayerLoading(true);
     getAdminPlayerDetail(playerId, days)
-      .then((d) => {
-        if (active) setPlayer(d);
-      })
-      .catch(() => {
-        if (active) setPlayer(null);
-      })
-      .finally(() => {
-        if (active) setPlayerLoading(false);
-      });
+      .then((d) => active && setPlayer(d))
+      .catch(() => active && setPlayer(null))
+      .finally(() => active && setPlayerLoading(false));
     return () => {
       active = false;
     };
   }, [isAdmin, playerId, days]);
 
-  const changeSearch = (value: string) => {
-    setSearch(value);
-    setPage(1);
-  };
-
   return {
     userData,
     isAdmin,
+    tab,
+    setTab: (next: Tab) => go({ tab: next, playerId: null, page: 1 }),
     days,
-    setDays,
+    setDays: (next: Window) => go({ days: next }),
     overview,
     games,
     cases,
@@ -128,18 +136,20 @@ export const useBackofficeServices = () => {
     wins,
     usersPage,
     page,
-    setPage,
+    setPage: (next: number) => go({ page: next }),
     search,
-    changeSearch,
+    // a new search starts at the first page, or page 4 of the old results is asked for
+    changeSearch: (value: string) => go({ search: value, page: 1 }),
     loading,
+    usersLoading,
     error,
     playerId,
     player,
     playerLoading,
-    openPlayer: (id: string) => setPlayerId(id),
+    openPlayer: (id: string) => go({ playerId: id, tab: "players" }),
     closePlayer: () => {
-      setPlayerId(null);
       setPlayer(null);
+      go({ playerId: null });
     },
   };
 };

--- a/src/pages/Backoffice/Backoffice.tabs.test.ts
+++ b/src/pages/Backoffice/Backoffice.tabs.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { parseAdminUrl, writeAdminUrl, AdminUrlState } from "./Backoffice.tabs";
+
+const parse = (qs: string) => parseAdminUrl(new URLSearchParams(qs));
+const write = (over: Partial<AdminUrlState> = {}) =>
+  writeAdminUrl({ tab: "overview", days: null, page: 1, search: "", playerId: null, ...over }).toString();
+
+describe("the backoffice url", () => {
+  it("opens on the overview with nothing set", () => {
+    expect(parse("")).toEqual({ tab: "overview", days: null, page: 1, search: "", playerId: null });
+  });
+
+  it("survives a reload with everything set", () => {
+    // the whole point: state lived in react only, so leaving the page and coming back
+    // dropped you at the default view with the search box empty
+    expect(parse("tab=players&days=30&q=nova&page=3")).toEqual({
+      tab: "players", days: 30, page: 3, search: "nova", playerId: null,
+    });
+  });
+
+  it("round trips", () => {
+    const state: AdminUrlState = { tab: "cases", days: 7, page: 2, search: "kani", playerId: null };
+    expect(parse(writeAdminUrl(state).toString())).toEqual(state);
+  });
+
+  it("writes only what differs from the default, so a shared link is short", () => {
+    expect(write()).toBe("");
+    expect(write({ tab: "games" })).toBe("tab=games");
+    expect(write({ days: 7 })).toBe("days=7");
+  });
+
+  it("puts a player link on the players tab whatever the tab says", () => {
+    // otherwise the row that opened the drill-down sits behind a tab you are not looking at
+    expect(parse("player=abc123&tab=cases").tab).toBe("players");
+    expect(parse("player=abc123").playerId).toBe("abc123");
+  });
+
+  it("refuses a tab that does not exist rather than rendering nothing", () => {
+    expect(parse("tab=nonsense").tab).toBe("overview");
+  });
+
+  it("refuses a nonsense window or page", () => {
+    expect(parse("days=99").days).toBe(null);
+    expect(parse("days=abc").days).toBe(null);
+    expect(parse("page=0").page).toBe(1);
+    expect(parse("page=-5").page).toBe(1);
+    expect(parse("page=abc").page).toBe(1);
+  });
+
+  it("keeps the two windows the toggle offers", () => {
+    expect(parse("days=7").days).toBe(7);
+    expect(parse("days=30").days).toBe(30);
+  });
+});

--- a/src/pages/Backoffice/Backoffice.tabs.ts
+++ b/src/pages/Backoffice/Backoffice.tabs.ts
@@ -1,0 +1,63 @@
+import { Window } from "./Backoffice.services";
+
+// the page used to hold every section at once, so reaching the player table meant scrolling
+// past the charts, the games, the wins and every case. one section at a time instead.
+export const TABS = ["overview", "games", "cases", "players", "predictions"] as const;
+export type Tab = (typeof TABS)[number];
+
+export const TAB_LABELS: Record<Tab, string> = {
+  overview: "Overview",
+  games: "Games",
+  cases: "Cases",
+  players: "Players",
+  predictions: "Predictions",
+};
+
+export const WINDOWS: { value: Window; text: string }[] = [
+  { value: 7, text: "7d" },
+  { value: 30, text: "30d" },
+  { value: null, text: "All" },
+];
+
+// every bit of state the page has lives in the query string, so the back button, a reload
+// and a pasted link all land where they were. it used to be react state only: opening a
+// player and coming back dropped you at the default view with the search box empty.
+export interface AdminUrlState {
+  tab: Tab;
+  days: Window;
+  page: number;
+  search: string;
+  playerId: string | null;
+}
+
+const isTab = (v: string | null): v is Tab => !!v && (TABS as readonly string[]).includes(v);
+
+export function parseAdminUrl(params: URLSearchParams): AdminUrlState {
+  const raw = params.get("days");
+  const days: Window = raw === "7" ? 7 : raw === "30" ? 30 : null;
+  const page = Math.max(1, Number(params.get("page")) || 1);
+  const playerId = params.get("player");
+  const tabParam = params.get("tab");
+
+  return {
+    // a link to a player is a link to the players tab whatever the tab says, or the row
+    // that opened it would be behind a tab you are not looking at
+    tab: playerId ? "players" : isTab(tabParam) ? tabParam : "overview",
+    days,
+    page,
+    search: params.get("q") || "",
+    playerId,
+  };
+}
+
+// only what differs from the default is written, so the common url stays short and a
+// shared link carries no noise
+export function writeAdminUrl(state: AdminUrlState): URLSearchParams {
+  const params = new URLSearchParams();
+  if (state.tab !== "overview") params.set("tab", state.tab);
+  if (state.days !== null) params.set("days", String(state.days));
+  if (state.search) params.set("q", state.search);
+  if (state.page > 1) params.set("page", String(state.page));
+  if (state.playerId) params.set("player", state.playerId);
+  return params;
+}

--- a/src/pages/Backoffice/Backoffice.view.tsx
+++ b/src/pages/Backoffice/Backoffice.view.tsx
@@ -15,6 +15,7 @@ import {
   TimeseriesPoint,
 } from "../../services/admin/AdminServices";
 import { Window } from "./Backoffice.services";
+import { Tab, TABS, TAB_LABELS, WINDOWS } from "./Backoffice.tabs";
 import AdminChart from "./AdminChart";
 import PredictionsAdmin from "./PredictionsAdmin";
 import { CHART_AMBER, CHART_INDIGO, fillDays } from "./adminSeries";
@@ -22,6 +23,8 @@ import { CHART_AMBER, CHART_INDIGO, fillDays } from "./adminSeries";
 interface Props {
   userData: any;
   isAdmin: boolean;
+  tab: Tab;
+  setTab: (t: Tab) => void;
   days: Window;
   setDays: (d: Window) => void;
   overview: AdminOverview | null;
@@ -35,6 +38,7 @@ interface Props {
   search: string;
   changeSearch: (s: string) => void;
   loading: boolean;
+  usersLoading: boolean;
   error: boolean;
   playerId: string | null;
   player: AdminPlayerDetail | null;
@@ -107,11 +111,6 @@ const Panel = ({ title, children }: { title: string; children: React.ReactNode }
   </div>
 );
 
-const WINDOWS: { value: Window; text: string }[] = [
-  { value: null, text: "All time" },
-  { value: 30, text: "30 days" },
-  { value: 7, text: "7 days" },
-];
 
 const BadgeGrant = ({ userId, held }: { userId: string; held: Badge[] }) => {
   const [badges, setBadges] = useState<Badge[]>(held);
@@ -301,9 +300,33 @@ const PlayerDetail = ({
   );
 };
 
+// a tab that has not answered yet shows its own placeholder rather than holding the whole
+// page back: the window toggle and the other tabs stay usable while it loads
+const SectionSkeleton = () => (
+  <Skeleton height={320} borderRadius={12} highlightColor="#161427" baseColor="#1c1a31" />
+);
+
+const TabBar = ({ tab, setTab }: { tab: Tab; setTab: (t: Tab) => void }) => (
+  <div className="flex gap-1 overflow-x-auto border-b border-line">
+    {TABS.map((name) => (
+      <button
+        key={name}
+        onClick={() => setTab(name)}
+        className={`whitespace-nowrap px-4 py-2 text-sm transition-colors border-b-2 -mb-px ${
+          tab === name
+            ? "border-accent text-ink"
+            : "border-transparent text-ink-muted hover:text-ink"
+        }`}
+      >
+        {TAB_LABELS[name]}
+      </button>
+    ))}
+  </div>
+);
+
 const BackofficeView: React.FC<Props> = ({
-  userData, isAdmin, days, setDays, overview, games, cases, series, wins, usersPage,
-  page, setPage, search, changeSearch, loading, error,
+  userData, isAdmin, tab, setTab, days, setDays, overview, games, cases, series, wins, usersPage,
+  page, setPage, search, changeSearch, loading, usersLoading, error,
   playerId, player, playerLoading, openPlayer, closePlayer,
 }) => {
   if (!userData || !isAdmin) {
@@ -318,16 +341,18 @@ const BackofficeView: React.FC<Props> = ({
       </div>
     );
   }
-  if (error || !overview || !games || !cases) {
+  if (error || !overview) {
     return <div className="w-full flex justify-center py-16 text-ink-muted">Could not load the numbers.</div>;
   }
 
   const windowText = days ? `last ${days} days` : "all time";
   const chartText = days ? `last ${days} days` : "last 90 days";
   const filled = fillDays(series || [], days);
-  const totalWagered = games.games.reduce((s, g) => s + g.wagered, 0);
-  const totalNet = games.games.reduce((s, g) => s + g.net, 0);
-  const totalFaucet = games.issuance.reduce((s, l) => s + l.issued, 0);
+  // each tab fetches its own section, so these are only there once the games tab has
+  // answered. the overview cards that use them wait on it rather than the whole page.
+  const totalWagered = games ? games.games.reduce((sum, g) => sum + g.wagered, 0) : 0;
+  const totalNet = games ? games.games.reduce((sum, g) => sum + g.net, 0) : 0;
+  const totalFaucet = games ? games.issuance.reduce((sum, l) => sum + l.issued, 0) : 0;
 
   return (
     <div className="w-full flex justify-center">
@@ -349,10 +374,14 @@ const BackofficeView: React.FC<Props> = ({
           </div>
         </div>
 
+        <TabBar tab={tab} setTab={setTab} />
+
         {playerId ? (
           <PlayerDetail player={player} loading={playerLoading} windowText={windowText} onBack={closePlayer} />
         ) : (
           <>
+            {tab === "overview" && (
+              <>
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
               <StatCard title="Users" sub={days ? `+${overview.users.new} new in the window` : undefined}>
                 {overview.users.total.toLocaleString()}
@@ -419,10 +448,10 @@ const BackofficeView: React.FC<Props> = ({
               />
             </div>
 
-            <Panel title="Prediction markets">
-              <PredictionsAdmin />
-            </Panel>
-
+              </>
+            )}
+            {tab === "games" && (games && wins ? (
+              <>
             <Panel title={`Games (${windowText}, most profitable first)`}>
               <div className="overflow-x-auto">
                 <table className="w-full text-left text-sm">
@@ -529,6 +558,12 @@ const BackofficeView: React.FC<Props> = ({
               </Panel>
             </div>
 
+              </>
+            ) : (
+              <SectionSkeleton />
+            ))}
+            {tab === "cases" && (cases ? (
+              <>
             <Panel title={`Cases (${windowText}, most opened first)`}>
               {cases.length === 0 ? (
                 <p className="text-ink-muted text-sm py-4 text-center">No cases opened in this window.</p>
@@ -565,6 +600,12 @@ const BackofficeView: React.FC<Props> = ({
               )}
             </Panel>
 
+              </>
+            ) : (
+              <SectionSkeleton />
+            ))}
+            {tab === "players" && (
+              <>
             <Panel title="Users">
               <input
                 value={search}
@@ -572,7 +613,7 @@ const BackofficeView: React.FC<Props> = ({
                 placeholder="Search by username"
                 className="w-full md:w-72 bg-surface-nav rounded-md px-3 py-2 text-ink text-sm focus:outline-none mb-3"
               />
-              {!usersPage ? (
+              {!usersPage || usersLoading ? (
                 <Skeleton height={200} borderRadius={8} highlightColor="#161427" baseColor="#1c1a31" />
               ) : (
                 <>
@@ -641,6 +682,16 @@ const BackofficeView: React.FC<Props> = ({
                 </>
               )}
             </Panel>
+              </>
+            )}
+            {tab === "predictions" && (
+              <>
+            <Panel title="Prediction markets">
+              <PredictionsAdmin />
+            </Panel>
+
+              </>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Problem

Three complaints, one root cause.

Reaching the player table meant scrolling past the charts, every game, every big win and every case, because the page rendered all of it at once in a 651 line view.

And every bit of state was React state with none of it in the URL:

```js
const [days, setDays] = useState<Window>(null);
const [page, setPage] = useState<number>(1);
const [search, setSearch] = useState<string>("");
const [playerId, setPlayerId] = useState<string | null>(null);
```

So opening a player and coming back dropped you at the default view with the search box empty, a reload lost your place, and nothing could be linked to.

## Change

**Tabs.** Overview, Games, Cases, Players, Predictions. The player table is one click.

**The URL is the state.** `?tab=players&days=30&q=nova&page=2&player=<id>`. Back, forward, reload and a pasted link all land where they were. Only what differs from the default is written, so the common URL stays empty. A link carrying a player opens the Players tab whatever the tab says, or the row that opened it sits behind a tab you are not looking at.

**A loading state on search.** The 300ms debounce plus the request used to leave the old rows sitting there with nothing to say it was working.

**Each tab fetches what it shows.** A load is two requests instead of five for four sections nobody is looking at, and a tab that has not answered shows its own placeholder rather than holding the page back.

## Tests

Frontend 259, 9 new on the URL: the round trip, only writing what differs, a player link forcing the Players tab, and refusing a nonsense tab, window or page rather than rendering nothing.

Checked in a browser against the built bundle: all five tabs render with no page errors, `?tab=players&days=30&q=nova&page=2` restores the search box, clicking a tab writes the URL and back undoes it.