### PR TITLE
fix(chat): keep the panel open when a phone resizes itself

### DIFF
--- a/e2e/chatDock.spec.ts
+++ b/e2e/chatDock.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { mockApi } from "./mocks";
+import { mockApi, mockSession } from "./mocks";
 
 // the rail has been wrong three times: it pushed the whole page including the navbar, then
 // it pushed centred boards that already had room beside them, then it left the full width
@@ -167,4 +167,89 @@ test("the arrow that closes the rail is where the one that reopens it appears", 
   await page.getByRole("button", { name: "Open chat" }).click();
   await page.locator("aside").waitFor({ state: "visible", timeout: 10000 });
   expect(await railWidth(page)).toBe(300);
+});
+
+// on a phone the chat is an overlay rather than a rail, and the thing that broke it was the
+// soft keyboard: it shrinks the viewport, which arrives as a resize, and the handler read
+// "is it narrow now" instead of "has it just stopped being wide". a phone is narrow the
+// whole time, so tapping the box to type closed the panel under the player.
+test.describe("the chat on a phone", () => {
+  const PHONE = { width: 390, height: 844 };
+  // what the keyboard leaves of the viewport on an iphone
+  const WITH_KEYBOARD = { width: 390, height: 508 };
+
+  const openChat = async (page: Page) => {
+    await page.goto("/crash");
+    await page.getByRole("button", { name: "Open chat" }).click();
+    await page.locator("aside").waitFor({ state: "visible", timeout: 10000 });
+  };
+
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(PHONE);
+  });
+
+  test("stays open when the keyboard takes half the screen", async ({ page }) => {
+    await openChat(page);
+
+    await page.setViewportSize(WITH_KEYBOARD);
+    await page.waitForTimeout(500);
+
+    await expect(page.locator("aside")).toBeVisible();
+  });
+
+  test("stays open through tapping the box and typing in it", async ({ page }) => {
+    // the box only exists for a signed in player; without one the panel offers a log in
+    await mockSession(page);
+    await openChat(page);
+    const box = page.getByPlaceholder("Say something");
+
+    await box.click();
+    await page.setViewportSize(WITH_KEYBOARD); // the keyboard the tap brings up
+    await page.waitForTimeout(300);
+    await box.fill("hello everyone");
+    await page.waitForTimeout(300);
+
+    await expect(page.locator("aside")).toBeVisible();
+    await expect(box).toHaveValue("hello everyone");
+  });
+
+  test("survives the url bar collapsing on a scroll", async ({ page }) => {
+    // the other resize a phone makes on its own, and the old handler closed on that too
+    await openChat(page);
+
+    await page.setViewportSize({ width: 390, height: 800 });
+    await page.waitForTimeout(300);
+    await page.setViewportSize(PHONE);
+    await page.waitForTimeout(300);
+
+    await expect(page.locator("aside")).toBeVisible();
+  });
+
+  test("still closes when the player asks it to", async ({ page }) => {
+    await openChat(page);
+
+    await page.getByRole("button", { name: "Hide chat" }).first().click();
+    await page.locator("aside").waitFor({ state: "detached", timeout: 10000 });
+
+    await expect(page.getByRole("button", { name: "Open chat" })).toBeVisible();
+  });
+
+  test("does not open itself on a phone just because a desktop left it open", async ({ page }) => {
+    // the stored preference means a docked rail, and a modal covering the page on load is
+    // not what anyone asked for
+    await page.goto("/crash");
+    await page.waitForTimeout(1200);
+
+    await expect(page.locator("aside")).toHaveCount(0);
+  });
+});
+
+test("a rail that stops fitting closes rather than becoming a modal", async ({ page }) => {
+  await open(page, "/crash");
+  expect(await railWidth(page)).toBe(300);
+
+  await page.setViewportSize({ width: 500, height: 800 });
+  await page.waitForTimeout(600);
+
+  await expect(page.locator("aside")).toHaveCount(0);
 });

--- a/e2e/mocks.ts
+++ b/e2e/mocks.ts
@@ -40,3 +40,24 @@ export async function mockApi(page: Page) {
   // discord's own widget endpoint, which is not ours and is not reachable from a runner
   await page.route("https://discord.com/**", (route) => route.abort());
 }
+
+// a signed-in session, for the parts of the ui that only exist for a logged in player.
+// the chat input is one: without this the panel shows the log-in prompt instead.
+export async function mockSession(page: Page) {
+  await page.route("**/users/me**", (route) =>
+    route.fulfill({
+      json: {
+        id: "player1",
+        _id: "player1",
+        username: "tester",
+        level: 30,
+        xp: 100000,
+        walletBalance: 5000,
+        profilePicture: "",
+        isAdmin: false,
+        nextBonus: new Date(Date.now() + 300000).toISOString(),
+      },
+    })
+  );
+  await page.addInitScript(() => localStorage.setItem("accessToken", "e2e-token"));
+}

