### PR TITLE
fix(header): stop the live drop clearing itself

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from "react-i18next";
 import OnboardingModal from "./components/OnboardingModal";
 import GiftPrompt from "./components/header/GiftPrompt";
 import ChatDock, { ChatToggle, useChatDock } from "./components/chat/ChatDock";
-import { freshDrops } from "./components/header/liveDrop";
+import { pushDrop } from "./components/header/liveDrop";
 
 const Header = lazy(() => import("./components/header/index"));
 const AppRoutes = lazy(() => import("./Routes"));
@@ -48,16 +48,6 @@ function App() {
   const [notification, setNotification] = useState<any>();
 
   const chat = useChatDock();
-
-  // a drop stops being live. the strip used to hold its 112px open on every page for the
-  // rest of the session, game pages included, because the queue only ever grew.
-  useEffect(() => {
-    const sweep = setInterval(
-      () => setRecentCaseOpenings((prev: any) => (prev.length ? freshDrops(prev) : prev)),
-      5000
-    );
-    return () => clearInterval(sweep);
-  }, []);
   const socket = SocketConnection.getInstance();
   const missionCheck = useRef<{ inFlight: boolean; timer: number | null; queuedAt: number }>({
     inFlight: false,
@@ -148,7 +138,7 @@ function App() {
       setTimeout(() => {
         // cap the queue immutably as it grows; the oldest drop falls off the end
         setRecentCaseOpenings((prevOpenings: any) =>
-          freshDrops([{ ...data, at: Date.now() }, ...prevOpenings]).slice(0, 20)
+          pushDrop(prevOpenings, data)
         );
       }, 7500);
     });

--- a/src/components/header/liveDrop.test.ts
+++ b/src/components/header/liveDrop.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { bestDrop, DROP_TTL_MS, freshDrops, isFreshDrop } from "./liveDrop";
+import { KEEP_DROPS, bestDrop, pushDrop } from "./liveDrop";
 import { BasicItem } from "../Types";
 
 const item = (name: string, rarity: string) => ({ name, rarity, image: `${name}.png` }) as BasicItem;
@@ -27,38 +27,39 @@ describe("picking what a multi-open shows", () => {
   });
 });
 
