### PR TITLE
fix(storage): expire the audit rows nothing reads twice

### DIFF
--- a/backend/__tests__/integration/rollRetention.test.js
+++ b/backend/__tests__/integration/rollRetention.test.js
@@ -8,14 +8,16 @@ afterAll(teardownDb);
 
 // the rolls collection was 36% of a 512 MB budget and only ever grew. this is the one
 // thing keeping it bounded, and losing it would not fail anything else.
-test("rolls expire after thirty days", async () => {
+test("rolls expire after three days", async () => {
   await Roll.init(); // build the indexes mongoose declares
   const indexes = await Roll.collection.indexes();
   const ttl = indexes.find((i) => i.expireAfterSeconds !== undefined);
 
   expect(ttl).toBeDefined();
   expect(ttl.key).toEqual({ createdAt: 1 });
-  expect(ttl.expireAfterSeconds).toBe(30 * 24 * 60 * 60);
+  // three days, down from thirty: 229K rolls past the old window were a third of the free
+  // tier's whole budget, and the fair page looks one up by id rather than by age
+  expect(ttl.expireAfterSeconds).toBe(3 * 24 * 60 * 60);
 });
 
 test("the lookups the fair page uses still have an index to stand on", async () => {

--- a/backend/__tests__/unit/retention.test.js
+++ b/backend/__tests__/unit/retention.test.js
@@ -1,0 +1,41 @@
+// the free tier is 512 MB and the database was growing toward it at 20 MB a day, most of it
+// audit rows nothing reads twice. each of these collections now expires its rows, and the
+// window is pinned here so a schema edit cannot quietly put it back to forever.
+const Roll = require("../../models/Roll");
+const Round = require("../../models/Round");
+const BlackjackHand = require("../../models/BlackjackHand");
+const MinesGame = require("../../models/MinesGame");
+const HiloGame = require("../../models/HiloGame");
+
+const DAY = 24 * 60 * 60;
+
+// the ttl declared on a schema, or null when the model would keep its rows forever
+const ttlOn = (model, field) => {
+  const hit = model.schema.indexes().find(([key, opts]) => key[field] !== undefined && opts.expireAfterSeconds != null);
+  return hit ? hit[1].expireAfterSeconds : null;
+};
+
+describe("what the database is allowed to keep", () => {
+  it("lets a roll go after three days", () => {
+    // only the fair page reads one, by id, and nobody has asked for one a week old
+    expect(ttlOn(Roll, "createdAt")).toBe(3 * DAY);
+  });
+
+  it("lets a settled round go after a week", () => {
+    // the history strip reads the last fifty and the recovery sweep only unfinished ones
+    expect(ttlOn(Round, "createdAt")).toBe(7 * DAY);
+  });
+
+  it("lets a finished hand or game go a week after its last touch", () => {
+    // the sweeps only look for work still owed, and the roll it produced is the record
+    expect(ttlOn(BlackjackHand, "updatedAt")).toBe(7 * DAY);
+    expect(ttlOn(MinesGame, "updatedAt")).toBe(7 * DAY);
+    expect(ttlOn(HiloGame, "updatedAt")).toBe(7 * DAY);
+  });
+
+  it("keeps every one of them for at least a day, so nothing is swept mid-play", () => {
+    for (const [model, field] of [[Roll, "createdAt"], [Round, "createdAt"], [BlackjackHand, "updatedAt"], [MinesGame, "updatedAt"], [HiloGame, "updatedAt"]]) {
+      expect(ttlOn(model, field)).toBeGreaterThanOrEqual(DAY);
+    }
+  });
+});

--- a/backend/models/BlackjackHand.js
+++ b/backend/models/BlackjackHand.js
@@ -71,5 +71,9 @@ blackjackHandSchema.index(
 );
 blackjackHandSchema.index({ status: 1, updatedAt: 1 });
 blackjackHandSchema.index({ userId: 1, createdAt: -1 });
+// a finished hand is never read again: the sweeps only look for work still owed, and the
+// roll it produced is what the fair page shows. the free tier's whole budget is 512 MB and
+// these were growing toward it for nothing, so a week after its last touch it expires.
+blackjackHandSchema.index({ updatedAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
 
 module.exports = mongoose.model("BlackjackHand", blackjackHandSchema);

--- a/backend/models/HiloGame.js
+++ b/backend/models/HiloGame.js
@@ -41,5 +41,9 @@ hiloGameSchema.index(
 );
 hiloGameSchema.index({ status: 1, updatedAt: 1 });
 hiloGameSchema.index({ userId: 1, createdAt: -1 });
+// a finished game is never read again: the sweeps only look for work still owed, and the
+// roll it produced is what the fair page shows. the free tier's whole budget is 512 MB and
+// these were growing toward it for nothing, so a week after its last touch it expires.
+hiloGameSchema.index({ updatedAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
 
 module.exports = mongoose.model("HiloGame", hiloGameSchema);

--- a/backend/models/MinesGame.js
+++ b/backend/models/MinesGame.js
@@ -42,5 +42,9 @@ minesGameSchema.index(
 );
 minesGameSchema.index({ status: 1, updatedAt: 1 });
 minesGameSchema.index({ userId: 1, createdAt: -1 });
+// a finished game is never read again: the sweeps only look for work still owed, and the
+// roll it produced is what the fair page shows. the free tier's whole budget is 512 MB and
+// these were growing toward it for nothing, so a week after its last touch it expires.
+minesGameSchema.index({ updatedAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
 
 module.exports = mongoose.model("MinesGame", minesGameSchema);

--- a/backend/models/Roll.js
+++ b/backend/models/Roll.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 
-const RETENTION_DAYS = 30;
+const RETENTION_DAYS = 3;
 
 // one audit record per provably-fair draw. holds everything needed to verify the
 // outcome later: the seed reference, client seed, nonce, the raw roll, and for case

--- a/backend/models/Round.js
+++ b/backend/models/Round.js
@@ -56,4 +56,8 @@ const RoundSchema = new mongoose.Schema(
 RoundSchema.index({ status: 1 });
 // round history, newest first
 RoundSchema.index({ game: 1, createdAt: -1 });
+// the empty-round prune clears the 99.5% nobody bet on after a day. the rest held their
+// seed reveal forever, and one nobody has asked to verify in a week is not worth the
+// storage: the history strip reads the last fifty, and the recovery sweep only unfinished.
+RoundSchema.index({ createdAt: 1 }, { expireAfterSeconds: 7 * 24 * 60 * 60 });
 module.exports = mongoose.model("Round", RoundSchema);

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -383,7 +383,7 @@
     "outcome": "Ergebnis",
     "previousSeedRevealedVerify": "Vorherige Seed offengelegt, prüf sie:",
     "roll": "Roll",
-    "rollNotFound": "Roll nicht gefunden. Rolls werden 30 Tage lang aufbewahrt.",
+    "rollNotFound": "Kein Wurf mit dieser ID. Wuerfe werden drei Tage aufbewahrt; ein gespeicherter Seed und Nonce lassen sich weiterhin pruefen.",
     "rotateRevealServerSeed": "Server-Seed wechseln und offenlegen",
     "serverSeed": "Server-Seed",
     "serverSeedHash": "Hash des Server-Seeds",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -383,7 +383,7 @@
     "outcome": "Outcome",
     "previousSeedRevealedVerify": "Previous seed revealed, verify it:",
     "roll": "Roll",
-    "rollNotFound": "Roll not found. Rolls are kept for 30 days.",
+    "rollNotFound": "No roll with that id. Rolls are kept for three days; a seed and nonce you saved still verify.",
     "rotateRevealServerSeed": "Rotate & reveal server seed",
     "serverSeed": "Server seed",
     "serverSeedHash": "Server seed hash",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -383,7 +383,7 @@
     "outcome": "Resultado",
     "previousSeedRevealedVerify": "Semilla anterior revelada, verifícala:",
     "roll": "Tirada",
-    "rollNotFound": "Tirada no encontrada. Las tiradas se guardan durante 30 días.",
+    "rollNotFound": "No hay ningun roll con ese id. Los rolls se guardan tres dias; una seed y un nonce que guardaste siguen verificando.",
     "rotateRevealServerSeed": "Rotar y revelar la semilla del servidor",
     "serverSeed": "Semilla del servidor",
     "serverSeedHash": "Hash de la semilla del servidor",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -383,7 +383,7 @@
     "outcome": "Résultat",
     "previousSeedRevealedVerify": "Seed précédente révélée, vérifiez-la :",
     "roll": "Tirage",
-    "rollNotFound": "Tirage introuvable. Les tirages sont conservés 30 jours.",
+    "rollNotFound": "Aucun tirage avec cet identifiant. Les tirages sont conserves trois jours; une graine et un nonce que vous avez gardes se verifient toujours.",
     "rotateRevealServerSeed": "Changer et révéler la seed serveur",
     "serverSeed": "Seed serveur",
     "serverSeedHash": "Hash de la seed serveur",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -383,7 +383,7 @@
     "outcome": "Hasil",
     "previousSeedRevealedVerify": "Seed sebelumnya telah terungkap, verifikasi:",
     "roll": "Roll",
-    "rollNotFound": "Roll tidak ditemukan. Roll disimpan selama 30 hari.",
+    "rollNotFound": "Tidak ada roll dengan id itu. Roll disimpan selama tiga hari; seed dan nonce yang kamu simpan masih bisa diverifikasi.",
     "rotateRevealServerSeed": "Putar & ungkapkan seed server",
     "serverSeed": "Server seed",
     "serverSeedHash": "Server seed hash",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -383,7 +383,7 @@
     "outcome": "Risultato",
     "previousSeedRevealedVerify": "Seed precedente rivelato, verificalo:",
     "roll": "Roll",
-    "rollNotFound": "Roll non trovato. I roll vengono conservati per 30 giorni.",
+    "rollNotFound": "Nessun roll con quell'id. I roll sono conservati per tre giorni; un seed e un nonce che hai salvato si verificano ancora.",
     "rotateRevealServerSeed": "Ruota e rivela il seed del server",
     "serverSeed": "Seed del server",
     "serverSeedHash": "Hash del seed del server",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -383,7 +383,7 @@
     "outcome": "結果",
     "previousSeedRevealedVerify": "前のシードを公開しました。検証してください：",
     "roll": "ロール",
-    "rollNotFound": "ロールが見つかりません。ロールは30日間保存されます。",
+    "rollNotFound": "そのIDのロールはありません。ロールの保存期間は3日です。保存したシードとノンスがあれば今でも検証できます。",
     "rotateRevealServerSeed": "サーバーシードをローテーションして公開",
     "serverSeed": "サーバーシード",
     "serverSeedHash": "サーバーシードのハッシュ",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -383,7 +383,7 @@
     "outcome": "결과",
     "previousSeedRevealedVerify": "이전 시드를 공개했습니다. 확인해 보세요:",
     "roll": "롤",
-    "rollNotFound": "롤을 찾을 수 없습니다. 롤은 30일간 보관됩니다.",
+    "rollNotFound": "해당 ID의 롤이 없습니다. 롤은 3일간 보관됩니다. 저장해 둔 시드와 논스로는 여전히 검증할 수 있습니다.",
     "rotateRevealServerSeed": "서버 시드 교체 및 공개",
     "serverSeed": "서버 시드",
     "serverSeedHash": "서버 시드 해시",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -383,7 +383,7 @@
     "outcome": "Resultado",
     "previousSeedRevealedVerify": "Seed anterior revelada, verifique:",
     "roll": "Roll",
-    "rollNotFound": "Roll não encontrado. Os rolls são guardados por 30 dias.",
+    "rollNotFound": "Nenhum roll com esse id. Os rolls ficam guardados por tres dias; uma seed e um nonce que voce salvou ainda verificam.",
     "rotateRevealServerSeed": "Trocar e revelar a seed do servidor",
     "serverSeed": "Seed do servidor",
     "serverSeedHash": "Hash da seed do servidor",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -383,7 +383,7 @@
     "outcome": "Kết quả",
     "previousSeedRevealedVerify": "Seed trước đã được công khai, hãy kiểm chứng:",
     "roll": "Roll",
-    "rollNotFound": "Không tìm thấy roll. Roll được lưu trong 30 ngày.",
+    "rollNotFound": "Khong co lan quay nao voi id do. Cac lan quay duoc luu trong ba ngay; seed va nonce ban da luu van xac minh duoc.",
     "rotateRevealServerSeed": "Đổi và công khai seed máy chủ",
     "serverSeed": "Seed máy chủ",
     "serverSeedHash": "Hash seed máy chủ",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -383,7 +383,7 @@
     "outcome": "结果",
     "previousSeedRevealedVerify": "上一个种子已公开，请验证：",
     "roll": "Roll",
-    "rollNotFound": "未找到该 Roll。Roll 仅保留 30 天。",
+    "rollNotFound": "没有这个 ID 的记录。记录只保留三天；你保存过的种子和随机数仍然可以验证。",
     "rotateRevealServerSeed": "轮换并公开服务器种子",
     "serverSeed": "服务器种子",
     "serverSeedHash": "服务器种子哈希",


### PR DESCRIPTION
## Problem

The free tier caps the database at 512 MB logical size. It read **293 MB** on 1 September and had climbed about 20 MB a day for a week.

| collection | docs | data | avg doc |
|---|---|---|---|
| rolls | 247K | 119 MB | 503 B |
| transactions | 331K | 73 MB | 231 B |
| blackjackhands | 8K | 6 MB | 820 B |
| rounds | 9K | 4 MB + 8.5 MB index | 434 B |

The spike was one day (27 August, 77K rolls) and one player opening cases by script, which is allowed. Rolls had a 30 day expiry, which at 500 bytes each was a third of the whole budget for rows nothing reads past a bounded lookup.

## Change

Every audit collection expires its rows.

| collection | expires | why that long |
|---|---|---|
| rolls | **3 days** (was 30) | the fair page looks one up by id, and nobody has asked for a week-old roll |
| rounds | 7 days | the history strip reads the last fifty; the recovery sweep only unfinished ones |
| blackjackhands, minesgames, hilogames | 7 days | the sweeps only look for work still owed; a finished game is never read again |

Each window is pinned in `retention.test.js`. The fair page now says rolls are kept three days instead of leaving a player to wonder whether they mistyped the id.

**The ledger is untouched.** `missions`, `accountBalance`, `most-opened`, `referrals` and the backoffice all sum it from the beginning, so it needs a per-user snapshot before it can be pruned. That is the next storage job, and it is a feature rather than a config change.

## Production

Mongoose does not change an existing TTL, so the rolls expiry was applied with `collMod` tonight and the four new indexes created ahead of this deploy. Measured after the monitor finished:

```
logical  295 MB -> 213 MB
rolls    247K   -> 18K docs
```

## Tests

Backend 1224. Four new in `retention.test.js`, the existing `rollRetention` integration test updated from thirty to three. Frontend locale parity, lint and typecheck clean.