--- a/src/components/chat/ChatDock.test.ts
+++ b/src/components/chat/ChatDock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { RAIL_WIDTH, shiftFor, shouldDock } from "./ChatDock";
+import { RAIL_WIDTH, closesOnResize, shiftFor, shouldDock } from "./ChatDock";
 
 describe("whether the rail has to push the page across", () => {
   it("leaves a centred board where it is when its own margin already fits the rail", () => {
@@ -77,5 +77,23 @@ describe("remembering the choice", () => {
 
   it("starts closed for somebody who has never touched it", () => {
     expect(shouldDock(true, null)).toBe(false);
+  });
+});
+
+describe("which resizes close the chat", () => {
+  it("closes a rail that has just stopped fitting, so it does not become a modal", () => {
+    expect(closesOnResize(true, false)).toBe(true);
+  });
+
+  it("leaves a phone alone, whatever its viewport does", () => {
+    // the reported bug: the soft keyboard shrinks the viewport, which arrives as a resize.
+    // asking "is it narrow now" is true on a phone the whole time, so tapping the box to
+    // type closed the panel under the player. so did the url bar collapsing on a scroll.
+    expect(closesOnResize(false, false)).toBe(false);
+  });
+
+  it("does not close on the way back to a wide window", () => {
+    expect(closesOnResize(false, true)).toBe(false);
+    expect(closesOnResize(true, true)).toBe(false);
   });
 });

--- a/src/components/chat/ChatDock.tsx
+++ b/src/components/chat/ChatDock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FiChevronRight, FiMessageSquare } from "react-icons/fi";
 import ChatPanel from "./ChatPanel";
 import i18n from "../../i18n";
@@ -68,6 +68,12 @@ const contentWidth = () => {
 // function of the two rather than a flag that gets flipped, because a flag can only be
 // wrong in one direction and stay that way.
 export const shouldDock = (wide: boolean, stored: string | null) => wide && stored === "1";
+
+// closing on a resize is only right when a docked rail would otherwise become a modal, so
+// it is keyed on the crossing rather than on the new width. a phone is under the width the
+// whole time: asking "is it narrow now" closed the panel on every resize the device makes,
+// and opening the keyboard to type is one of them.
+export const closesOnResize = (wasWide: boolean, isWideNow: boolean) => wasWide && !isWideNow;
 
 // the rail only pushes the page when the page has no room to give. a board centred in a
 // wide window already leaves more than the rail needs on its left, and moving it across
@@ -139,15 +145,18 @@ export const useChatDock = () => {
     setOpen(shouldDock(isWide(), readStored()));
   }, []);
 
+  // what the last resize saw, so a narrowing can be told from a screen that was always narrow
+  const wasWide = useRef(isWide());
+
   useEffect(() => {
-    // re-derived on every resize rather than latched shut. it used to only ever close: one
-    // resize while the window was briefly under the width, which is every drag of a window
-    // edge and every viewport change a test makes, and the rail never came back without a
-    // reload. a narrow screen still never keeps it docked, because it would eat the board.
     const onResize = () => {
       const next = isWide();
       setWide(next);
-      setOpen(shouldDock(next, readStored()));
+      // only a window that has just stopped being wide closes: a docked rail must not turn
+      // into a modal covering the page. an overlay opened on a phone stays, because the
+      // soft keyboard and the collapsing url bar both arrive here as a resize.
+      if (closesOnResize(wasWide.current, next)) setOpen(false);
+      wasWide.current = next;
     };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);


### PR DESCRIPTION
## Problem

On a phone, tapping the chat input closed the chat.

The soft keyboard shrinks the viewport, which arrives as a `resize`. The handler recomputed the open state from `shouldDock(isNarrowNow, stored)`, and `shouldDock` requires a wide window. A phone is under the width the whole time, so **every resize a phone makes closed the panel**: the keyboard, and the URL bar collapsing on a scroll.

`shouldDock` was conflating two things. On a narrow screen the chat is an overlay, not a rail, so it eats no board and there is no reason to close it.

## Change

The close is keyed on the **crossing** rather than on the new width:

```ts
closesOnResize = (wasWide, isWideNow) => wasWide && !isWideNow
```

A docked rail that no longer fits still closes, so it cannot become a modal covering the page. An overlay opened on a phone stays until the player closes it. It still does not open itself on a phone from a stored preference, since that preference means a docked rail.

## Tests

Six e2e cases on a 390x844 viewport, driving the keyboard as a real viewport change to 390x508:

- stays open when the keyboard takes half the screen
- stays open through tapping the box and typing in it
- survives the URL bar collapsing on a scroll
- still closes when the player asks it to
- does not open itself on load because a desktop left it docked
- a rail that stops fitting closes rather than becoming a modal

**Three of them fail against the old handler**, checked by reverting the fix and rerunning.

Frontend 262, e2e 60.