-describe("how long a drop stays on the live strip", () => {
-  const at = (msAgo: number) => ({ at: Date.now() - msAgo });
+describe("what takes a drop off the strip", () => {
+  const drops = (n: number) => Array.from({ length: n }, (_, i) => `d${i}`);
 
-  it("keeps one that has just landed", () => {
-    expect(isFreshDrop(at(0))).toBe(true);
-    expect(isFreshDrop(at(DROP_TTL_MS - 1000))).toBe(true);
+  it("keeps what is there when nobody is opening anything", () => {
+    // nothing but a newer drop removes one. the strip used to empty itself after a quiet
+    // spell, so a bar full of items went blank while the player was looking at it.
+    const bar = drops(6);
+    expect(pushDrop(bar, "new")).toEqual(["new", ...bar]);
+    expect(pushDrop(bar, "new")).toHaveLength(7);
   });
 
-  it("drops one that is no longer live, so the strip gives its space back", () => {
-    // it used to hold its 112px open on every page for the rest of the session, game
-    // boards included, because the queue only ever grew
-    expect(isFreshDrop(at(DROP_TTL_MS + 1000))).toBe(false);
+  it("puts the newest at the front", () => {
+    expect(pushDrop(["b", "c"], "a")[0]).toBe("a");
   });
 
-  it("treats a drop with no timestamp as stale rather than immortal", () => {
-    expect(isFreshDrop({})).toBe(false);
+  it("drops the oldest only once the bar is full", () => {
+    const full = drops(KEEP_DROPS);
+    const after = pushDrop(full, "new");
+
+    expect(after).toHaveLength(KEEP_DROPS);
+    expect(after[0]).toBe("new");
+    expect(after).not.toContain(`d${KEEP_DROPS - 1}`);
   });
 
-  it("empties completely once the room goes quiet", () => {
-    expect(freshDrops([at(60000), at(90000)])).toHaveLength(0);
-    expect(freshDrops([])).toHaveLength(0);
+  it("fills from empty as openings arrive, which is how a fresh page starts", () => {
+    let bar: string[] = [];
+    for (const d of ["a", "b", "c"]) bar = pushDrop(bar, d);
+    expect(bar).toEqual(["c", "b", "a"]);
   });
 
-  it("keeps the whole row while the feed is still live", () => {
-    // dropping the old ones one at a time left the strip half filled: a few cards on the
-    // left and a stretch of bare background to the right of them. the row is full width,
-    // so it either fills or it is not there at all.
-    const drops = [at(1000), at(20000), at(90000), at(600000)];
-    expect(freshDrops(drops)).toHaveLength(4);
-  });
-
-  it("goes on the newest, not on each one", () => {
-    expect(freshDrops([at(90000), at(1000)])).toHaveLength(0);
+  it("never grows past the cap however many arrive", () => {
+    let bar: string[] = [];
+    for (let i = 0; i < KEEP_DROPS * 3; i++) bar = pushDrop(bar, `d${i}`);
+    expect(bar).toHaveLength(KEEP_DROPS);
   });
 });

--- a/src/components/header/liveDrop.ts
+++ b/src/components/header/liveDrop.ts
@@ -9,17 +9,10 @@ export const bestDrop = (items: BasicItem[]): BasicItem | undefined =>
     undefined
   );
 
-// how long a drop stays on the live strip. it used to stay for the rest of the session,
-// so one case opened at any point held the strip's 112px open on every page after it,
-// game boards included. long enough to be seen, short enough to give the space back.
-export const DROP_TTL_MS = 45000;
+// the strip holds the last few openings and nothing else takes them off it. a drop leaves
+// only when newer ones push it past the end, so a quiet minute leaves the bar exactly as it
+// was rather than emptying it. it is a local list: a reload starts it over.
+export const KEEP_DROPS = 20;
 
-export const isFreshDrop = (drop: { at?: number }, now = Date.now()) =>
-  now - (drop.at || 0) < DROP_TTL_MS;
-
-// the strip is live while its newest drop is, and then it goes entirely. expiring the rows
-// one at a time emptied it from the tail while new ones still arrived at the head, so the
-// feed sat half filled with a stretch of bare background to the right of it. the row it
-// draws is full width, so it either fills or it is not there.
-export const freshDrops = <T extends { at?: number }>(drops: T[], now = Date.now()) =>
-  drops.length && isFreshDrop(drops[0], now) ? drops : [];
+export const pushDrop = <T,>(drops: T[], drop: T, keep = KEEP_DROPS) =>
+  [drop, ...drops].slice(0, keep);


### PR DESCRIPTION
## Problem

The live drop strip empties after 45 seconds of quiet, so a bar full of items goes blank while the player is looking at it.

The expected behaviour is the one it had originally: a local list of the last 20 openings, where a drop leaves **only** when newer ones push it past the end, and a reload starts it over. People stopping opening cases should change nothing.

## Change

The expiry is gone, along with the sweep that ran it. `pushDrop` puts the newest at the front and trims to the cap, which is the whole rule.

## Why the expiry was there, and why removing it is safe

It was added to reclaim the 112px the strip holds on a game page. It was never what did that.

Measured on `/hilo` against the built bundle with no drops on the board: the gap under the navbar is **60px**, the same as with the expiry in place. The 132px was the back button and the page title, and both were fixed separately in #294. The strip only costs anything once it has something to show, which is the point of it.

## Tests

Frontend 261. The expiry tests are replaced with the rule that is actually wanted: a quiet spell leaves the bar untouched, the newest goes to the front, the oldest leaves only when the bar is full, it fills from empty as openings arrive, and it never grows past the cap. E2E 60.